### PR TITLE
Cassandra config update

### DIFF
--- a/kork-cassandra/kork-cassandra.gradle
+++ b/kork-cassandra/kork-cassandra.gradle
@@ -1,5 +1,7 @@
 dependencies {
+  compile project(":kork-core")
   compile spinnaker.dependency('bootAutoConfigure')
+  runtime 'org.hibernate:hibernate-validator:5.2.2.Final'
   spinnaker.group('cassandra')
   testRuntime spinnaker.dependency('slf4jSimple')
   spinnaker.group('spockBase')

--- a/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/ClusterHostSupplierFactory.java
+++ b/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/ClusterHostSupplierFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.astyanax;
+
+import com.google.common.base.Supplier;
+import com.netflix.astyanax.connectionpool.Host;
+
+import java.util.List;
+
+public interface ClusterHostSupplierFactory {
+  static ClusterHostSupplierFactory nullSupplierFactory() {
+    return new ClusterHostSupplierFactory() {
+      @Override
+      public Supplier<List<Host>> createHostSupplier(String clusterName) {
+        return null;
+      }
+    };
+  }
+  Supplier<List<Host>> createHostSupplier(String clusterName);
+}

--- a/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/DefaultAstyanaxKeyspaceFactory.java
+++ b/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/DefaultAstyanaxKeyspaceFactory.java
@@ -36,11 +36,12 @@ public class DefaultAstyanaxKeyspaceFactory implements AstyanaxKeyspaceFactory {
 
     public DefaultAstyanaxKeyspaceFactory(final AstyanaxConfiguration astyanaxConfiguration,
                                           final ConnectionPoolConfiguration connectionPoolConfiguration,
-                                          final ConnectionPoolMonitor connectionPoolMonitor) {
+                                          final ConnectionPoolMonitor connectionPoolMonitor,
+                                          final KeyspaceInitializer keyspaceInitializer) {
         keyspaces = CacheBuilder
                 .newBuilder()
                 .removalListener(createRemovalListener())
-                .build(createCacheLoader(astyanaxConfiguration, connectionPoolConfiguration, connectionPoolMonitor));
+                .build(createCacheLoader(astyanaxConfiguration, connectionPoolConfiguration, connectionPoolMonitor, keyspaceInitializer));
     }
 
     @Override
@@ -114,7 +115,8 @@ public class DefaultAstyanaxKeyspaceFactory implements AstyanaxKeyspaceFactory {
 
     CacheLoader<KeyspaceKey, AstyanaxContext<Keyspace>> createCacheLoader(final AstyanaxConfiguration astyanaxConfiguration,
                                                                           final ConnectionPoolConfiguration connectionPoolConfiguration,
-                                                                          final ConnectionPoolMonitor connectionPoolMonitor) {
+                                                                          final ConnectionPoolMonitor connectionPoolMonitor,
+                                                                          final KeyspaceInitializer keyspaceInitializer) {
         return new CacheLoader<KeyspaceKey, AstyanaxContext<Keyspace>>() {
             @Override
             public AstyanaxContext<Keyspace> load(KeyspaceKey key) throws Exception {
@@ -126,6 +128,7 @@ public class DefaultAstyanaxKeyspaceFactory implements AstyanaxKeyspaceFactory {
                         .withConnectionPoolMonitor(connectionPoolMonitor)
                         .buildKeyspace(ThriftFamilyFactory.getInstance());
                 context.start();
+                keyspaceInitializer.initKeyspace(context.getClient());
                 return context;
             }
         };

--- a/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/DefaultAstyanaxKeyspaceFactory.java
+++ b/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/DefaultAstyanaxKeyspaceFactory.java
@@ -17,17 +17,21 @@
 package com.netflix.spinnaker.kork.astyanax;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
 import com.google.common.cache.*;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.netflix.astyanax.AstyanaxConfiguration;
 import com.netflix.astyanax.AstyanaxContext;
 import com.netflix.astyanax.Keyspace;
 import com.netflix.astyanax.connectionpool.ConnectionPoolConfiguration;
-import com.netflix.astyanax.connectionpool.ConnectionPoolMonitor;
+import com.netflix.astyanax.connectionpool.Host;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.netflix.astyanax.connectionpool.exceptions.UnknownException;
+import com.netflix.astyanax.connectionpool.impl.ConnectionPoolConfigurationImpl;
 import com.netflix.astyanax.thrift.ThriftFamilyFactory;
 
 import javax.annotation.PreDestroy;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 public class DefaultAstyanaxKeyspaceFactory implements AstyanaxKeyspaceFactory {
@@ -36,12 +40,13 @@ public class DefaultAstyanaxKeyspaceFactory implements AstyanaxKeyspaceFactory {
 
     public DefaultAstyanaxKeyspaceFactory(final AstyanaxConfiguration astyanaxConfiguration,
                                           final ConnectionPoolConfiguration connectionPoolConfiguration,
-                                          final ConnectionPoolMonitor connectionPoolMonitor,
+                                          final KeyspaceConnectionPoolMonitorFactory connectionPoolMonitorFactory,
+                                          final ClusterHostSupplierFactory clusterHostSupplierFactory,
                                           final KeyspaceInitializer keyspaceInitializer) {
         keyspaces = CacheBuilder
                 .newBuilder()
                 .removalListener(createRemovalListener())
-                .build(createCacheLoader(astyanaxConfiguration, connectionPoolConfiguration, connectionPoolMonitor, keyspaceInitializer));
+                .build(createCacheLoader(astyanaxConfiguration, connectionPoolConfiguration, connectionPoolMonitorFactory, clusterHostSupplierFactory, keyspaceInitializer));
     }
 
     @Override
@@ -53,6 +58,9 @@ public class DefaultAstyanaxKeyspaceFactory implements AstyanaxKeyspaceFactory {
                 throw (ConnectionException) ex.getCause();
             }
             throw new UnknownException(ex.getCause());
+        } catch (UncheckedExecutionException uee) {
+          uee.printStackTrace();
+          throw uee;
         }
     }
 
@@ -115,17 +123,24 @@ public class DefaultAstyanaxKeyspaceFactory implements AstyanaxKeyspaceFactory {
 
     CacheLoader<KeyspaceKey, AstyanaxContext<Keyspace>> createCacheLoader(final AstyanaxConfiguration astyanaxConfiguration,
                                                                           final ConnectionPoolConfiguration connectionPoolConfiguration,
-                                                                          final ConnectionPoolMonitor connectionPoolMonitor,
+                                                                          final KeyspaceConnectionPoolMonitorFactory connectionPoolMonitorFactory,
+                                                                          final ClusterHostSupplierFactory clusterHostSupplierFactory,
                                                                           final KeyspaceInitializer keyspaceInitializer) {
         return new CacheLoader<KeyspaceKey, AstyanaxContext<Keyspace>>() {
             @Override
             public AstyanaxContext<Keyspace> load(KeyspaceKey key) throws Exception {
+                Supplier<List<Host>> hostSupplier = clusterHostSupplierFactory.createHostSupplier(key.getClusterName());
+                if (hostSupplier != null) {
+                  hostSupplier.get();
+                  ((ConnectionPoolConfigurationImpl) connectionPoolConfiguration).setSeeds(null);
+                }
                 AstyanaxContext<Keyspace> context = new AstyanaxContext.Builder()
                         .forCluster(key.getClusterName())
                         .forKeyspace(key.getKeyspaceName())
                         .withAstyanaxConfiguration(astyanaxConfiguration)
                         .withConnectionPoolConfiguration(connectionPoolConfiguration)
-                        .withConnectionPoolMonitor(connectionPoolMonitor)
+                        .withConnectionPoolMonitor(connectionPoolMonitorFactory.createMonitorForKeyspace(key.getClusterName(), key.getKeyspaceName()))
+                        .withHostSupplier(hostSupplier)
                         .buildKeyspace(ThriftFamilyFactory.getInstance());
                 context.start();
                 keyspaceInitializer.initKeyspace(context.getClient());

--- a/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/EurekaHostSupplier.java
+++ b/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/EurekaHostSupplier.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.astyanax;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.netflix.appinfo.AmazonInfo;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.astyanax.connectionpool.Host;
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.discovery.shared.Application;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class EurekaHostSupplier implements Supplier<List<Host>> {
+  public static class Factory implements ClusterHostSupplierFactory {
+    private final DiscoveryClient discoveryClient;
+
+    public Factory(DiscoveryClient discoveryClient) {
+      this.discoveryClient = Preconditions.checkNotNull(discoveryClient, "discoveryClient");
+    }
+
+    @Override
+    public Supplier<List<Host>> createHostSupplier(String clusterName) {
+      return new EurekaHostSupplier(clusterName, discoveryClient);
+    }
+  }
+
+  public static ClusterHostSupplierFactory factory(DiscoveryClient discoveryClient) {
+    return new Factory(discoveryClient);
+  }
+
+  private static final Logger logger = LoggerFactory.getLogger(EurekaHostSupplier.class);
+  private final String applicationName;
+  private final DiscoveryClient discoveryClient;
+
+  public EurekaHostSupplier(String applicationName, DiscoveryClient discoveryClient) {
+    this.applicationName = Preconditions.checkNotNull(applicationName, "applicationName");
+    this.discoveryClient = Preconditions.checkNotNull(discoveryClient, "discoveryClient");
+  }
+
+  @Override
+  public List<Host> get() {
+    return Optional.ofNullable(discoveryClient.getApplication(applicationName))
+      .map(Application::getInstances)
+      .map(List::stream)
+      .map(ss ->
+        ss.filter(EurekaHostSupplier::isUp)
+          .map(EurekaHostSupplier::buildHost)
+          .collect(Collectors.toList()))
+      .orElse(Collections.emptyList());
+  }
+
+  static boolean isUp(InstanceInfo info) {
+    return info.getStatus() == InstanceInfo.InstanceStatus.UP;
+  }
+
+  static Host buildHost(InstanceInfo info) {
+    String[] parts = StringUtils.split(
+      StringUtils.split(info.getHostName(), ".")[0], '-');
+
+    Host host = new Host(info.getHostName(), info.getPort())
+      .addAlternateIpAddress(
+        StringUtils.join(new String[] { parts[1], parts[2], parts[3],
+          parts[4] }, "."))
+      .addAlternateIpAddress(info.getIPAddr())
+      .setId(info.getId());
+
+    try {
+      if (info.getDataCenterInfo() instanceof AmazonInfo) {
+        AmazonInfo amazonInfo = (AmazonInfo)info.getDataCenterInfo();
+        host.setRack(amazonInfo.get(AmazonInfo.MetaDataKey.availabilityZone));
+      }
+    }
+    catch (Throwable t) {
+      logger.error("Error getting rack for host " + host.getName(), t);
+    }
+
+    return host;
+  }
+}

--- a/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/KeyspaceConnectionPoolMonitorFactory.java
+++ b/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/KeyspaceConnectionPoolMonitorFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.astyanax;
+
+import com.netflix.astyanax.connectionpool.ConnectionPoolMonitor;
+import com.netflix.astyanax.connectionpool.impl.CountingConnectionPoolMonitor;
+
+public interface KeyspaceConnectionPoolMonitorFactory {
+  static KeyspaceConnectionPoolMonitorFactory defaultFactory() {
+    return new KeyspaceConnectionPoolMonitorFactory() {
+      @Override
+      public ConnectionPoolMonitor createMonitorForKeyspace(String clusterName, String keyspace) {
+        return new CountingConnectionPoolMonitor();
+      }
+    };
+  }
+  ConnectionPoolMonitor createMonitorForKeyspace(String clusterName, String keyspace);
+}

--- a/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/KeyspaceInitializer.java
+++ b/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/KeyspaceInitializer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.astyanax;
+
+import com.netflix.astyanax.Keyspace;
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+
+public interface KeyspaceInitializer {
+    void initKeyspace(Keyspace keyspace) throws ConnectionException;
+}

--- a/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/SpectatorConnectionPoolMonitor.java
+++ b/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/SpectatorConnectionPoolMonitor.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.astyanax;
+
+import com.google.common.base.Preconditions;
+import com.netflix.astyanax.connectionpool.ConnectionPoolMonitor;
+import com.netflix.astyanax.connectionpool.Host;
+import com.netflix.astyanax.connectionpool.HostConnectionPool;
+import com.netflix.astyanax.connectionpool.impl.CountingConnectionPoolMonitor;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+
+import java.util.Optional;
+
+public class SpectatorConnectionPoolMonitor extends CountingConnectionPoolMonitor {
+
+  public static KeyspaceConnectionPoolMonitorFactory factory(final Registry registry) {
+    return new KeyspaceConnectionPoolMonitorFactory() {
+      @Override
+      public ConnectionPoolMonitor createMonitorForKeyspace(String clusterName, String keyspace) {
+        return new SpectatorConnectionPoolMonitor(registry, clusterName, keyspace);
+      }
+    };
+  }
+
+  private final Registry registry;
+  private final String cluster;
+  private final String keyspace;
+
+  public SpectatorConnectionPoolMonitor(Registry registry, String cluster, String keyspace) {
+    this.registry = Preconditions.checkNotNull(registry);
+    this.cluster = Preconditions.checkNotNull(cluster);
+    this.keyspace = Preconditions.checkNotNull(keyspace);
+  }
+
+  @Override
+  public void incOperationFailure(Host host, Exception reason) {
+    super.incOperationFailure(host, reason);
+    registry.counter(hostId("operationFailure", host, reason)).increment();
+  }
+
+  Id baseId(String name) {
+    return registry.createId("astyanax.connectionPool." + name, "cluster", cluster, "keyspace", keyspace);
+  }
+
+  Id hostId(String name, Host host) {
+    String rack = Optional.ofNullable(host).map(Host::getRack).orElse("unknown");
+    return baseId(name).withTag("rack", rack);
+  }
+
+  Id hostId(String name, Host host, Exception cause) {
+    String causeTag = Optional.ofNullable(cause).map(Object::getClass).map(Class::getSimpleName).orElse("unknown");
+    return hostId(name, host).withTag("cause", causeTag);
+  }
+
+  @Override
+  public void incOperationSuccess(Host host, long latency) {
+    super.incOperationSuccess(host, latency);
+    registry.counter(hostId("operationSuccess", host)).increment();
+    registry.distributionSummary(hostId("operationLatency", host)).record(latency);
+  }
+
+  @Override
+  public void incConnectionCreated(Host host) {
+    super.incConnectionCreated(host);
+    registry.counter(hostId("connectionCreated", host)).increment();
+  }
+
+  @Override
+  public void incConnectionClosed(Host host, Exception reason) {
+    super.incConnectionClosed(host, reason);
+    registry.counter(hostId("connectionClosed", host, reason)).increment();
+  }
+
+  @Override
+  public void incConnectionCreateFailed(Host host, Exception reason) {
+    super.incConnectionCreateFailed(host, reason);
+    registry.counter(hostId("connectionCreateFailed", host, reason)).increment();
+  }
+
+  @Override
+  public void incConnectionBorrowed(Host host, long delay) {
+    super.incConnectionBorrowed(host, delay);
+    registry.counter(hostId("connectionBorrowed", host)).increment();
+    registry.distributionSummary(hostId("connectionBorrowedDelay", host)).record(delay);
+  }
+
+  @Override
+  public void incConnectionReturned(Host host) {
+    super.incConnectionReturned(host);
+    registry.counter(hostId("connectionReturned", host)).increment();
+  }
+
+  @Override
+  public void incFailover(Host host, Exception reason) {
+    super.incFailover(host, reason);
+    registry.counter(hostId("failover", host, reason)).increment();
+  }
+
+  @Override
+  public void onHostAdded(Host host, HostConnectionPool<?> pool) {
+    super.onHostAdded(host, pool);
+    registry.counter(hostId("hostAdded", host)).increment();
+  }
+
+  @Override
+  public void onHostRemoved(Host host) {
+    super.onHostRemoved(host);
+    registry.counter(hostId("hostRemoved", host)).increment();
+  }
+
+  @Override
+  public void onHostDown(Host host, Exception reason) {
+    super.onHostDown(host, reason);
+    registry.counter(hostId("hostDown", host, reason)).increment();
+  }
+
+  @Override
+  public void onHostReactivated(Host host, HostConnectionPool<?> pool) {
+    super.onHostReactivated(host, pool);
+    registry.counter(hostId("hostReactivated", host)).increment();
+  }
+
+  @Override
+  public long getBadRequestCount() {
+    return super.getBadRequestCount();
+  }
+}

--- a/kork-cassandra/src/test/groovy/com/netflix/spinnaker/kork/astyanax/AstyanaxComponentsSpec.groovy
+++ b/kork-cassandra/src/test/groovy/com/netflix/spinnaker/kork/astyanax/AstyanaxComponentsSpec.groovy
@@ -39,11 +39,14 @@ class AstyanaxComponentsSpec extends Specification {
         and:
         def ctx = createContext()
 
-        expect:
-        ctx.getBean(AstyanaxComponents.EmbeddedCassandraRunner)
+        when:
+        def bean = ctx.getBean(KeyspaceInitializer)
+
+        then:
+        bean instanceof AstyanaxComponents.EmbeddedCassandraRunner
 
         cleanup:
-        ctx.close()
+        ctx?.close()
 
         and:
         properties.each { k, v -> System.clearProperty(k) }
@@ -61,13 +64,13 @@ class AstyanaxComponentsSpec extends Specification {
         def ctx = createContext(context)
 
         when:
-        ctx.getBean(AstyanaxComponents.EmbeddedCassandraRunner)
+        def bean = ctx.getBean(KeyspaceInitializer)
 
         then:
-        thrown NoSuchBeanDefinitionException
+        !(bean instanceof AstyanaxComponents.EmbeddedCassandraRunner)
 
         cleanup:
-        ctx.close()
+        ctx?.close()
 
         and:
         properties.each { k, v -> System.clearProperty(k) }

--- a/kork-cassandra/src/test/java/com/netflix/spinnaker/kork/astyanax/DefaultAstyanaxKeyspaceFactoryTest.java
+++ b/kork-cassandra/src/test/java/com/netflix/spinnaker/kork/astyanax/DefaultAstyanaxKeyspaceFactoryTest.java
@@ -71,14 +71,15 @@ public class DefaultAstyanaxKeyspaceFactoryTest {
         public final AtomicInteger removeCount = new AtomicInteger();
 
         public TestDAKF(AstyanaxComponents comp) {
-            super(comp.astyanaxConfiguration(), comp.connectionPoolConfiguration(9160, "127.0.0.1", 3), comp.connectionPoolMonitor());
+            super(comp.astyanaxConfiguration(), comp.connectionPoolConfiguration(9160, "127.0.0.1", 3), comp.connectionPoolMonitor(), comp.noopKeyspaceInitializer());
         }
 
         @Override
         CacheLoader<DefaultAstyanaxKeyspaceFactory.KeyspaceKey, AstyanaxContext<Keyspace>> createCacheLoader(AstyanaxConfiguration astyanaxConfiguration,
                                                                                                              ConnectionPoolConfiguration connectionPoolConfiguration,
-                                                                                                             ConnectionPoolMonitor connectionPoolMonitor) {
-            final CacheLoader<KeyspaceKey, AstyanaxContext<Keyspace>> delegate = super.createCacheLoader(astyanaxConfiguration, connectionPoolConfiguration, connectionPoolMonitor);
+                                                                                                             ConnectionPoolMonitor connectionPoolMonitor,
+                                                                                                             KeyspaceInitializer keyspaceInitializer) {
+            final CacheLoader<KeyspaceKey, AstyanaxContext<Keyspace>> delegate = super.createCacheLoader(astyanaxConfiguration, connectionPoolConfiguration, connectionPoolMonitor, keyspaceInitializer);
             return new CacheLoader<KeyspaceKey, AstyanaxContext<Keyspace>>() {
                 @Override
                 public AstyanaxContext<Keyspace> load(KeyspaceKey key) throws Exception {

--- a/kork-cassandra/src/test/java/com/netflix/spinnaker/kork/astyanax/DefaultAstyanaxKeyspaceFactoryTest.java
+++ b/kork-cassandra/src/test/java/com/netflix/spinnaker/kork/astyanax/DefaultAstyanaxKeyspaceFactoryTest.java
@@ -23,7 +23,6 @@ import com.netflix.astyanax.AstyanaxConfiguration;
 import com.netflix.astyanax.AstyanaxContext;
 import com.netflix.astyanax.Keyspace;
 import com.netflix.astyanax.connectionpool.ConnectionPoolConfiguration;
-import com.netflix.astyanax.connectionpool.ConnectionPoolMonitor;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -71,15 +70,17 @@ public class DefaultAstyanaxKeyspaceFactoryTest {
         public final AtomicInteger removeCount = new AtomicInteger();
 
         public TestDAKF(AstyanaxComponents comp) {
-            super(comp.astyanaxConfiguration(), comp.connectionPoolConfiguration(9160, "127.0.0.1", 3), comp.connectionPoolMonitor(), comp.noopKeyspaceInitializer());
+            super(comp.astyanaxConfiguration(comp.cassandraAsyncExecutor(5)), comp.connectionPoolConfiguration(), comp.countingConnectionPoolMonitor(), comp.clusterHostSupplierFactory(), comp.noopKeyspaceInitializer());
         }
 
         @Override
         CacheLoader<DefaultAstyanaxKeyspaceFactory.KeyspaceKey, AstyanaxContext<Keyspace>> createCacheLoader(AstyanaxConfiguration astyanaxConfiguration,
                                                                                                              ConnectionPoolConfiguration connectionPoolConfiguration,
-                                                                                                             ConnectionPoolMonitor connectionPoolMonitor,
+                                                                                                             KeyspaceConnectionPoolMonitorFactory connectionPoolMonitorFactory,
+                                                                                                             ClusterHostSupplierFactory hostSupplierFactory,
                                                                                                              KeyspaceInitializer keyspaceInitializer) {
-            final CacheLoader<KeyspaceKey, AstyanaxContext<Keyspace>> delegate = super.createCacheLoader(astyanaxConfiguration, connectionPoolConfiguration, connectionPoolMonitor, keyspaceInitializer);
+
+            final CacheLoader<KeyspaceKey, AstyanaxContext<Keyspace>> delegate = super.createCacheLoader(astyanaxConfiguration, connectionPoolConfiguration, connectionPoolMonitorFactory, hostSupplierFactory, keyspaceInitializer);
             return new CacheLoader<KeyspaceKey, AstyanaxContext<Keyspace>>() {
                 @Override
                 public AstyanaxContext<Keyspace> load(KeyspaceKey key) throws Exception {


### PR DESCRIPTION
Makes kork-cassandra more configurable/tunable for production Cassandra clients

* ConnectionPoolConfiguration and AsytanaxProperties are bound via `@ConfigurationProperties`
* Allows a host supplier for ring discovery
  * provides an optional EurekaHostSupplier to discover nodes via Eureka

Closes #12 (Rebased on top of it)

@ajordens ptal

