### PR TITLE
Adds support for configuring CRL or custom blacklisting on tomcat SSL

### DIFF
--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile spinnaker.dependency('groovy')
   compile spinnaker.dependency('okHttp')
   compile spinnaker.dependency('retrofit')
+  compile spinnaker.dependency('guava')
 
 
   spinnaker.group('spockBase')

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy
@@ -16,14 +16,17 @@
 
 package com.netflix.spinnaker.config
 
+import com.netflix.spinnaker.tomcat.x509.BlacklistingSSLImplementation
 import groovy.util.logging.Slf4j
 import org.apache.catalina.connector.Connector
+import org.apache.coyote.http11.AbstractHttp11JsseProtocol
 import org.apache.coyote.http11.Http11NioProtocol
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer
 import org.springframework.boot.context.embedded.Ssl
+import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -37,6 +40,12 @@ class TomcatConfiguration {
   @Value('${default.apiPort:-1}')
   int apiPort
 
+  //TODO(cfieber) remove this when https://github.com/spring-projects/spring-boot/issues/6171 is implemented
+  // the default value of null equates to no CRL file in the connector config so we don't have to null-check it
+  // below
+  @Value('${server.ssl.crlFile:#{null}}')
+  String crlFile
+
   /**
    * Setup multiple connectors:
    * - an https connector requiring client auth that will service API requests
@@ -47,6 +56,19 @@ class TomcatConfiguration {
   EmbeddedServletContainerCustomizer containerCustomizer() throws Exception {
     return { ConfigurableEmbeddedServletContainer container ->
       TomcatEmbeddedServletContainerFactory tomcat = (TomcatEmbeddedServletContainerFactory) container
+      //this will only handle the case where SSL is enabled on the main tomcat connector
+      tomcat.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+        @Override
+        void customize(Connector connector) {
+          def handler = connector.getProtocolHandler()
+          if (handler instanceof AbstractHttp11JsseProtocol) {
+            if (handler.isSSLEnabled()) {
+              handler.setSslImplementationName(BlacklistingSSLImplementation.name)
+              handler.setCrlFile(crlFile)
+            }
+          }
+        }
+      })
 
       if (legacyServerPort > 0) {
         log.info("Creating legacy connector on port ${legacyServerPort}")
@@ -70,7 +92,11 @@ class TomcatConfiguration {
         }
         ssl.clientAuth = Ssl.ClientAuth.NEED
 
-        tomcat.configureSsl(apiConnector.getProtocolHandler() as Http11NioProtocol, ssl)
+        Http11NioProtocol handler = apiConnector.getProtocolHandler() as Http11NioProtocol
+        handler.setCrlFile(crlFile)
+        handler.setSslImplementationName(BlacklistingSSLImplementation.name)
+
+        tomcat.configureSsl(handler, ssl)
         tomcat.addAdditionalTomcatConnectors(apiConnector)
       }
     } as EmbeddedServletContainerCustomizer

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/Blacklist.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/Blacklist.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.tomcat.x509;
+
+import java.security.cert.X509Certificate;
+
+public interface Blacklist {
+
+  static Blacklist forFile(String blacklistFile) {
+    return new ReloadingFileBlacklist(blacklistFile);
+  }
+
+  boolean isBlacklisted(X509Certificate cert);
+}

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/BlacklistingJSSESocketFactory.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/BlacklistingJSSESocketFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.tomcat.x509;
+
+import org.apache.tomcat.util.net.AbstractEndpoint;
+import org.apache.tomcat.util.net.jsse.JSSESocketFactory;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.util.Optional;
+
+public class BlacklistingJSSESocketFactory extends JSSESocketFactory {
+  private static final String BLACKLIST_PREFIX = "blacklist:";
+
+  private final Blacklist blacklist;
+
+  public BlacklistingJSSESocketFactory(AbstractEndpoint<?> endpoint) {
+    super(endpoint);
+    String blacklistFile = Optional.ofNullable(endpoint.getCrlFile())
+      .filter(file -> file.startsWith(BLACKLIST_PREFIX))
+      .map(file -> file.substring(BLACKLIST_PREFIX.length()))
+      .orElse(null);
+
+    if (blacklistFile != null) {
+      endpoint.setCrlFile(null);
+      blacklist = Blacklist.forFile(blacklistFile);
+    } else {
+      blacklist = null;
+    }
+  }
+
+  @Override
+  public TrustManager[] getTrustManagers() throws Exception {
+    TrustManager[] trustManagers = super.getTrustManagers();
+    if (blacklist != null && trustManagers != null) {
+      int delegatedCount = 0;
+      for (int i = 0; i < trustManagers.length; i++) {
+        TrustManager tm = trustManagers[i];
+        if (tm instanceof X509TrustManager) {
+          trustManagers[i] = new BlacklistingX509TrustManager((X509TrustManager) tm, blacklist);
+          delegatedCount++;
+        }
+      }
+
+      if (delegatedCount != 1) {
+        throw new IllegalStateException("expected single X509TrustManager");
+      }
+    }
+
+    return trustManagers;
+  }
+}

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/BlacklistingSSLImplementation.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/BlacklistingSSLImplementation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.tomcat.x509;
+
+import org.apache.tomcat.util.net.AbstractEndpoint;
+import org.apache.tomcat.util.net.SSLUtil;
+import org.apache.tomcat.util.net.ServerSocketFactory;
+import org.apache.tomcat.util.net.jsse.JSSEImplementation;
+
+/**
+ * An SSLImplementation that enforces a blacklist of client certificates.
+ *
+ * To enable the blacklist behavior, use the {{AbstractEndpoint}} {{crlFile}} property
+ * following the naming convention {{blacklist:/path/to/blacklist/file}}
+ *
+ * The format of the blacklist file is one entry per line conforming to
+ * {{issuer X500 name:::blacklisted certificate serial number}}
+ * Blank lines and lines that begin with {{#}} are ignored.
+ *
+ * The Blacklist file is refreshed periodically, so it can be updated in place to pick up newly
+ * revoked certificates.
+ */
+public class BlacklistingSSLImplementation extends JSSEImplementation {
+  @Override
+  public ServerSocketFactory getServerSocketFactory(AbstractEndpoint<?> endpoint) {
+    return new BlacklistingJSSESocketFactory(endpoint);
+  }
+
+  @Override
+  public SSLUtil getSSLUtil(AbstractEndpoint<?> endpoint) {
+    return new BlacklistingJSSESocketFactory(endpoint);
+  }
+}

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/BlacklistingX509TrustManager.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/BlacklistingX509TrustManager.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.tomcat.x509;
+
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.CRLReason;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateRevokedException;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Objects;
+
+public class BlacklistingX509TrustManager implements X509TrustManager {
+  private final X509TrustManager delegate;
+  private final Blacklist blacklist;
+
+  public BlacklistingX509TrustManager(X509TrustManager delegate, Blacklist blacklist) {
+    this.delegate = Objects.requireNonNull(delegate);
+    this.blacklist = Objects.requireNonNull(blacklist);
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] x509Certificates, String authType) throws CertificateException {
+    if (x509Certificates != null) {
+      for (X509Certificate cert : x509Certificates) {
+        if (blacklist.isBlacklisted(cert)) {
+          throw new CertificateRevokedException(new Date(), CRLReason.UNSPECIFIED, cert.getIssuerX500Principal(), Collections.emptyMap());
+        }
+      }
+    }
+
+    delegate.checkClientTrusted(x509Certificates, authType);
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] x509Certificates, String authType) throws CertificateException {
+    delegate.checkServerTrusted(x509Certificates, authType);
+  }
+
+  @Override
+  public X509Certificate[] getAcceptedIssuers() {
+    return delegate.getAcceptedIssuers();
+  }
+
+}
+

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/ReloadingFileBlacklist.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/ReloadingFileBlacklist.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.tomcat.x509;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableSet;
+
+import javax.security.auth.x500.X500Principal;
+import java.io.File;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class ReloadingFileBlacklist implements Blacklist {
+  private static class Entry {
+    private static final String DELIMITER = ":::";
+    private final X500Principal issuer;
+    private final BigInteger serial;
+
+    private static Entry fromString(String blacklistEntry) {
+      int idx = blacklistEntry.indexOf(DELIMITER);
+      if (idx == -1) {
+        throw new IllegalArgumentException("Missing delimiter " + DELIMITER + " in " + blacklistEntry);
+      }
+      X500Principal principal = new X500Principal(blacklistEntry.substring(0, idx));
+      BigInteger serial = new BigInteger(blacklistEntry.substring(idx + DELIMITER.length()));
+      return new Entry(principal, serial);
+    }
+
+    private Entry(X500Principal issuer, BigInteger serial) {
+      this.issuer = Objects.requireNonNull(issuer);
+      this.serial = Objects.requireNonNull(serial);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Entry entry = (Entry) o;
+
+      if (!issuer.equals(entry.issuer)) return false;
+      return serial.equals(entry.serial);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = issuer.hashCode();
+      result = 31 * result + serial.hashCode();
+      return result;
+    }
+  }
+
+  private static final int DEFAULT_RELOAD_INTERVAL_SECONDS = 5;
+  private final String blacklistFile;
+  private final LoadingCache<String, Set<Entry>> blacklist;
+
+  public ReloadingFileBlacklist(String blacklistFile, long reloadInterval, TimeUnit unit) {
+    this.blacklistFile = blacklistFile;
+    this.blacklist = CacheBuilder
+      .newBuilder()
+      .expireAfterAccess(reloadInterval, unit)
+      .build(new CacheLoader<String, Set<Entry>>() {
+        @Override
+        public Set<Entry> load(String key) throws Exception {
+          File f = new File(key);
+          if (!f.exists()) {
+            return Collections.emptySet();
+          }
+          return ImmutableSet.copyOf(Files.lines(f.toPath())
+            .map(String::trim)
+            .filter(line -> !(line.isEmpty() || line.startsWith("#")))
+            .map(Entry::fromString)
+            .collect(Collectors.toSet()));
+        }
+      });
+  }
+
+  public ReloadingFileBlacklist(String blacklistFile) {
+    this(blacklistFile, DEFAULT_RELOAD_INTERVAL_SECONDS, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public boolean isBlacklisted(X509Certificate cert) {
+    try {
+      return blacklist.get(blacklistFile).contains(new Entry(cert.getIssuerX500Principal(), cert.getSerialNumber()));
+    } catch (ExecutionException ee) {
+      Throwable cause = ee.getCause();
+      if (cause != null) {
+        if (cause instanceof RuntimeException) {
+          throw (RuntimeException) cause;
+        }
+        throw new RuntimeException(cause);
+      }
+      throw new RuntimeException(ee);
+    }
+
+  }
+}

--- a/kork-web/src/test/groovy/com/netflix/spinnaker/tomcat/x509/BlacklistingX509TrustManagerSpec.groovy
+++ b/kork-web/src/test/groovy/com/netflix/spinnaker/tomcat/x509/BlacklistingX509TrustManagerSpec.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.tomcat.x509
+
+import spock.lang.Specification
+
+import javax.net.ssl.X509TrustManager
+import javax.security.auth.x500.X500Principal
+import java.security.cert.CertificateRevokedException
+import java.security.cert.X509Certificate
+
+class BlacklistingX509TrustManagerSpec extends Specification {
+  def delegate = Mock(X509TrustManager)
+  def blacklist = Mock(Blacklist)
+
+  def trustManager = new BlacklistingX509TrustManager(delegate, blacklist)
+
+  def "should delegate for server auth"() {
+    when:
+    trustManager.checkServerTrusted(certs, authType)
+
+    then:
+    1 * delegate.checkServerTrusted(certs, authType)
+    0 * _
+
+    where:
+    cert = testCert(12345, "Test")
+    certs = [cert] as X509Certificate[]
+    authType = 'RSA'
+  }
+
+  def "should delegate for trusted issuers"() {
+    when:
+    trustManager.getAcceptedIssuers()
+
+    then:
+    1 * delegate.getAcceptedIssuers() >> []
+    0 * _
+  }
+
+  def "should fall back to delegate if not blacklisted"() {
+
+    when:
+    trustManager.checkClientTrusted(certs, authType)
+
+    then:
+    1 * blacklist.isBlacklisted(cert) >> false
+    1 * delegate.checkClientTrusted(certs, authType)
+    0 * _
+
+    where:
+    cert = testCert(12345, "Test")
+    certs = [cert] as X509Certificate[]
+    authType = 'RSA'
+  }
+
+  def "should reject a blacklisted cert"() {
+    when:
+    trustManager.checkClientTrusted(certs, authType)
+
+    then:
+    1 * blacklist.isBlacklisted(cert) >> true
+    thrown(CertificateRevokedException)
+    0 * _
+
+
+    where:
+    cert = testCert(12345, "Test")
+    certs = [cert] as X509Certificate[]
+    authType = 'RSA'
+  }
+
+  private X509Certificate testCert(int certSerial, String issuerCN) {
+    BigInteger serial = certSerial as BigInteger
+    X500Principal issuer = new X500Principal("O=Test, OU=Test, CN=$issuerCN, L=Testland, ST=CA, C=US")
+
+
+    return Stub(X509Certificate) {
+      getSerialNumber() >> serial
+      getIssuerX500Principal() >> issuer
+    }
+
+  }
+}

--- a/kork-web/src/test/groovy/com/netflix/spinnaker/tomcat/x509/ReloadingFileBlacklistSpec.groovy
+++ b/kork-web/src/test/groovy/com/netflix/spinnaker/tomcat/x509/ReloadingFileBlacklistSpec.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.tomcat.x509
+
+import spock.lang.Specification
+
+import javax.security.auth.x500.X500Principal
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+
+class ReloadingFileBlacklistSpec extends Specification {
+  def "should extract cert identification from blacklist file"() {
+    given:
+    def blFile = createBlacklist()
+    def bl = new ReloadingFileBlacklist(blFile.getPath())
+
+    expect:
+    bl.isBlacklisted(cert) == expected
+
+    where:
+    issuer | serial | expected
+    "O=Test, OU=Test, CN=TestCN, L=Testland, ST=CA, C=US" | 1 | true
+    "O=Test, OU=Test, CN=TestCN, L=Testland, ST=CA, C=US" | 2 | true
+    "O=Test, OU=Test, CN=TestCN, L=Testland, ST=CA, C=US" | 2 | true
+    "O=Test, OU=Test, CN=TestCN, L=Testland, ST=CA, C=US" | 4 | false
+    "O=Test, OU=Test, CN=TestCN2, L=Testland, ST=CA, C=US" | 1 | true
+    "O=Test, OU=Test, CN=TestCN2, L=Testland, ST=CA, C=US" | 2 | false
+
+    cert = testCert(serial, issuer)
+  }
+
+  def "should reload cert identification from blacklist file"() {
+    given:
+    def blFile = createBlacklist()
+    def bl = new ReloadingFileBlacklist(blFile.getPath(), 1, TimeUnit.MILLISECONDS)
+
+    when:
+    def result = bl.isBlacklisted(cert)
+
+    then:
+    result == false
+
+    when:
+    blFile.text += issuer + ':::' + serial
+    Thread.sleep(10)
+
+    and:
+    result = bl.isBlacklisted(cert)
+
+    then:
+    result == true
+
+
+    where:
+    issuer = "O=Test, OU=Test, CN=TestCN2, L=Testland, ST=CA, C=US"
+    serial = 2
+    cert = testCert(serial, issuer)
+  }
+
+
+
+  private File createBlacklist() {
+    def bl = File.createTempFile("blacklist", ".test")
+    bl.deleteOnExit()
+
+    bl.text = '''\
+    # a comment
+
+    O=Test, OU=Test, CN=TestCN, L=Testland, ST=CA, C=US:::1
+    O=Test, OU=Test, CN=TestCN, L=Testland, ST=CA, C=US:::2
+    O=Test, OU=Test, CN=TestCN, L=Testland, ST=CA, C=US:::3
+    O=Test, OU=Test, CN=TestCN2, L=Testland, ST=CA, C=US:::1
+    '''.stripIndent()
+
+    return bl
+  }
+
+  private X509Certificate testCert(int certSerial, String issuerName) {
+    BigInteger serial = certSerial as BigInteger
+    X500Principal issuer = new X500Principal(issuerName)
+
+
+    return Stub(X509Certificate) {
+      getSerialNumber() >> serial
+      getIssuerX500Principal() >> issuer
+    }
+
+  }
+}


### PR DESCRIPTION
This is a bit convoluted due to what it takes to wire in the TrustManager to tomcat

This exposes a `server.ssl.crlFile` configuration property which is configured onto the tomcat connector.

That can either be the path to a legitimate CRL file, in which case the standard Tomcat CRL handling will apply.

Alternatively this can be the path to a custom blacklist file. To configure this way, prefix the path with `blacklist:`

E.g. in the relevant yaml file:

````yaml
server:
  ssl:
    crlFile: blacklist:/path/to/my/blacklist
````

The custom blacklist takes the form of one entry per line following
````
certificate issuer x500 name:::certificate serial number
````

e.g.
````
OU=Some OU, O=My Org, CN=My CA, L=Where Waldo is, ST=CA, C=US:::12345
````

A client presented certificate will be compared against the blacklist and rejected if it is found, otherwise SSL negotiation will fall back to Tomcat's standard behavior.

The two primary advantages of this custom implementation are:
1) Managing a CA and generating CRLs is hard
2) The file will refresh every 5 seconds, so it can be updated in a running system to revoke certificates without restarting the process

I'd like to say there are lots of unit tests around this but standing up the PKIX bits for a test seemed a bit painful.  I've manually tested this pretty extensively.

If https://github.com/spring-projects/spring-boot/issues/6171 gets implemented then the `@Value` annotation in here probably becomes redundant.

@spinnaker/netflix-reviewers PTAL