### PR TITLE
fixes open file leak in ssl blacklist reading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
   group = 'com.netflix.spinnaker.kork'
 
   spinnaker {
-    dependenciesVersion = "0.44.0"
+    dependenciesVersion = "0.50.0"
   }
 
   jacoco {

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/ReloadingFileBlacklist.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/ReloadingFileBlacklist.java
@@ -89,7 +89,8 @@ public class ReloadingFileBlacklist implements Blacklist {
           if (!f.exists()) {
             return Collections.emptySet();
           }
-          return ImmutableSet.copyOf(Files.lines(f.toPath())
+          return ImmutableSet.copyOf(Files.readAllLines(f.toPath())
+            .stream()
             .map(String::trim)
             .filter(line -> !(line.isEmpty() || line.startsWith("#")))
             .map(Entry::fromString)


### PR DESCRIPTION
Using Files.lines returns a Stream that has to be explicitly closed, switched to Files.readAllLines since we are going to process them all anyway..