### PR TITLE
Stackdriver prototype checkpoint using links to spectator and kork.

### DIFF
--- a/kork-stackdriver/kork-stackdriver.gradle
+++ b/kork-stackdriver/kork-stackdriver.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2016 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-include 'kork-core', 'kork-cassandra', 'kork-jedis-test', 'kork-swagger', 'kork-security', 'kork-web', 'kork-hystrix', 'kork-stackdriver', 'spectator-web-spring', 'spectator-ext-stackdriver'
+dependencies {
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('bootDataRest')
+  compile spinnaker.dependency('rxJava')
 
-rootProject.name='kork'
-
-def setBuildFile(project) {
-    project.buildFileName = "${project.name}.gradle"
-    project.children.each {
-        setBuildFile(it)
-    }
-}
-
-rootProject.children.each {
-    setBuildFile it
+  compile project(':spectator-ext-stackdriver')
+  compile project(':spectator-web-spring')
 }

--- a/kork-stackdriver/src/main/java/com/netflix/spinnaker/config/StackdriverConfig.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spinnaker/config/StackdriverConfig.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config;
+
+import com.netflix.spectator.controllers.filter.PrototypeMeasurementFilter;
+import com.netflix.spectator.stackdriver.ConfigParams;
+import com.netflix.spectator.stackdriver.MetricDescriptorCache;
+import com.netflix.spectator.stackdriver.StackdriverWriter;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.controllers.MetricsController;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import rx.Observable;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
+
+
+@Configuration
+@EnableConfigurationProperties
+@Import({MetricsController.class})
+@ConditionalOnExpression("${spectator.stackdriver.enabled:false}")
+class StackdriverConfig {
+
+  @Value("${spectator.applicationName:}")
+  private String applicationName;
+
+  @Value("${spectator.stackdriver.credentialsPath:}")
+  private String credentialsPath;
+
+  @Value("${spectator.stackdriver.projectName:}")
+  private String projectName;
+
+  @Value("${spectator.stackdriver.uniqueMetricsPerApplication:true}")
+  private boolean uniqueMetricsPerApplication;
+
+  // If provided, takes precedence over the *Regex filters above.
+  @Value("${spectator.webEndpoint.prototypeFilter.path:}")
+  private String prototypeFilterPath;
+
+  @Value("${spectator.stackdriver.period:60}")
+  private int pushPeriodSecs;
+
+  private StackdriverWriter stackdriver;
+
+  @Configuration
+  @ConfigurationProperties(prefix="stackdriver")
+  static public class StackdriverConfigurationHints {
+    /**
+     * This class lets spring load from our YAML file into a Hint instance.
+     */
+    static public class MutableHint extends MetricDescriptorCache.CustomDescriptorHint {
+        public void setLabels(List<String> labels) {
+            this.labels = labels;
+        }
+        public void setRedacted(List<String> labels) {
+            this.redacted = labels;
+        }
+        public void setName(String name) {
+            this.name = name;
+        }
+    };
+
+    public List<MutableHint> hints;
+    public void setHints(List<MutableHint> hints) { this.hints = hints; }
+    public List<MutableHint> getHints() { return hints; }
+  };
+
+  @Autowired
+  StackdriverConfigurationHints stackdriverHints;
+
+  @Autowired
+  Registry registry;
+
+  /**
+   * Schedule a thread to flush our registry into stackdriver periodically.
+   *
+   * This configures our StackdriverWriter as well.
+   */
+  @Bean
+  public StackdriverWriter defaultStackdriverWriter() throws IOException {
+    Logger log = LoggerFactory.getLogger("StackdriverConfig");
+    log.info("Creating StackdriverWriter.");
+    Predicate<Measurement> filterNotSpring = new Predicate<Measurement>() {
+      public boolean test(Measurement measurement) {
+        // Dont store measurements that dont have tags.
+        // These are from spring; those of interest were replicated in spectator.
+        if (measurement.id().tags().iterator().hasNext()) {
+          return true;
+        }
+
+        return false;
+      }
+    };
+    Predicate<Measurement> measurementFilter;
+
+    if (!prototypeFilterPath.isEmpty()) {
+      log.info("Configuring stackdriver filter from {}", prototypeFilterPath);
+      measurementFilter = PrototypeMeasurementFilter.loadFromPath(
+           prototypeFilterPath).and(filterNotSpring);
+    } else {
+      measurementFilter = filterNotSpring;
+    }
+
+    ConfigParams params = new ConfigParams.Builder()
+        .setCounterStartTime(new Date().getTime())
+        .setUniqueMetricsPerApplication(uniqueMetricsPerApplication)
+        .setCustomTypeNamespace("spinnaker")
+        .setProjectName(projectName)
+        .setApplicationName(applicationName)
+        .setCredentialsPath(credentialsPath)
+        .setMeasurementFilter(measurementFilter)
+        .build();
+
+    stackdriver = new StackdriverWriter(params);
+
+    if (stackdriverHints != null && stackdriverHints.hints != null) {
+        log.info("Adding {} custom descriptor hints",
+                 stackdriverHints.hints.size());
+        stackdriver.getDescriptorCache()
+            .addCustomDescriptorHints(stackdriverHints.hints);
+    } else {
+        log.info("No custom descriptor hints");
+    }
+    Scheduler scheduler = Schedulers.from(Executors.newFixedThreadPool(1));
+
+    // Note that the globalRegistry gives different results than
+    // the autowired registry in MetricsController but we get startup
+    // circular references trying to autowire it here.
+    // (the difference is the timers() and counters() streams are empty
+    //  but the registry seems to have the same metrics within).
+    Observable.timer(pushPeriodSecs, TimeUnit.SECONDS)
+        .repeat()
+        .subscribe(interval -> { stackdriver.writeRegistry(registry); });
+
+    return stackdriver;
+  }
+
+  /**
+   * We can optionally add a registry if one doesnt exist.
+   *
+   * While we need a registry, it could be provided elsewhere.
+  @Bean
+  @ConditionalOnExpression("${spectator.stackdriver.defaultRegistry:false}")
+  Registry defaultMetricRegistry() {
+    Logger log = LoggerFactory.getLogger("StackdriverConfig");
+    log.info("Creating default registry.");
+    return new DefaultRegistry(com.netflix.spectator.api.Clock.SYSTEM);
+  }
+   * This causes a circular dependency for some reason, even with disabled.
+   *
+   * Reviewer, please confirm that I dont need this.
+   */
+};

--- a/spectator-ext-stackdriver
+++ b/spectator-ext-stackdriver
@@ -1,0 +1,1 @@
+../spectator/spectator-ext-stackdriver

--- a/spectator-web-spring
+++ b/spectator-web-spring
@@ -1,0 +1,1 @@
+../spectator/spectator-web-spring


### PR DESCRIPTION
@cfieber 
Could you have a preliminary review of this?
It depends on two other PRs waiting in review for brian to have time to look at it.
I'm running out of time so want to seed this one.

The treatment of spectator as a local project and symbolic links to it are temporary until those PRs are in. Everything else is what I think is an initial version.

There's a comment for you where I conditionally create a default registry. I dont know if I can count on one being there or not. Even if I conditionally exclude it I get circular references so hope I can remove it.

The gist is that once this is in there, I just need to add a dependency to kork-stackdriver in each of the microservices and it will pull in the spectator modules I added as well. The main thing is a periodic thread (off by default) that pushes to metrics to stackdriver. I need some custom configuration to workaround stackdriver problems [*] especially as mitigator to those that may get introduced in future service updates.

[*] the problems are mostly in inconsistent tag usage for a given id.name. Not all the call sites are the same set of tags, which is OK except stackdriver wants a fixed schema before the initial use. So far I've identified that igor sometimes adds a "master" for jenkins, and clouddriver sometimes adds a "region". I also have the ability to redact bad tags. I dont need this at the moment, but I did earlier on in development and left it in as a post-deploy mitigation mechanism for a particular scenario.