### PR TITLE
Add kork-stackdriver module providing optional stackdriver publisher.

### DIFF
--- a/kork-stackdriver/kork-stackdriver.gradle
+++ b/kork-stackdriver/kork-stackdriver.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+dependencies {
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('bootDataRest')
+  compile spinnaker.dependency('rxJava')
+
+  compile project(':spectator-web-spring')
+
+  // The remainingo dependencies are only for the spectator modules folded into this.
+  // If they are split into spectator-ext-stackdriver then these could go along.
+  // None of the above are needed by this spectator module.
+  // (in addition, would need to add jcenter() as a repository; kork already does)  
+  compile spinnaker.dependency('spectatorApi')
+  compile compile('com.google.apis:google-api-services-monitoring:v3-rev6-1.22.0')
+  testCompile 'org.mockito:mockito-core:1.+'
+
+  testCompile 'junit:junit:4.+'
+}

--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/ConfigParams.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/ConfigParams.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spectator.stackdriver;
+
+import com.netflix.spectator.api.Measurement;
+
+import com.google.api.services.monitoring.v3.Monitoring;
+import com.google.api.services.monitoring.v3.MonitoringScopes;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import java.util.function.Predicate;
+import java.util.Collections;
+import java.util.UUID;
+
+
+
+/**
+ * Factory to instantiate StackdriverWriter instance.
+ */
+public class ConfigParams {
+  /**
+   * Derived if not explicitly set.
+   */
+  protected Monitoring monitoring;
+
+  /**
+   * Required. The stackdriver project to store the data under.
+   */
+  protected String projectName;
+
+  /**
+   * Required.
+   */
+  protected String customTypeNamespace;
+
+  /**
+   * Required.
+   */
+  protected String applicationName;
+
+  /**
+   * Derived if not explicitly set.
+   */
+  protected String instanceId;
+
+  /**
+   * Optional.
+   */
+  protected Predicate<Measurement> measurementFilter;
+
+  /**
+   * Derived if not set.
+   */
+  protected MetricDescriptorCache descriptorCache;
+
+  /**
+   * Optional.
+   */
+  protected long counterStartTime;
+
+
+  /**
+   * Optional.
+   */
+  protected boolean uniqueMetricsPerApplication = true;
+
+  /**
+   * Builds an instance of ConfigParams.
+   */
+  public static class Builder extends ConfigParams {
+    private String credentialsPath;
+
+    private String validateString(String value, String purpose) {
+      if (value == null || value.isEmpty()) {
+          throw new IllegalStateException(
+              "The " + purpose + " has not been specified.");
+      }
+      return value;
+    }
+
+    /**
+     * Ensure the configuration parameters are complete and valid.
+     *
+     * If some required parameters are not yet explicitly set then this
+     * may initialize them.
+     */
+    public ConfigParams build() {
+      ConfigParams result = new ConfigParams();
+
+      result.projectName
+          = validateString(projectName, "stackdriver projectName");
+      result.applicationName
+          = validateString(applicationName, "applicationName");
+      result.customTypeNamespace
+          = validateString(customTypeNamespace,
+                           "stackdriver customTypeNamespace");
+
+      result.uniqueMetricsPerApplication = uniqueMetricsPerApplication;
+      result.counterStartTime = counterStartTime;
+      result.measurementFilter = measurementFilter;
+
+      result.instanceId = instanceId;
+      result.monitoring = monitoring;
+      result.descriptorCache = descriptorCache;
+
+      if (result.instanceId == null || result.instanceId.isEmpty()) {
+          UUID uuid = UUID.randomUUID();
+          byte[] uuidBytes = new byte[16];
+          addLong(uuidBytes, 0, uuid.getLeastSignificantBits());
+          addLong(uuidBytes, 8, uuid.getMostSignificantBits());
+          result.instanceId
+              = java.util.Base64.getEncoder().encodeToString(uuidBytes);
+      }
+
+      if (result.monitoring == null) {
+        try {
+          HttpTransport transport = GoogleNetHttpTransport.newTrustedTransport();
+          JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+          GoogleCredential credential = loadCredential(transport, jsonFactory,
+                                                       credentialsPath);
+          result.monitoring
+              = new Monitoring.Builder(transport, jsonFactory, credential)
+                    .setApplicationName("Spectator")
+                    .build();
+        } catch (IOException | java.security.GeneralSecurityException e) {
+            final Logger log = LoggerFactory.getLogger("StackdriverWriter");
+            log.error("Caught exception initializing client: " + e);
+            throw new IllegalStateException(e);
+        }
+      }
+
+      if (result.descriptorCache == null) {
+        result.descriptorCache = new MetricDescriptorCache(result);
+      }
+      return result;
+    }
+
+    /**
+     * The Stackdriver namespace containing Custom Metric Descriptor types.
+     *
+     * This is intended to group a family of metric types together for a
+     * particular system. (e.g. "spinnaker")
+     */
+     public Builder setCustomTypeNamespace(String name) {
+       customTypeNamespace = name;
+       return this;
+     }
+
+    /**
+     * Sets the Google project name for Stackdriver to manage metrics under.
+     *
+     * This is a Google Cloud Platform project owned by the user deploying
+     * the system using Spectator and used by Stackdriver to catalog our data
+     * (e.g. "my-unique-project").
+     */
+    public Builder setProjectName(String name) {
+      projectName = name;
+      return this;
+    }
+
+    /**
+     * The path to specific Google Credentials create the client stub with.
+     *
+     * This is not needed if injecting a specific Monitoring client stub.
+     */
+    public Builder setCredentialsPath(String path) {
+      credentialsPath = path;
+      return this;
+    }
+
+    /**
+     * Sets the application name that we are associating these metrics with.
+     *
+     * This will be the APPLICATION_LABEL value for the metrics we store.
+     * It distinguishes similar metrics within a system that are coming from
+     * different services.
+     * (e.g. "clouddriver")
+     */
+    public Builder setApplicationName(String name) {
+      applicationName = name;
+      return this;
+    }
+
+    /**
+     * Sets the instance id that we are associating these metrics with.
+     *
+     * This will be the INSTANCE_LABEL value for the metrics we store.
+     */
+    public Builder setInstanceId(String id) {
+      instanceId = id;
+      return this;
+    }
+
+    /**
+     * Sets the Spectator MeasurementFilter determining which metrics
+     * to store in Stackdriver.
+     */
+    public Builder setMeasurementFilter(Predicate<Measurement> filter) {
+      measurementFilter = filter;
+      return this;
+    }
+
+    /**
+     * Overrides the normal Stackdriver Monitoring client to use when
+     * interacting with Stackdriver.
+     */
+    public Builder setStackdriverStub(Monitoring stub) {
+      monitoring = stub;
+      return this;
+    }
+
+    /**
+     * Overrides the normal MetricDescriptorCache for the Stackdriver server.
+     */
+    public Builder setDescriptorCache(MetricDescriptorCache cache) {
+      descriptorCache = cache;
+      return this;
+    }
+
+    /**
+     * Distinguish application using a distinct metric type, or a Time Series label.
+     */
+    public Builder setUniqueMetricsPerApplication(boolean distinctTypes) {
+      uniqueMetricsPerApplication = distinctTypes;
+      return this;
+    }
+
+    /**
+     * Specifies the starting time interval for CUMULATIVE Stackdriver
+     * metric descriptor types.
+     */
+    public Builder setCounterStartTime(long millis) {
+      counterStartTime = millis;
+      return this;
+    }
+
+    /**
+     * Helper function to encode a value into buffer when constructing a UUID.
+     */
+    private void addLong(byte[] buffer, int offset, long value) {
+      for (int i = 0; i < 8; ++i) {
+         buffer[i + offset] = (byte) (value >> (8 * i) & 0xff);
+      }
+    }
+
+    /**
+     * Helper function for the validator that reads our credentials for
+     * talking to Stackdriver.
+     */
+    private static GoogleCredential loadCredential(
+          HttpTransport transport, JsonFactory factory, String credentialsPath)
+          throws IOException {
+      final Logger log = LoggerFactory.getLogger("StackdriverWriter");
+
+      GoogleCredential credential;
+      if (credentialsPath != null && !credentialsPath.isEmpty()) {
+        FileInputStream stream = new FileInputStream(credentialsPath);
+        try {
+          credential = GoogleCredential.fromStream(stream, transport, factory)
+                      .createScoped(
+                           Collections.singleton(MonitoringScopes.MONITORING));
+          log.info("Loaded credentials from from {}", credentialsPath);
+        } finally {
+          stream.close();
+        }
+      } else {
+        log.info("spectator.stackdriver.monitoring.enabled without"
+                 + " spectator.stackdriver.credentialsPath. "
+                 + " Using default application credentials.");
+        credential = GoogleCredential.getApplicationDefault();
+      }
+      return credential;
+    }
+  };
+
+  /**
+   * The Stackdriver namespace containing Custom Metric Descriptor types.
+   */
+  public String getCustomTypeNamespace() {
+     return customTypeNamespace;
+  }
+
+  /**
+   * The Google project name for Stackdriver to manage metrics under.
+   */
+  public String getProjectName() {
+    return projectName;
+  }
+
+  /**
+   * The application name that we are associating these metrics with.
+   */
+  public String getApplicationName() {
+    return applicationName;
+  }
+
+  /**
+   * The instance id that we are associating these metrics with.
+   */
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  /**
+   * Determines which metrics to write into stackdriver.
+   */
+  public Predicate<Measurement> getMeasurementFilter() {
+    return measurementFilter;
+  }
+
+  /**
+   * The Stackdriver Monitoring client stub.
+   */
+  public Monitoring getStackdriverStub() {
+      return monitoring;
+  }
+
+  /**
+   * The MetricDescriptorCache.
+   */
+  public MetricDescriptorCache getDescriptorCache() {
+      return descriptorCache;
+  }
+
+  /**
+   * Whether metric type specifies the application, or Time Series data should.
+   */
+  public boolean isMetricUniquePerApplication() {
+      return uniqueMetricsPerApplication;
+  }
+
+  /**
+   * The TimeInterval start time for CUMULATIVE metric descriptor types.
+   */
+  public long getCounterStartTime() {
+      return counterStartTime;
+  }
+};

--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/MetricDescriptorCache.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/MetricDescriptorCache.java
@@ -1,0 +1,776 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spectator.stackdriver;
+
+import com.google.api.services.monitoring.v3.Monitoring;
+import com.google.api.services.monitoring.v3.model.ListMetricDescriptorsResponse;
+import com.google.api.services.monitoring.v3.model.LabelDescriptor;
+import com.google.api.services.monitoring.v3.model.MetricDescriptor;
+
+import com.google.api.client.http.HttpResponseException;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * Manages the custom MetricDescriptors to use with Stackdriver.
+ *
+ * Maps Spectator Metrics and Measurements into Stackdriver MetricDescriptors.
+ */
+public class MetricDescriptorCache {
+  /**
+   * Used to inject minimal labels required by a given custom descriptor.
+   *
+   * This is a workaround to ensure that certain labels exist within a
+   * given metric when it is created on demand where the call sites are
+   * inconsistent and may not contain all the labels ultimately needed.
+   * Since stackdriver descriptors are immutable, we need to get it right
+   * up front, yet we still want to allow hands-free maintainence where
+   * possible and just adapt to the runtime code, creating new metrics
+   * as they are introduced.
+   */
+  public static class CustomDescriptorHint {
+    /**
+     * The name of the hinted metric is the measurement name.
+     */
+    protected String name;
+
+    /**
+     * Set of labels that the metric should be sure to specify when it is
+     * created. Typically these are labels that are not always present so
+     * cannot be inferred in a small measurement sample.
+     */
+    protected List<String> labels;
+
+    /**
+     * Set of labels that the metric should ommit both when defining and
+     * writing.
+     */
+    protected List<String> redacted;
+
+    /**
+     * The name of the Spectator Measurement name that this hint is for.
+     */
+    public String getName() {
+      return name;
+    }
+
+    /**
+     * The minimal labels that the descriptor should have.
+     *
+     * In practice this is intended to convey labels that might not
+     * always be present if the descriptor is being inferred from a use site.
+     */
+    public List<String> getLabels() {
+      return labels;
+    }
+
+    /**
+     * Labels that should be ignored.
+     *
+     * This only ignores the label, not the value.
+     */
+    public List<String> getRedacted() {
+      return redacted;
+    }
+
+    /**
+     * Constructs a hint, aliases labels list.
+     */
+    public CustomDescriptorHint(String name,
+                                List<String> labels) {
+      this(name, labels, null);
+    }
+
+    /**
+     * Constructs a hint, aliases labels list.
+     *
+     * @param name
+     *   The name of the measurment this is for.
+     *
+     * @param labels
+     *   A minimal list of labels that should be included.
+     *   These are typically labels that are not always used
+     *   so may not be present in a small sample if the type
+     *   labels are inferred.
+     *
+     * @param redact
+     *   A list of labels to ommit if they are found.
+     *   This is a workaround for Stackdriver's 10-label constraint.
+     */
+    public CustomDescriptorHint(String name,
+                                List<String> labels,
+                                List<String> redact) {
+      this.name = name;
+      this.labels = labels;
+      this.redacted = redact;
+    }
+
+    /**
+     * Default constructor for spring loader.
+     */
+    protected CustomDescriptorHint() {
+        // empty.
+    }
+  };
+
+
+  /**
+   * Stackdriver Label identifying the application reporting the values.
+   *
+   * This is used when not configured for uniqueMetricsPerApplication
+   */
+  public static final String APPLICATION_LABEL = "MicroserviceSrc";
+
+  /**
+   * Stackdriver Label identifying the replica instance reporting the values.
+   */
+  public static final String INSTANCE_LABEL = "InstanceSrc";
+
+
+  /**
+   * We are going to use this as an internal sentinal to
+   * distinguish between not knowing the descriptor for a type
+   * vs the type being invalid for having a descriptor.
+   * This is used to simplify the interface to an internal helper function.
+   */
+  private static final MetricDescriptor INVALID_METRIC_DESCRIPTOR
+      = new MetricDescriptor();
+
+
+  /**
+   * The client-side stub talking to Stackdriver.
+   */
+  private final Monitoring service;
+
+  /**
+   * The name of the project we give to stackdriver for metric types.
+   */
+  private final String projectResourceName;
+
+  /**
+   * Internal logging.
+   */
+  private final Logger log = LoggerFactory.getLogger("StackdriverMdCache");
+
+  /**
+   * The prefix used when declaring Stackdriver Custom Metric types.
+   * This has to look a particular way so we'll capture that here.
+   *
+   * The postfix will be the Spectator measurement name.
+   */
+  private String baseStackdriverMetricTypeName;
+
+  /**
+   * The prefix used when declaring Stackdriver Custom Metric names.
+   * This has to look a particular way so we'll capture that here.
+   *
+   * The postfix will be the Spectator measurement name.
+   */
+  private String baseStackdriverMetricName;
+
+  /**
+   * HACK: Stackdriver descriptors are immutable descriptors requiring
+   *       labels be known (and declared) up front.
+   *  Some types we are sharing across services that use different labels.
+   *  This is a mechanism allowing external injection of these special cases.
+   *  The hints are only used when the need to create a descriptor arises.
+   *  Descriptors are only created once in the lifetime of a project (unless
+   *  the label is explicitly deleted, erasing all history, at some point).
+   *
+   *  We could externally create the labels, but doing so dynamically feels
+   *  more maintainable.
+   *
+   *  The key in this table is the desired Stackdriver descriptor name.
+   *
+   *  Note that this is not thread safe. Presumably we write to the hints
+   *  only on startup, and from within one thread so this doesnt matter.
+   */
+  private final Map<String, Set<String>> labelHints
+      = new HashMap<String, Set<String>>();
+
+  /**
+   * This is a workaround for Stackdriver limiting custom metrics to
+   * having 10 labels (b/31469504). For certain known metrics that
+   * have more than 10 labels but some can be ommitted, this map
+   * defines which of those labels to redact. It is populated from
+   * the hints as well.
+   */
+  private final Map<String, Set<String>> redactedHints
+      = new HashMap<String, Set<String>>();
+
+  /**
+   * Depending on our monitoredResource, we may need to add additional
+   * labels into our time series data to identify ourselves as the source.
+   * If so, this is it.
+   */
+  protected Map<String, String> extraTimeSeriesLabels
+      = new HashMap<String, String>();
+
+
+  /**
+   * These are the custom MetricDescriptor types we know about so that we
+   * know whether we need to create a new one or not. Types are created on
+   * demand, but remembered across executions, so only created once, forever.
+   * Instead of even remembering them, we could probably just assume it exists
+   * then respond to an error by creating it and trying again.
+   *
+   * The key in the map is the Stackdriver descriptor type.
+   *
+   * protected for testing.
+   */
+  protected final Map<String, MetricDescriptor> knownDescriptors
+      = new HashMap<String, MetricDescriptor>();
+
+  /**
+   * If we run into a problem with a type descriptor, we'll blacklist it
+   * in order to avoid filling our log file with errors and potentially
+   * having side effects preventing good metrics from being logged.
+   */
+  private final Set<String> badDescriptorTypes = new HashSet<String>();
+
+  /**
+   * A set of descriptorTypes that we created but have not yet confirmed.
+   *
+   * This is to work around the race condition in b/31469322 where the
+   * descriptor may not yet be ready to use when we want to actually use it.
+   * This list acts as a guard to prevent us from attempting to recreate the
+   * descriptor while waiting for it to be fetched into knownDescriptors.
+   */
+  private final Set<String> unconfirmedDescriptorTypes = new HashSet<String>();
+
+  /**
+   * Constructor.
+   *
+   * @param configParams
+   *   Only the stackdriverStub, projectName, and customTypeNamespace
+   *   are used.
+   */
+  public MetricDescriptorCache(ConfigParams configParams) {
+    service = configParams.getStackdriverStub();
+    projectResourceName = "projects/" + configParams.getProjectName();
+
+    baseStackdriverMetricTypeName
+        = String.format("custom.googleapis.com/%s/",
+                        configParams.getCustomTypeNamespace());
+    if (configParams.isMetricUniquePerApplication()) {
+        baseStackdriverMetricTypeName
+            += String.format("%s/", configParams.getApplicationName());
+    }
+
+    baseStackdriverMetricName
+        = String.format("%s/metricDescriptors/%s",
+                        projectResourceName, baseStackdriverMetricTypeName);
+  }
+
+  /**
+   * Convert a Spectator ID into a Stackdriver Custom Descriptor Type name.
+   *
+   * @param id
+   *   Spectator measurement id
+   *
+   * @return
+   *   Fully qualified Stackdriver custom Metric Descriptor type.
+   *   This always returns the type, independent of filtering.
+   */
+  public String idToDescriptorType(Id id) {
+    return baseStackdriverMetricTypeName + id.name();
+  }
+
+  /**
+   * Convert a Spectator ID into a Stackdriver Custom Descriptor instance name.
+   *
+   * @param id
+   *   Spectator measurement id
+   *
+   * @return
+   *   Fully qualified Stackdriver custom Metric Descriptor name.
+   *   This always returns the name, independent of filtering.
+   */
+  public String idToDescriptorName(Id id) {
+    return baseStackdriverMetricName + id.name();
+  }
+
+  /**
+   * Returns a reference to extra labels to include with TimeSeries data.
+   */
+  public Map<String, String> getExtraTimeSeriesLabels() {
+    return extraTimeSeriesLabels;
+  }
+
+  /**
+   * Specifies a label binding to be added to every custom metric TimeSeries.
+   *
+   * This also adds the labels to every custom MetricDescriptor created.
+   *
+   * Therefore this method should only be called before any Stackdriver
+   * activity. This is awkward to enfore here because in practice the
+   * labels are needed once we determine the Stackdriver Monitored Resource,
+   * however that can be deferred until after we construct the cache in
+   * the event that Stackdriver was not available when we needed to create
+   * a custom MonitoredResource.
+   */
+  public void addExtraTimeSeriesLabel(String key, String value) {
+    extraTimeSeriesLabels.put(key, value);
+  }
+
+  /**
+   * Inject a hints about one or more types.
+   *
+   * Hints are only used if and when we need to create a type descriptor for
+   * a type. This happens at most once over the lifetime of a system (not just
+   * a process invocation). Adding hints is a preemtive workaround for known
+   * inconsistent uses for given types where an incomplete descriptor may
+   * otherwise be inferred.
+   *
+   * Note that the name of the hint is just the Spectator name, not the
+   * Stackdriver type name. That is, it does not yet contain the
+   * baseStackdriverMetricTypeName. This is for [assumed] convienence
+   * specifying the hints.
+   */
+  public void addCustomDescriptorHints(
+        List<? extends CustomDescriptorHint> hints) {
+    for (CustomDescriptorHint hint : hints) {
+      String name = hint.getName();
+      String typeName = name.startsWith(baseStackdriverMetricTypeName)
+                      ? name : baseStackdriverMetricTypeName + name;
+
+      List<String> added = hint.getLabels();
+      if (added != null && !added.isEmpty()) {
+          labelHints.computeIfAbsent(typeName, k -> new HashSet<String>())
+              .addAll(added);
+      }
+      List<String> redacted = hint.getRedacted();
+      if (redacted != null && !redacted.isEmpty()) {
+          redactedHints.computeIfAbsent(typeName, k -> new HashSet<String>())
+              .addAll(redacted);
+      }
+    }
+  }
+
+  /**
+   * Lookup all the pre-existing custom metrics so that we
+   * know if we need to create new metric descriptors or not.
+   */
+  void initKnownDescriptors()
+      throws HttpResponseException, IOException {
+    ListMetricDescriptorsResponse response =
+      service.projects().metricDescriptors().list(projectResourceName)
+      .execute();
+
+    for (MetricDescriptor descriptor : response.getMetricDescriptors()) {
+      if (descriptor.getType().startsWith(baseStackdriverMetricTypeName)) {
+        knownDescriptors.put(descriptor.getType(), descriptor);
+      }
+    }
+  }
+
+  /**
+   * Get the descriptor for a measurement, if there is one.
+   *
+   * As a side effect, we will ensure that we have a Stackdriver descriptor for
+   * the measurement. If for some reason we cannot have a descriptor then
+   * we will drop that measurement from those collected, thus ensuring that
+   * all the metrics returned can be written into Stackdriver.
+   *
+   * @param registry
+   *   The Spectator Registry is used to determine the meter type if needed.
+   *
+   * @param meter
+   *   The Spectator Meter that the measurement is from.
+   *
+   * @param measurement
+   *   The Spectator Measurement that we want a descriptor for.
+   *
+   * @return
+   *   The available Metric Descriptor or null if none in the cache.
+   *   null does not necessarily mean future calls will fail.
+   */
+  public MetricDescriptor descriptorOrNull(
+        Registry registry, Meter meter, Measurement measurement) {
+    if (lookupDescriptor(registry, meter, measurement) == null) {
+      return null;
+    }
+
+    String descriptorType = idToDescriptorType(measurement.id());
+    MetricDescriptor descriptor = knownDescriptors.get(descriptorType);
+    if (descriptor == null) {
+      log.error("*** No stackdriver descriptor for {}", descriptorType);
+      return null;
+    }
+    return descriptor;
+  }
+
+  /**
+   * Perform a preliminary lookup locally before we hit the server.
+   *
+   * This is factored out to simplify the call site. There isnt anything
+   * special about not wanting to hit the server.
+   *
+   * @param typeName
+   *   The desired custom MetricDescriptor type name.
+   *
+   * @param meter
+   *   The Spectator meter that the type is for.
+   *   This is only used to filter out spring-only metrics
+   *   which are not of interest to Spinnaker and often have
+   *   names that are not friendly to our heuristics.
+   *
+   * @return
+   *   The descriptor if we already have one, null if we dont.
+   *   INVALID_METRIC_DESCRIPTOR indicates the descriptor isnt valid
+   *   so dont pursue this type further.
+   */
+  private MetricDescriptor preliminaryLookup(String typeName) {
+    if (knownDescriptors.isEmpty()) {
+      try {
+        initKnownDescriptors();
+      } catch (HttpResponseException rex) {
+        log.error(
+            "Caught HttpResponseException initializing KnownDescriptors", rex);
+        return INVALID_METRIC_DESCRIPTOR;
+      } catch (IOException ioex) {
+        log.error("Caught IOException initializing knownDescriptors.", ioex);
+        return INVALID_METRIC_DESCRIPTOR;
+      }
+    }
+
+    MetricDescriptor found = knownDescriptors.get(typeName);
+    if (found != null) {
+      return found;
+    } else if (badDescriptorTypes.contains(typeName)) {
+      return INVALID_METRIC_DESCRIPTOR;
+    }
+
+    return null;
+  }
+
+  /**
+   * Lookup a descriptor, creating one if needed.
+   *
+   * @param registry
+   *   The Spectator Registry is used to determine the meter type if needed.
+   *
+   * @param meter
+   *   The Spectator Meter is used for reference if this is the
+   *   first time the Id has even been seen over the lifetime of
+   *   the project this is running in.
+   *
+   * @param measurement
+   *   The Spectator Mesurement to get the descriptor for.
+   *
+   * @return
+   *   The descriptor or null if a descriptor is not yet available.
+   *   A null result could mean that the descriptor is inflight
+   *   with a pending creation request.
+   */
+  MetricDescriptor lookupDescriptor(
+        Registry registry, Meter meter, Measurement measurement) {
+    Id id = measurement.id();
+    String descriptorType = idToDescriptorType(id);
+    MetricDescriptor found = preliminaryLookup(descriptorType);
+    if (found != null) {
+      // This public function returns null to indicate invalid descriptors
+      // because it is easier to consume that way. However internally we
+      // go the other way and return null indicating 'dont known'
+      // because it is more readable.
+      return found == INVALID_METRIC_DESCRIPTOR ? null : found;
+    }
+
+    String descriptorName = idToDescriptorName(id);
+    try {
+      return fetchDescriptorFromService(descriptorName, descriptorType);
+    } catch (HttpResponseException rex) {
+      if (rex.getStatusCode() == 404) {
+        log.debug("It appears that descriptor name='{}' does not yet exist.",
+                 descriptorName);
+      } else {
+        log.error(
+            "Caught HttpResponseException fetching descriptor", rex);
+      }
+    } catch (IOException ioex) {
+      log.error(
+          "Caught HttpResponseException fetching descriptor", ioex);
+    }
+
+    return createDescriptor(registry, meter, measurement);
+  }
+
+  /**
+   * Helper function to fetch an individual descriptor from Stackdriver.
+   *
+   * This is used to lookup whether or not a particular type already exists.
+   * Normally we would already know this from initKnownDescriptors, however
+   * there is a race condition on first usage where the descriptor did not
+   * exist on our startup but another process has since created it.
+   *
+   * Fetching it will correct for that.
+   */
+  MetricDescriptor fetchDescriptorFromService(String descriptorName,
+                                              String descriptorType)
+       throws IOException {
+    MetricDescriptor descriptor
+        = service.projects().metricDescriptors().get(descriptorName).execute();
+    knownDescriptors.put(descriptorType, descriptor);
+    if (unconfirmedDescriptorTypes.contains(descriptorType)) {
+        unconfirmedDescriptorTypes.remove(descriptorType);
+    }
+    return descriptor;
+  }
+
+  /**
+   * Creates a new descriptor.
+   *
+   * @param measurement
+   *   The Spectator Measurement is used to determine the name and labels.
+   *
+   * @param registry
+   *   The Spectator Registry is used to determine the meter type if needed.
+   *
+   * @param meter
+   *   The Spectator Meter may be considered for the kind of descriptor and
+   *   other metadata.
+   *
+   * @return
+   *   This may return null if the descriptor is not yet available for use.
+   */
+  private MetricDescriptor createDescriptor(
+        Registry registry, Meter meter, Measurement measurement) {
+    Id id = measurement.id();
+    try {
+      createDescriptorInServer(id, registry, meter);
+    } catch (HttpResponseException rex) {
+      log.error(
+          "Caught HttpResponseException creating descriptor", rex);
+    } catch (IOException ioex) {
+      log.error(
+          "Caught IOException creating descriptor", ioex);
+    }
+
+    String descriptorName = idToDescriptorName(id);
+    String descriptorType = idToDescriptorType(id);
+    try {
+      return fetchDescriptorFromService(descriptorName, descriptorType);
+    } catch (IOException ioex) {
+      if (!unconfirmedDescriptorTypes.contains(descriptorType)) {
+        log.warn("Descriptor for name='{}', type='{}' is not yet ready:",
+                 descriptorName, descriptorType, ioex);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Creates a new [globally persistent] descriptor within Stackdriver.
+   *
+   * Since descriptors are global and persistent this only happens the
+   * first time we wish to use it over the lifetime of the project that
+   * is managing the Stackdriver data.  It is also possible a extra times
+   * in other processes encountering a race condition on the first-time use.
+   *
+   * There is an additional race condition within Stackdriver itself between
+   * creating a new descriptor and using one for the first time.
+   * b/31469322 notes that when this race condition occurs, creating time
+   * series data may auto-create the metric descriptor for us, which will
+   * overwrite the descriptor we attempted to create, losing any subtle
+   * details we may have added (especially additional labels from the hints).
+   *
+   * Therefore, this method is void and requires discovery of the descriptor
+   * through the normal fetching even though we are the ones that created it.
+   */
+  void createDescriptorInServer(Id id, Registry registry, Meter meter)
+       throws IOException {
+    String descriptorName = idToDescriptorName(id);
+    String descriptorType = idToDescriptorType(id);
+    if (unconfirmedDescriptorTypes.contains(descriptorType)) {
+        // creation request is already in-flight.
+        return;
+    }
+
+    MetricDescriptor descriptor = new MetricDescriptor();
+    descriptor.setName(descriptorName);
+    descriptor.setDisplayName(id.name());
+    descriptor.setType(descriptorType);
+    descriptor.setValueType("DOUBLE");
+    if (meterIsTimer(registry, meter)) {
+      if (id.name().endsWith("_totalTime")) {
+        descriptor.setUnit("ns");
+      }
+      descriptor.setMetricKind("CUMULATIVE");
+    } else {
+      descriptor.setMetricKind(meterToKind(registry, meter));
+    }
+
+    List<LabelDescriptor> labels = new ArrayList<LabelDescriptor>();
+    for (String key : extraTimeSeriesLabels.keySet()) {
+        LabelDescriptor labelDescriptor = new LabelDescriptor();
+        labelDescriptor.setKey(key);
+        labelDescriptor.setValueType("STRING");
+        labels.add(labelDescriptor);
+    }
+
+    for (Tag tag : id.tags()) {
+       LabelDescriptor labelDescriptor = new LabelDescriptor();
+       labelDescriptor.setKey(tag.key());
+       labelDescriptor.setValueType("STRING");
+       labels.add(labelDescriptor);
+    }
+
+    maybeAddLabelHints(descriptorType, labels);
+    if (labels.size() > 10) {
+        log.error("{} has too many labels for stackdriver to handle: {}",
+                  id.name(), labels);
+        log.warn("*** MARKING {} AS A BAD METRIC ***to ignore from now on.",
+                 id.name());
+        badDescriptorTypes.add(descriptorType);
+        return;
+     }
+
+    descriptor.setLabels(labels);
+    MetricDescriptor response = service.projects().metricDescriptors()
+      .create(projectResourceName, descriptor)
+      .execute();
+    unconfirmedDescriptorTypes.add(descriptorType);
+
+    log.info("Created new MetricDescriptor {}", response.toString());
+  }
+
+  /**
+   * Convert a Spectator Meter type into a Stackdriver Metric kind.
+   */
+  public String meterToKind(Registry registry, Meter meter) {
+    if (meter instanceof Counter) {
+      return "CUMULATIVE";
+    }
+
+    if (registry.counters().anyMatch(m -> m.id().equals(meter.id()))) {
+      return "CUMULATIVE";
+    }
+    return "GAUGE";
+  }
+
+  /**
+   * Given a list of labels, maybe embellish it with additional labels
+   * depending on whether there are hints for the given descriptorType.
+   */
+  private void maybeAddLabelHints(String descriptorType,
+                                  List<LabelDescriptor> labels) {
+    Set<String> redact = redactedHints.get(descriptorType);
+    if (redact != null) {
+      for (String name : redact) {
+        for (int i = 0; i < labels.size(); ++i) {
+            if (labels.get(i).getKey().equals(name)) {
+                log.debug("Redacting label {}", name);
+                labels.remove(i);
+                break;
+            }
+        }
+      }
+    }
+    Set<String> ensure = labelHints.get(descriptorType);
+    if (ensure == null) return;
+
+    log.info("Verifying labels in {}", descriptorType);
+    for (String key : ensure) {
+      boolean found = false;
+      for (LabelDescriptor label : labels) {
+        if (label.getKey().equals(key)) {
+          log.info("Found hinted label '{}'", key);
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        LabelDescriptor labelDescriptor = new LabelDescriptor();
+        log.info("Injecting hinted label '{}'.", key);
+        labelDescriptor.setKey(key);
+        labelDescriptor.setValueType("STRING");
+        labels.add(labelDescriptor);
+      }
+    }
+  }
+
+  /**
+   * Get the labels to use for a given metric instance.
+   *
+   * @param descriptor
+   *   The Stackdriver MetricDescriptor for the labels.
+   *
+   * @param tags
+   *   The Spectator Measurement tags for the data.
+   *
+   * @return
+   *   A map of label key, value bindings may include fewer or more
+   *   tags than those provided depending on the extra tags and configured
+   *   custom descriptor hints.
+   */
+  public Map<String, String> tagsToTimeSeriesLabels(
+          MetricDescriptor descriptor, Iterable<Tag> tags) {
+    HashMap<String, String> labels
+        = new HashMap<String, String>(extraTimeSeriesLabels);
+
+    for (Tag tag :tags) {
+      addSanitizedLabel(descriptor, tag, labels);
+    }
+    return labels;
+  }
+
+  /**
+   * Helper function providing a hook to fix or omit bad labels.
+   */
+  private void addSanitizedLabel(
+        MetricDescriptor descriptor, Tag tag, Map<String, String> labels) {
+    Set<String> redact = redactedHints.get(descriptor.getType());
+    if (redact != null && redact.contains(tag.key())) {
+      log.debug("Redacting use of label {}", tag.key());
+      return;
+    }
+    labels.put(tag.key(), tag.value());
+  }
+
+  /**
+   * Remember the analysis of meters to determine if they are timers or not.
+   * This is because meterIsTimer is called continuously, not just on creation
+   * of a new descriptor.
+   */
+  private Map<Id, Boolean> idToTimer = new HashMap<Id, Boolean>();
+
+  /**
+   * Determine if meter is a Timer or not.
+   */
+  public boolean meterIsTimer(Registry registry, Meter meter) {
+    return idToTimer.computeIfAbsent(meter.id(), k -> {
+        return registry.timers().anyMatch(m -> m.id().equals(meter.id()));
+    });
+  }
+}

--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/MonitoredResourceBuilder.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/MonitoredResourceBuilder.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spectator.stackdriver;
+
+import com.google.api.services.monitoring.v3.model.MonitoredResource;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Builds a MonitoredResource instance to attach to TimeSeries data.
+ *
+ * This will build different resource types depending on where the runtime
+ * is deployed.
+ */
+class MonitoredResourceBuilder {
+  private String stackdriverProjectId = "";
+
+  /**
+   * Constructor.
+   */
+  MonitoredResourceBuilder() {
+    // empty.
+  }
+
+  /**
+   * The GCP project that the data should be stored under.
+   *
+   * This is not always used. It depends on the what the managed resource
+   * will be. Setting it makes it available later if it is needed.
+   */
+  MonitoredResourceBuilder setStackdriverProject(String name) {
+    stackdriverProjectId = name;
+    return this;
+  }
+
+  /**
+   * Helper function to read the result from a HTTP GET.
+   */
+  private String getConnectionValue(HttpURLConnection con) throws IOException {
+    int responseCode = con.getResponseCode();
+    if (responseCode < 200 || responseCode > 299) {
+      throw new IOException("Unexpected responseCode " + responseCode);
+    }
+    BufferedReader input
+        = new BufferedReader(new InputStreamReader(con.getInputStream(),
+                                                   "US-ASCII"));
+    StringBuffer value = new StringBuffer();
+    for (String line = input.readLine();
+         line != null;
+         line = input.readLine()) {
+      value.append(line);
+    }
+    input.close();
+    return value.toString();
+  }
+
+  /**
+   * Helper function to read a value from the GCP Metadata Service.
+   *
+   * This will throw an IOException if not on GCP.
+   */
+  String getGoogleMetadataValue(String key) throws IOException {
+    URL url = new URL(String.format(
+                "http://169.254.169.254/computeMetadata/v1/%s", key));
+    HttpURLConnection con = (HttpURLConnection) url.openConnection();
+    con.setConnectTimeout(250);
+    con.setInstanceFollowRedirects(true);
+    con.setRequestMethod("GET");
+    con.setRequestProperty("Metadata-Flavor", "Google");
+    return getConnectionValue(con);
+  }
+
+  /**
+   * Collect the GCP labels to use for a gce_instance resource.
+   *
+   * This will return false if not on a GCE instance.
+   */
+  boolean maybeCollectGceInstanceLabels(Map<String, String> labels) {
+    try {
+      String id = getGoogleMetadataValue("instance/id");
+      String zone = getGoogleMetadataValue("instance/zone");
+      zone = zone.substring(zone.lastIndexOf('/') + 1);
+      String project = getGoogleMetadataValue("project/project-id");
+      labels.put("instance_id", id);
+      labels.put("zone", zone);
+      labels.put("project_id", project);
+      return true;
+    } catch (IOException ioex) {
+      return false;
+    }
+  }
+
+  /**
+   * Collect the GKE labels to use for a gke_container resource.
+   *
+   * This will return false if not on a GKE instance.
+   */
+  boolean maybeCollectGkeInstanceLabels(Map<String, String> labels) {
+      // Not sure how to get the info I need
+      /*
+       * project_id: The identifier of the GCP project associated with this.
+       * cluster_name: An immutable name for the cluster the container is in.
+       * namespace_id: Immutable ID of the cluster namespace the container is in.
+       * instance_id: Immutable ID of the GCE instance the container is in.
+       * pod_id: Immutable ID of the pod the container is in.
+       * container_name: Immutable name of the container.
+       * zone: The GCE zone in which the instance is running.
+       */
+      return false;
+  }
+
+  /**
+   * Return the attribute value associated with the key.
+   *
+   * Uses regexp matching, returning "" if the key isnt found.
+   */
+  String matchAttribute(String text, String key) {
+    String regex = String.format("\"%s\" : \"(.+?)\"", key);
+    Pattern p = Pattern.compile(regex);
+    Matcher m = p.matcher(text);
+    return m.find() ? m.group(1) : "";
+  }
+
+  /**
+   * Return the AWS identify document from the AWS Metadata Service.
+   *
+   * Throws an IOException if not running on an AWS instance.
+   */
+  String getAwsIdentityDocument() throws IOException {
+    URL url = new URL(
+      "http://169.254.169.254/latest/dynamic/instance-identity/document");
+    HttpURLConnection con = (HttpURLConnection) url.openConnection();
+    con.setConnectTimeout(250);
+    con.setRequestMethod("GET");
+    return getConnectionValue(con);
+  }
+
+  /**
+   * Collect the EC2 labels to use for a aws_ec2_instance resource.
+   *
+   * Returns false if not an AWS ec2 instance.
+   */
+  boolean maybeCollectEc2InstanceLabels(Map<String, String> labels) {
+    String doc;
+    try {
+      doc = getAwsIdentityDocument();
+    } catch (IOException ioex) {
+      return false;
+    }
+    String id = matchAttribute(doc, "instanceId");
+    String account = matchAttribute(doc, "accountId");
+    String region = matchAttribute(doc, "region");
+
+    if (id.isEmpty() || account.isEmpty() || region.isEmpty()) {
+        return false;
+    } else if (stackdriverProjectId.isEmpty()) {
+      throw new IllegalStateException("stackdriverProjectId was not set.");
+    }
+
+    labels.put("instance_id", id);
+    labels.put("region", region);
+    labels.put("aws_account", account);
+    labels.put("project_id", stackdriverProjectId);
+    return true;
+  }
+
+  /**
+   * Create a MonitoredResource that describes this deployment.
+   *
+   * This will throw an IOException if the resource could not be created.
+   * In practice this exception is not currently thrown.
+   *
+   * However the expectation is that custom types will be added in the future
+   * and there may be transient IO errors interacting with Stackdriver to
+   * create the type.
+   */
+  public MonitoredResource build() throws IOException {
+    HashMap<String, String> labels = new HashMap<String, String>();
+    MonitoredResource resource = new MonitoredResource();
+
+    if (maybeCollectGceInstanceLabels(labels)) {
+      resource.setType("gce_instance");
+    } else if (maybeCollectGkeInstanceLabels(labels)) {
+      resource.setType("gke_container");
+    } else if (maybeCollectEc2InstanceLabels(labels)) {
+      resource.setType("aws_ec2_instance");
+    } else if (stackdriverProjectId.isEmpty()) {
+      throw new IllegalStateException("stackdriverProjectId was not set.");
+    } else {
+      labels.put("project_id", stackdriverProjectId);
+      resource.setType("global");
+    }
+
+    resource.setLabels(labels);
+    return resource;
+  }
+}

--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/StackdriverWriter.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/StackdriverWriter.java
@@ -1,0 +1,500 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spectator.stackdriver;
+
+
+import com.google.api.services.monitoring.v3.Monitoring;
+import com.google.api.services.monitoring.v3.model.CreateTimeSeriesRequest;
+import com.google.api.services.monitoring.v3.model.Metric;
+import com.google.api.services.monitoring.v3.model.MetricDescriptor;
+import com.google.api.services.monitoring.v3.model.MonitoredResource;
+import com.google.api.services.monitoring.v3.model.Point;
+import com.google.api.services.monitoring.v3.model.TimeInterval;
+import com.google.api.services.monitoring.v3.model.TimeSeries;
+import com.google.api.services.monitoring.v3.model.TypedValue;
+
+import com.google.api.client.http.HttpResponseException;
+import com.google.common.collect.Lists;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.function.Predicate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/* These are builtin metric types that we might be able to use
+ * except probably not because there isnt a label to say this is our use
+ * as opposed to the assumption that "there is only one" of them.
+
+    "agent.googleapis.com/jvm/memory/usage"
+    "agent.googleapis.com/jvm/cpu/time"
+    "agent.googleapis.com/jvm/gc/time"
+    "agent.googleapis.com/jvm/thread/num_live"
+    "agent.googleapis.com/jvm/thread/peak"
+    "agent.googleapis.com/jvm/uptime"
+
+    "agent.googleapis.com/tomcat/manager/sessions"
+    "agent.googleapis.com/tomcat/request_processor/error_count"
+    "agent.googleapis.com/tomcat/request_processor/processing_time"
+    "agent.googleapis.com/tomcat/request_processor/request_count"
+    "agent.googleapis.com/tomcat/request_processor/traffic_count"
+    "agent.googleapis.com/tomcat/threads/current"
+    "agent.googleapis.com/tomcat/threads/busy"
+*/
+
+
+/**
+ * Adapter from Spectator Meters to Stackdriver Time Series Metrics.
+ *
+ * This class is not thread safe, but is assumed to be called from a
+ * single thread.
+ *
+ * Places that are not thread safe include the management of
+ * the custom descriptor cache and the use of java.text.DataFormat,
+ * which is stated to not be thread-safe.
+ */
+public class StackdriverWriter {
+  /**
+   * This is the Spectator Id used for the timer measuring writeRegistry calls.
+   */
+  public static final String WRITE_TIMER_NAME = "stackdriver.writeRegistry";
+
+  /**
+   * Stackdriver limits TimeSeries create requests to 200 values.
+   */
+  private static final int MAX_TS_PER_REQUEST = 200;
+
+  /**
+   * Spectator doesnt have a public concrete Id class so we'll use the
+   * default registry as a factory.
+   *
+   * We need to generate IDs for synthetic measurements (e.g. Timers).
+   */
+  private static final Registry ID_FACTORY = new DefaultRegistry(Clock.SYSTEM);
+
+  /**
+   * Internal logging.
+   */
+  private final Logger log = LoggerFactory.getLogger("StackdriverWriter");
+
+  /**
+   * TimeSeries data in Stackdriver API takes a date string, not a timestamp.
+   *
+   * We are using a literal 'Z' here rather than the time format Z because
+   * Stackdriver doesnt recognize the format that Java produces. So instead
+   * we'll report in UTC and have it convert our time into GMT for reporting.
+   */
+  private final SimpleDateFormat rfc3339;
+
+  /**
+   * This is required before writing time series data.
+   */
+  protected MonitoredResource monitoredResource;
+
+  /**
+   * The client-side stub talking to Stackdriver.
+   */
+  private final Monitoring service;
+
+  /**
+   * The name of the project we give to stackdriver for metric types and data.
+   */
+  private final String projectResourceName;
+
+  /**
+   * The name of our application is used to identify the source of the metrics.
+   */
+  private final String applicationName;
+
+  /**
+   * A unique id that distinguishes our data from other replicas with the same
+   * applicationName (in the same project).
+   */
+  private String instanceId;
+
+  /**
+   * Manages the custom Metric Descriptors with Stackdriver.
+   */
+  private MetricDescriptorCache cache;
+
+  /**
+   * The Stackdriver TimeInterval Start time for CUMULATIVE (counter) types.
+   */
+  private String counterStartTimeRfc3339;
+
+  /**
+   * Kork needs this to add the hints.
+   */
+  public MetricDescriptorCache getDescriptorCache() {
+    return cache;
+  }
+
+  /**
+   * Filters the measurements we want to push to Stackdriver.
+   */
+  private Predicate<Measurement> measurementFilter;
+
+  /**
+   * Whether to add an APPLICATION_LABEL tag to time series data.
+   * (otherwise the application is presumed to have been captured elsewhere).
+   */
+  private boolean addApplicationLabelToTimeSeriesData;
+
+  /**
+   * If Stackdriver were to return an error complaining about a TimeSeries
+   * data element we are trying to write, it references that by its index
+   * into the array we sent. That is pretty much useless to debug since we
+   * have no idea what or how the data is organized.
+   *
+   * This method is intended to interpret the Stackdriver error message
+   * in the context of the request we made and return the referenced element
+   * so that it can be logged in more explicit detail to understand what
+   * happened (most likely what label was missing from what descriptor type).
+   *
+   * @param msg
+   *   The exception message.
+   *
+   * @param nextN
+   *   The time series data from the request
+   *
+   * @return
+   *   The time series element referred to by the message, or null.
+   */
+  public static TimeSeries
+  findProblematicTimeSeriesElement(String msg, List<TimeSeries> nextN) {
+    String regex = "timeSeries\\[(\\d+?)\\]\\.metric\\.labels\\[(\\d+?)\\]";
+    Matcher matcher = Pattern.compile(regex).matcher(msg);
+    if (matcher.find()) {
+      int tsIndex = Integer.parseInt(matcher.group(1));
+      return nextN.get(tsIndex);
+    }
+    return null;
+  }
+
+  /**
+   * Constructs a writer instance.
+   *
+   * @param configParams
+   *   The configuration parameters.
+   */
+  @SuppressWarnings("PMD.BooleanInversion")
+  public StackdriverWriter(ConfigParams configParams) {
+    cache = configParams.getDescriptorCache();
+    service = configParams.getStackdriverStub();
+    projectResourceName = "projects/" + configParams.getProjectName();
+    applicationName = configParams.getApplicationName();
+    instanceId = configParams.getInstanceId();
+    measurementFilter = configParams.getMeasurementFilter();
+    addApplicationLabelToTimeSeriesData
+        = !configParams.isMetricUniquePerApplication();
+
+    rfc3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'000000Z'");
+    rfc3339.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+    Date startDate = new Date(configParams.getCounterStartTime());
+    counterStartTimeRfc3339 = rfc3339.format(startDate);
+
+    log.info("Constructing StackdriverWriter {}={}",
+             MetricDescriptorCache.INSTANCE_LABEL, instanceId);
+  }
+
+  /**
+   * Helper function for logging time series errors in more detail.
+   *
+   * @see #findProblematicTimeSeriesElement
+   */
+  private void handleTimeSeriesResponseException(
+       HttpResponseException rex, String msg, List<TimeSeries> nextN) {
+    TimeSeries ts = findProblematicTimeSeriesElement(rex.getMessage(), nextN);
+    if (ts != null) {
+      log.error("{}:  time series element: {}",
+                rex.getMessage(), ts.toString());
+    } else {
+      log.error("Caught HttpResponseException {}", msg, rex);
+    }
+  }
+
+  /**
+   * Convert a Spectator metric Meter into a Stackdriver TimeSeries entry.
+   *
+   * @param descriptor
+   *   The Stackdriver MetricDescriptor for the measurement.
+   *
+   * @param measurement
+   *   The Spectator Measurement to encode.
+   *
+   * @return
+   *   The Stackdriver TimeSeries equivalent for the measurement.
+   */
+  public TimeSeries measurementToTimeSeries(
+        MetricDescriptor descriptor, Measurement measurement) {
+    Map<String, String> labels
+        = cache.tagsToTimeSeriesLabels(descriptor, measurement.id().tags());
+
+    long millis = measurement.timestamp();
+    double value = measurement.value();
+
+    TimeInterval timeInterval = new TimeInterval();
+    Date date = new Date(millis);
+    timeInterval.setEndTime(rfc3339.format(date));
+
+    if (descriptor.getMetricKind().equals("CUMULATIVE")) {
+      timeInterval.setStartTime(counterStartTimeRfc3339);
+    }
+
+    TypedValue typedValue = new TypedValue();
+    typedValue.setDoubleValue(value);
+
+    Point point = new Point();
+    point.setValue(typedValue);
+    point.setInterval(timeInterval);
+
+    Metric metric = new Metric();
+    metric.setType(descriptor.getType());
+    metric.setLabels(labels);
+
+    TimeSeries ts = new TimeSeries();
+    ts.setResource(monitoredResource);
+    ts.setMetric(metric);
+    ts.setMetricKind(descriptor.getMetricKind());
+    ts.setValueType("DOUBLE");
+    ts.setPoints(Lists.<Point>newArrayList(point));
+
+    return ts;
+  }
+
+  /**
+   * Generate an Id for the derived timer measurements.
+   *
+   * @param id
+   *   The original Measurement id
+   *
+   * @return
+   *   A copy of the original but without the 'statistic' tag, and the
+   *   name will be decorated with "__count" or "__totalTime" depending on the
+   *   value of the original statistic tag.
+   */
+  Id deriveBaseTimerId(Id id) {
+    String suffix = null;
+    ArrayList<Tag> tags = new ArrayList<Tag>();
+    for (Tag tag : id.tags()) {
+      if (tag.key().equals("statistic")) {
+        if (tag.value().equals("totalTime")) {
+          suffix = "totalTime";
+        } else if (tag.value().equals("count")) {
+          suffix = "count";
+        } else {
+          throw new IllegalStateException(
+                       "Unexpected statistic=" + tag.value());
+        }
+        continue;
+      }
+      tags.add(tag);
+    }
+    if (suffix == null) {
+        // Didnt have statistic, so return original.
+        return id;
+    }
+
+    return ID_FACTORY.createId(id.name() + "__" + suffix).withTags(tags);
+  }
+
+  /**
+   * Remember the derived Ids that we use for timer transformations.
+   */
+  private Map<Id, Id> timerBaseIds = new HashMap<Id, Id>();
+
+  /**
+   * Transform timer measurements from a composite with count/totalTime tags
+   * to a pair of specialized measurements without the "statistic" tag.
+   *
+   * This is so we can have different units for the measurement
+   * MetricDescriptor to note that the totalTime is in nanoseconds.
+   *
+   * @param measurements
+   *   The list of measurements to transform come from a Timer meter.
+   *
+   * @return
+   *   A list of measurements, probably the same as the original size, where
+   *   each of the elements corresponds to an original element but does not
+   *   have the "statistic" label. Where the original was "count", the new
+   *   id name will have a "__count" suffix and "__totalTime" for the
+   *   "totalTime" statistic. The base name will be the same as the original.
+   */
+  private Iterable<Measurement> transformTimerMeasurements(
+      Iterable<Measurement> measurements) {
+    ArrayList<Measurement> result = new ArrayList<Measurement>();
+    for (Measurement measurement : measurements) {
+      if (!measurementFilter.test(measurement)) {
+        continue;
+      }
+      Id id = timerBaseIds.computeIfAbsent(
+                  measurement.id(), k -> deriveBaseTimerId(k));
+      result.add(
+         new Measurement(id, measurement.timestamp(), measurement.value()));
+    }
+    return result;
+  }
+
+  /**
+   * Add a TimeSeries for each appropriate meter measurement.
+   */
+  void addMeterToTimeSeries(
+        Registry registry, Meter meter, List<TimeSeries> tsList) {
+    Iterable<Measurement> measurements = meter.measure();
+    boolean applyFilter = true;
+
+    if (cache.meterIsTimer(registry, meter)) {
+       measurements = transformTimerMeasurements(measurements);
+       applyFilter = false;
+    }
+    for (Measurement measurement : measurements) {
+      if (applyFilter && !measurementFilter.test(measurement)) {
+        continue;
+      }
+
+      MetricDescriptor descriptor
+          = cache.descriptorOrNull(registry, meter, measurement);
+      if (descriptor == null) {
+        continue;
+      }
+      tsList.add(measurementToTimeSeries(descriptor, measurement));
+    }
+  }
+
+  /**
+   * Produce a TimeSeries for each appropriate measurement in the registry.
+   */
+  public List<TimeSeries> registryToTimeSeries(Registry registry) {
+    log.info("Collecting metrics...");
+    ArrayList<TimeSeries> tsList = new ArrayList<TimeSeries>();
+    Iterator<Meter> iterator = registry.iterator();
+
+    while (iterator.hasNext()) {
+      addMeterToTimeSeries(registry, iterator.next(), tsList);
+    }
+    return tsList;
+  }
+
+  /**
+   * Update Stackdriver with the current Spectator metric registry values.
+   */
+  public void writeRegistry(Registry registry) {
+    // The timer will appear in our response, but be off by one invocation
+    // because it isnt updated until we finish.
+    Id writeId = registry.createId(WRITE_TIMER_NAME);
+    registry.timer(writeId).record(new Runnable() {
+        public void run() {
+            writeRegistryHelper(registry);
+        }
+    });
+  }
+
+  /**
+   * Get the monitoredResource for the TimeSeries data.
+   *
+   * This will return null if the resource cannot be determined.
+   */
+  MonitoredResource determineMonitoredResource() {
+    if (monitoredResource == null) {
+      String project
+          = projectResourceName.substring(projectResourceName.indexOf('/') + 1);
+      try {
+          monitoredResource = new MonitoredResourceBuilder()
+              .setStackdriverProject(project)
+              .build();
+          if (addApplicationLabelToTimeSeriesData) {
+            cache.addExtraTimeSeriesLabel(
+                MetricDescriptorCache.APPLICATION_LABEL, applicationName);
+          }
+          if (monitoredResource.getType().equals("global")) {
+            cache.addExtraTimeSeriesLabel(
+              MetricDescriptorCache.INSTANCE_LABEL, instanceId);
+          }
+          log.info("Using monitoredResource={} with extraTimeSeriesLabels={}",
+                   monitoredResource, cache.getExtraTimeSeriesLabels());
+      } catch (IOException ioex) {
+        log.error("Unable to determine monitoredResource at this time.", ioex);
+      }
+    }
+    return monitoredResource;
+  }
+
+  /**
+   * Implementatio of writeRegistry wrapped for timing.
+   */
+  private void writeRegistryHelper(Registry registry) {
+    MonitoredResource resource = determineMonitoredResource();
+    if (resource == null) {
+      log.warn("Cannot determine the managed resource - not flushing metrics.");
+      return;
+    }
+    List<TimeSeries> tsList = registryToTimeSeries(registry);
+    if (tsList.isEmpty()) {
+       log.info("No metric data points.");
+       return;
+    }
+
+    CreateTimeSeriesRequest tsRequest = new CreateTimeSeriesRequest();
+    int offset = 0;
+    int failed = 0;
+    List<TimeSeries> nextN;
+
+    log.info("Writing metrics...");
+    while (offset < tsList.size()) {
+      if (offset + MAX_TS_PER_REQUEST < tsList.size()) {
+        nextN = tsList.subList(offset, offset + MAX_TS_PER_REQUEST);
+        offset += MAX_TS_PER_REQUEST;
+      } else {
+        nextN = tsList.subList(offset, tsList.size());
+        offset = tsList.size();
+      }
+      tsRequest.setTimeSeries(nextN);
+      try {
+        log.debug("Writing {} points.", nextN.size());
+        service.projects().timeSeries().create(projectResourceName, tsRequest)
+               .execute();
+      } catch (HttpResponseException rex) {
+        handleTimeSeriesResponseException(rex, "creating time series", nextN);
+        failed += nextN.size();
+      } catch (IOException ioex) {
+        log.error("Caught HttpResponseException creating time series " + ioex);
+        failed += nextN.size();
+      }
+    }
+    log.info("Wrote {} values", tsList.size() - failed);
+  }
+}

--- a/kork-stackdriver/src/main/java/com/netflix/spinnaker/config/StackdriverConfig.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spinnaker/config/StackdriverConfig.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config;
+
+import com.netflix.spectator.controllers.filter.PrototypeMeasurementFilter;
+import com.netflix.spectator.stackdriver.ConfigParams;
+import com.netflix.spectator.stackdriver.MetricDescriptorCache;
+import com.netflix.spectator.stackdriver.StackdriverWriter;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.controllers.MetricsController;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import rx.Observable;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
+
+
+@Configuration
+@EnableConfigurationProperties
+@Import({MetricsController.class})
+@ConditionalOnExpression("${spectator.stackdriver.enabled:false}")
+class StackdriverConfig {
+
+  @Value("${spectator.applicationName:${spring.application.name}}")
+  private String applicationName;
+
+  @Value("${spectator.stackdriver.credentialsPath:}")
+  private String credentialsPath;
+
+  @Value("${spectator.stackdriver.projectName:}")
+  private String projectName;
+
+  @Value("${spectator.stackdriver.uniqueMetricsPerApplication:true}")
+  private boolean uniqueMetricsPerApplication;
+
+  // If provided, takes precedence over the *Regex filters above.
+  @Value("${spectator.webEndpoint.prototypeFilter.path:}")
+  private String prototypeFilterPath;
+
+  @Value("${spectator.stackdriver.period:60}")
+  private int pushPeriodSecs;
+
+  private StackdriverWriter stackdriver;
+
+  @Configuration
+  @ConfigurationProperties(prefix="stackdriver")
+  static public class StackdriverConfigurationHints {
+    /**
+     * This class lets spring load from our YAML file into a Hint instance.
+     */
+    static public class MutableHint extends MetricDescriptorCache.CustomDescriptorHint {
+        public void setLabels(List<String> labels) {
+            this.labels = labels;
+        }
+        public void setRedacted(List<String> labels) {
+            this.redacted = labels;
+        }
+        public void setName(String name) {
+            this.name = name;
+        }
+    };
+
+    public List<MutableHint> hints;
+    public void setHints(List<MutableHint> hints) { this.hints = hints; }
+    public List<MutableHint> getHints() { return hints; }
+  };
+
+  @Autowired
+  StackdriverConfigurationHints stackdriverHints;
+
+  @Autowired
+  Registry registry;
+
+  /**
+   * Schedule a thread to flush our registry into stackdriver periodically.
+   *
+   * This configures our StackdriverWriter as well.
+   */
+  @Bean
+  public StackdriverWriter defaultStackdriverWriter() throws IOException {
+    Logger log = LoggerFactory.getLogger("StackdriverConfig");
+    log.info("Creating StackdriverWriter.");
+    Predicate<Measurement> filterNotSpring = new Predicate<Measurement>() {
+      public boolean test(Measurement measurement) {
+        // Dont store measurements that dont have tags.
+        // These are from spring; those of interest were replicated in spectator.
+        if (measurement.id().tags().iterator().hasNext()) {
+          return true;
+        }
+
+        return false;
+      }
+    };
+    Predicate<Measurement> measurementFilter;
+
+    if (!prototypeFilterPath.isEmpty()) {
+      log.info("Configuring stackdriver filter from {}", prototypeFilterPath);
+      measurementFilter = PrototypeMeasurementFilter.loadFromPath(
+           prototypeFilterPath).and(filterNotSpring);
+    } else {
+      measurementFilter = filterNotSpring;
+    }
+
+    ConfigParams params = new ConfigParams.Builder()
+        .setCounterStartTime(new Date().getTime())
+        .setUniqueMetricsPerApplication(uniqueMetricsPerApplication)
+        .setCustomTypeNamespace("spinnaker")
+        .setProjectName(projectName)
+        .setApplicationName(applicationName)
+        .setCredentialsPath(credentialsPath)
+        .setMeasurementFilter(measurementFilter)
+        .build();
+
+    stackdriver = new StackdriverWriter(params);
+
+    if (stackdriverHints != null && stackdriverHints.hints != null) {
+        log.info("Adding {} custom descriptor hints",
+                 stackdriverHints.hints.size());
+        stackdriver.getDescriptorCache()
+            .addCustomDescriptorHints(stackdriverHints.hints);
+    } else {
+        log.info("No custom descriptor hints");
+    }
+    Scheduler scheduler = Schedulers.from(Executors.newFixedThreadPool(1));
+
+    // Note that the globalRegistry gives different results than
+    // the autowired registry in MetricsController but we get startup
+    // circular references trying to autowire it here.
+    // (the difference is the timers() and counters() streams are empty
+    //  but the registry seems to have the same metrics within).
+    Observable.timer(pushPeriodSecs, TimeUnit.SECONDS)
+        .repeat()
+        .subscribe(interval -> { stackdriver.writeRegistry(registry); });
+
+    return stackdriver;
+  }
+
+  /**
+   * We can optionally add a registry if one doesnt exist.
+   *
+   * While we need a registry, it could be provided elsewhere.
+  @Bean
+  @ConditionalOnExpression("${spectator.stackdriver.defaultRegistry:false}")
+  Registry defaultMetricRegistry() {
+    Logger log = LoggerFactory.getLogger("StackdriverConfig");
+    log.info("Creating default registry.");
+    return new DefaultRegistry(com.netflix.spectator.api.Clock.SYSTEM);
+  }
+   * This causes a circular dependency for some reason, even with disabled.
+   *
+   * Reviewer, please confirm that I dont need this.
+   */
+};

--- a/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MetricDescriptorCacheTest.java
+++ b/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MetricDescriptorCacheTest.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spectator.stackdriver;
+
+import com.google.api.services.monitoring.v3.model.*;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Measurement;
+
+import com.google.api.services.monitoring.v3.Monitoring;
+
+import java.io.IOException;
+
+import java.util.function.Predicate;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MetricDescriptorCacheTest {
+  static class TestableMetricDescriptorCache extends MetricDescriptorCache {
+    public TestableMetricDescriptorCache(ConfigParams params) {
+      super(params);
+      addExtraTimeSeriesLabel(APPLICATION_LABEL, params.getApplicationName());
+      addExtraTimeSeriesLabel(INSTANCE_LABEL, params.getInstanceId());
+    }
+
+    public void injectDescriptor(Id id, MetricDescriptor value) {
+        injectDescriptor(idToDescriptorType(id), value);
+    }
+
+    public void injectDescriptor(String key, MetricDescriptor value) {
+        knownDescriptors.put(key, value);
+    }
+
+    public MetricDescriptor peekDescriptor(Id id) {
+      return knownDescriptors.get(idToDescriptorType(id));
+    }
+  };
+
+  static class ReturnExecuteDescriptorArg implements Answer {
+    private Monitoring.Projects.MetricDescriptors.Create mockCreateMethod;
+
+    public ReturnExecuteDescriptorArg(
+            Monitoring.Projects.MetricDescriptors.Create mockCreateMethod) {
+      this.mockCreateMethod = mockCreateMethod;
+    }
+
+    public Object answer(InvocationOnMock invocation) {
+      try {
+        MetricDescriptor descArg
+                = (MetricDescriptor) invocation.getArguments()[1];
+        when(mockCreateMethod.execute()).thenReturn(descArg);
+        return mockCreateMethod;
+      } catch (IOException ioex) {
+        return null;  // Not Reached
+      }
+    }
+  };
+
+  private long millis = 12345L;
+  private Clock clock = new Clock() {
+      public long wallTime() {
+          return millis;
+      }
+
+      public long monotonicTime() {
+          return millis;
+      }
+  };
+  DefaultRegistry registry = new DefaultRegistry(clock);
+
+  TestableMetricDescriptorCache cache;
+  String projectName = "test-project";
+  String applicationName = "test-application";
+
+  Id idA = registry.createId("idA");
+  Id idB = registry.createId("idB");
+  Id idAXY = idA.withTag("tagA", "X").withTag("tagB", "Y");
+  Id idAYX = idA.withTag("tagA", "Y").withTag("tagB", "X");
+  Id idBXY = idB.withTag("tagA", "X").withTag("tagB", "Y");
+
+  Predicate<Measurement> allowAll = new Predicate<Measurement>() {
+    public boolean test(Measurement measurement) {
+      return true;
+    }
+  };
+
+  @Mock Monitoring monitoringApi;
+  @Mock Monitoring.Projects projectsApi;
+  @Mock Monitoring.Projects.MetricDescriptors descriptorsApi;
+
+  ConfigParams.Builder config;
+
+  MetricDescriptor descriptorA;
+  MetricDescriptor descriptorB;
+
+  Measurement meterMeasurement(Meter meter) {
+    return meter.measure().iterator().next();
+  }
+
+  private MetricDescriptor makeDescriptor(
+        Id id, List<String> tagNames, String kind) {
+    MetricDescriptor descriptor = new MetricDescriptor();
+    descriptor.setName(cache.idToDescriptorName(id));
+    descriptor.setDisplayName(id.name());
+    descriptor.setType(cache.idToDescriptorType(id));
+    descriptor.setValueType("DOUBLE");
+    descriptor.setMetricKind(kind);
+
+    List<LabelDescriptor> labels = new ArrayList<LabelDescriptor>();
+    LabelDescriptor labelDescriptor = new LabelDescriptor();
+    labelDescriptor.setKey(MetricDescriptorCache.APPLICATION_LABEL);
+    labelDescriptor.setValueType("STRING");
+    labelDescriptor.setKey(MetricDescriptorCache.INSTANCE_LABEL);
+    labelDescriptor.setValueType("STRING");
+    labels.add(labelDescriptor);
+    for (String key : tagNames) {
+      labelDescriptor = new LabelDescriptor();
+      labelDescriptor.setKey(key);
+      labelDescriptor.setValueType("STRING");
+      labels.add(labelDescriptor);
+    }
+    descriptor.setLabels(labels);
+    return descriptor;
+  }
+
+  Set<String> getLabelKeys(Iterable<LabelDescriptor> labels) {
+    Set<String> result = new HashSet<String>();
+    for (LabelDescriptor label : labels) {
+      result.add(label.getKey());
+    }
+    return result;
+  }
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    when(monitoringApi.projects()).thenReturn(projectsApi);
+    when(projectsApi.metricDescriptors()).thenReturn(descriptorsApi);
+
+    config = new ConfigParams.Builder()
+        .setStackdriverStub(monitoringApi)
+        .setCustomTypeNamespace("TESTNAMESPACE")
+        .setProjectName(projectName)
+        .setApplicationName(applicationName)
+        .setMeasurementFilter(allowAll);
+
+    cache = new TestableMetricDescriptorCache(config.build());
+    List<String> testTags = Arrays.asList("tagA", "tagB");
+    descriptorA = makeDescriptor(idA, testTags, "GAUGE");
+    descriptorB = makeDescriptor(idB, testTags, "CUMULATIVE");
+  }
+
+  @Test
+  public void descriptorTypeAreCompliant() {
+    Assert.assertEquals(
+        "custom.googleapis.com/TESTNAMESPACE/" + applicationName + "/idA",
+        cache.idToDescriptorType(idA));
+  }
+
+  @Test
+  public void descriptorNamesAreCompliant() {
+    // https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors
+    Assert.assertEquals(
+        "projects/test-project/metricDescriptors/" + cache.idToDescriptorType(idA),
+        cache.idToDescriptorName(idA));
+  }
+
+  @Test
+  public void testCreateDescriptorHelperCreateProperDescriptors()
+          throws IOException {
+    Meter counterA = registry.counter(idAXY);
+
+    Monitoring.Projects.MetricDescriptors.Create mockCreateMethod
+        = Mockito.mock(Monitoring.Projects.MetricDescriptors.Create.class);
+
+    when(descriptorsApi.create(
+            eq("projects/test-project"), any(MetricDescriptor.class)))
+            .thenAnswer(new ReturnExecuteDescriptorArg(mockCreateMethod));
+    cache.createDescriptorInServer(idAXY, registry, counterA);
+
+    verify(mockCreateMethod, times(1)).execute();
+
+    ArgumentCaptor<MetricDescriptor> captor
+        = ArgumentCaptor.forClass(MetricDescriptor.class);
+    verify(descriptorsApi, times(1)).create(eq("projects/test-project"),
+                                               captor.capture());
+    MetricDescriptor descriptor = captor.getValue();
+
+    Assert.assertEquals(cache.idToDescriptorName(idA), descriptor.getName());
+    Assert.assertEquals(cache.idToDescriptorType(idA), descriptor.getType());
+    Assert.assertEquals("DOUBLE", descriptor.getValueType());
+    Assert.assertEquals("CUMULATIVE", descriptor.getMetricKind());
+    Assert.assertEquals(
+        getLabelKeys(descriptor.getLabels()),
+        new HashSet(Arrays.asList(
+               MetricDescriptorCache.APPLICATION_LABEL,
+               MetricDescriptorCache.INSTANCE_LABEL,
+               "tagA", "tagB")));
+
+    for (LabelDescriptor label : descriptor.getLabels()) {
+        Assert.assertEquals("STRING", label.getValueType());
+    }
+  }
+
+  @Test
+  public void testCreateDescriptorHelperRespectsHints() throws IOException {
+    cache.addCustomDescriptorHints(
+        Arrays.asList(
+            new MetricDescriptorCache.CustomDescriptorHint(
+                idAXY.name(), Arrays.asList("tagA", "tagU"))));
+
+    Meter counterA = registry.counter(idAXY);
+    Meter counterB = registry.counter(idBXY);
+
+    Monitoring.Projects.MetricDescriptors.Create mockCreateMethod
+          = Mockito.mock(Monitoring.Projects.MetricDescriptors.Create.class);
+
+    when(descriptorsApi.create(
+            eq("projects/test-project"), any(MetricDescriptor.class)))
+            .thenAnswer(new ReturnExecuteDescriptorArg(mockCreateMethod));
+    cache.createDescriptorInServer(idAXY, registry, counterA);
+
+    ArgumentCaptor<MetricDescriptor> captor
+        = ArgumentCaptor.forClass(MetricDescriptor.class);
+    verify(descriptorsApi, times(1)).create(eq("projects/test-project"),
+                                               captor.capture());
+    verify(mockCreateMethod, times(1)).execute();
+
+    MetricDescriptor descriptor = captor.getValue();
+    Assert.assertEquals(
+        getLabelKeys(descriptor.getLabels()),
+        new HashSet<String>(
+                Arrays.asList(
+                        MetricDescriptorCache.APPLICATION_LABEL,
+                        MetricDescriptorCache.INSTANCE_LABEL,
+                        "tagA", "tagB", "tagU")));
+    reset(descriptorsApi);
+    reset(mockCreateMethod);
+
+    when(descriptorsApi.create(
+            eq("projects/test-project"), any(MetricDescriptor.class)))
+            .thenAnswer(new ReturnExecuteDescriptorArg(mockCreateMethod));
+    cache.createDescriptorInServer(idBXY, registry, counterB);
+    verify(mockCreateMethod, times(1)).execute();
+
+    captor = ArgumentCaptor.forClass(MetricDescriptor.class);
+    verify(descriptorsApi, times(1)).create(eq("projects/test-project"),
+                                               captor.capture());
+    descriptor = captor.getValue();
+
+    Assert.assertEquals(
+        getLabelKeys(descriptor.getLabels()),
+        new HashSet<String>(
+            Arrays.asList(MetricDescriptorCache.APPLICATION_LABEL,
+                          MetricDescriptorCache.INSTANCE_LABEL,
+                          "tagA", "tagB")));
+  }
+
+  @Test
+  public void testCreateDescriptorHelperRedacts() throws IOException {
+    cache.addCustomDescriptorHints(
+        Arrays.asList(
+            new MetricDescriptorCache.CustomDescriptorHint(
+                    idAXY.name(), null, Arrays.asList("tagA", "tagU"))));
+
+    Meter counterA = registry.counter(idAXY);
+    Meter counterB = registry.counter(idBXY);
+
+    Monitoring.Projects.MetricDescriptors.Create mockCreateMethod
+          = Mockito.mock(Monitoring.Projects.MetricDescriptors.Create.class);
+
+    when(descriptorsApi.create(
+            eq("projects/test-project"), any(MetricDescriptor.class)))
+            .thenAnswer(new ReturnExecuteDescriptorArg(mockCreateMethod));
+    cache.createDescriptorInServer(idAXY, registry, counterA);
+
+    ArgumentCaptor<MetricDescriptor> captor
+        = ArgumentCaptor.forClass(MetricDescriptor.class);
+    verify(descriptorsApi, times(1)).create(eq("projects/test-project"),
+                                               captor.capture());
+    verify(mockCreateMethod, times(1)).execute();
+
+    MetricDescriptor descriptor = captor.getValue();
+    Assert.assertEquals(
+        getLabelKeys(descriptor.getLabels()),
+        new HashSet<String>(
+                Arrays.asList(
+                        MetricDescriptorCache.APPLICATION_LABEL,
+                        MetricDescriptorCache.INSTANCE_LABEL,
+                        "tagB")));
+  }
+
+
+  @Test
+  public void testEnsureDescriptorDescriptorIsAlreadyLoaded() {
+    MetricDescriptor descriptor = new MetricDescriptor();
+    Meter counterA = registry.counter(idAXY);
+    cache.injectDescriptor(idA, descriptor);
+    Assert.assertEquals(
+        descriptor,
+        cache.descriptorOrNull(
+            registry, counterA, meterMeasurement(counterA)));
+  }
+
+  @Test
+  public void testEnsureDescriptorWhenDescriptorIsNotAlreadyLoaded()
+          throws IOException {
+    Meter counterA = registry.counter(idAXY);
+
+    Monitoring.Projects.MetricDescriptors.Create mockCreateMethod
+          = Mockito.mock(Monitoring.Projects.MetricDescriptors.Create.class);
+
+    cache.injectDescriptor(idB, new MetricDescriptor());
+    when(descriptorsApi.create(
+            eq("projects/test-project"), any(MetricDescriptor.class)))
+            .thenAnswer(new ReturnExecuteDescriptorArg(mockCreateMethod));
+
+    cache.createDescriptorInServer(idA, registry, counterA);
+    verify(mockCreateMethod, times(1)).execute();
+
+    ArgumentCaptor<MetricDescriptor> captor
+          = ArgumentCaptor.forClass(MetricDescriptor.class);
+    verify(descriptorsApi, times(1)).create(eq("projects/test-project"),
+                                               captor.capture());
+    MetricDescriptor descriptor = captor.getValue();
+    Assert.assertTrue(descriptor != null);
+
+    // Since we should have a pending request, future creates wont do anything
+    reset(descriptorsApi);
+    reset(mockCreateMethod);
+    cache.createDescriptorInServer(idA, registry, counterA);
+    verify(descriptorsApi, times(0)).create(
+        any(String.class), any(MetricDescriptor.class));
+  }
+
+  @Test
+  public void testEnsureDescriptorDescriptorIsAlreadyRegistered()
+        throws IOException {
+    Monitoring.Projects.MetricDescriptors.List mockListMethod
+        = Mockito.mock(Monitoring.Projects.MetricDescriptors.List.class);
+    Meter counterA = registry.counter(idAXY);
+    ListMetricDescriptorsResponse response
+        = new ListMetricDescriptorsResponse();
+    response.setMetricDescriptors(Arrays.asList(descriptorA));
+
+    when(descriptorsApi.list("projects/test-project"))
+         .thenReturn(mockListMethod);
+    when(mockListMethod.execute()).thenReturn(response);
+    MetricDescriptor found = cache.descriptorOrNull(
+        registry, counterA, meterMeasurement(counterA));
+    verify(mockListMethod, times(1)).execute();
+    Assert.assertEquals(found, descriptorA);
+
+    // Returns same response from cache.
+    reset(mockListMethod);
+    found = cache.descriptorOrNull(
+        registry, counterA, meterMeasurement(counterA));
+    Assert.assertTrue(found == descriptorA);
+    verify(mockListMethod, times(0)).execute();
+  }
+
+  @Test
+  public void testEnsureDescriptorFailsIfnitFails()
+      throws IOException {
+    Monitoring.Projects.MetricDescriptors.List mockListMethod
+        = Mockito.mock(Monitoring.Projects.MetricDescriptors.List.class);
+    Meter counterA = registry.counter(idAXY);
+
+    when(descriptorsApi.list("projects/test-project"))
+        .thenThrow(new IOException());
+    Assert.assertTrue(
+        null == cache.descriptorOrNull(
+                    registry, counterA, meterMeasurement(counterA)));
+    verify(descriptorsApi, times(1)).list(any(String.class));
+
+    reset(descriptorsApi);
+
+    ListMetricDescriptorsResponse response
+        = new ListMetricDescriptorsResponse();
+    response.setMetricDescriptors(Arrays.asList(descriptorA));
+
+    when(descriptorsApi.list("projects/test-project"))
+        .thenReturn(mockListMethod);
+    when(mockListMethod.execute())
+        .thenReturn(response);
+    Assert.assertTrue(
+         cache.descriptorOrNull(registry, counterA, meterMeasurement(counterA))
+         == descriptorA);
+  }
+}

--- a/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MonitoredResourceBuilderTest.java
+++ b/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MonitoredResourceBuilderTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spectator.stackdriver;
+
+import com.google.api.services.monitoring.v3.model.MonitoredResource;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(JUnit4.class)
+public class MonitoredResourceBuilderTest {
+
+  MonitoredResourceBuilder builder;
+
+  @Before
+  public void setup() {
+    builder = spy(new MonitoredResourceBuilder());
+  }
+
+  @Test
+  public void testGceInstance() throws IOException {
+    builder.setStackdriverProject("UNUSED");
+
+    String instance = "MY INSTANCE";
+    String zone = "us-central1-f";
+    String zone_path = "path/to/" + zone;
+    String project = "MY PROJECT";
+
+    doReturn(instance).when(builder)
+        .getGoogleMetadataValue("instance/id");
+    doReturn(zone_path).when(builder)
+        .getGoogleMetadataValue("instance/zone");
+    doReturn(project).when(builder)
+        .getGoogleMetadataValue("project/project-id");
+
+    Map<String, String> labels = new HashMap<String, String>();
+    labels.put("instance_id", instance);
+    labels.put("zone", zone);
+    labels.put("project_id", project);
+
+    MonitoredResource resource = builder.build();
+    Assert.assertEquals("gce_instance", resource.getType());
+    Assert.assertEquals(labels, resource.getLabels());
+  }
+
+  @Test
+  public void testMatchAttribute() {
+      String text =  "{\n"
+            + " \"version\" : \"2016-08-01\",\n"
+            + " \"instanceId\" : \"the-instance\",\n"
+            + " \"region\" : \"us-east-1\"\n"
+            + "}";
+
+      Assert.assertEquals("the-instance",
+                          builder.matchAttribute(text, "instanceId"));
+      Assert.assertEquals("us-east-1",
+                          builder.matchAttribute(text, "region"));
+      Assert.assertEquals("", builder.matchAttribute(text, "notFound"));
+  }
+
+  @Test
+  public void testEc2Instance() throws IOException {
+      String region = "us-east-1";
+      String instanceId = "i-abcdef";
+      String accountId = "12345";
+      String project = "StackdriverProject";
+      
+      builder.setStackdriverProject(project);
+
+      String awsIdentityDoc
+          = "{\n"
+          + "\"privateIp\" : \"123.45.67.89\",\n"
+          + "\"devpayProductCodes\" : null,\n"
+          + "\"availabilityZone\" : \"us-east-1d\",\n"
+          + "\"accountId\" : \"" + accountId + "\",\n"
+          + "\"version\" : \"2010-08-31\",\n"
+          + "\"instanceId\" : \"" + instanceId + "\",\n"
+          + "\"billingProducts\" : null,\n"
+          + "\"region\" : \"" + region + "\"\n"
+          + "}";
+      
+    doThrow(new IOException()).when(builder)
+        .getGoogleMetadataValue(any(String.class));
+
+    doReturn(awsIdentityDoc).when(builder)
+        .getAwsIdentityDocument();
+
+    Map<String, String> labels = new HashMap<String, String>();
+    labels.put("instance_id", instanceId);
+    labels.put("aws_account", accountId);
+    labels.put("region", region);
+    labels.put("project_id", project);
+
+    MonitoredResource resource = builder.build();
+    Assert.assertEquals("aws_ec2_instance", resource.getType());
+    Assert.assertEquals(labels, resource.getLabels());
+  }
+
+  @Test
+  public void testGlobal() throws IOException {
+      String project = "StackdriverProject";
+      builder.setStackdriverProject(project);
+
+    doThrow(new IOException()).when(builder)
+        .getGoogleMetadataValue(any(String.class));
+    doThrow(new IOException()).when(builder)
+        .getAwsIdentityDocument();
+
+    Map<String, String> labels = new HashMap<String, String>();
+    labels.put("project_id", project);
+
+    MonitoredResource resource = builder.build();
+    Assert.assertEquals("global", resource.getType());
+    Assert.assertEquals(labels, resource.getLabels());
+  }
+}

--- a/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/StackdriverWriterTest.java
+++ b/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/StackdriverWriterTest.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spectator.stackdriver;
+
+import com.google.api.services.monitoring.v3.model.*;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Tag;
+
+import com.google.api.services.monitoring.v3.Monitoring;
+
+import java.io.IOException;
+
+import java.util.function.Predicate;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class StackdriverWriterTest {
+  static class TestableStackdriverWriter extends StackdriverWriter {
+      public TestableStackdriverWriter(ConfigParams params) {
+        super(params);
+        monitoredResource = new MonitoredResource();
+
+        Map<String, String> labels = new HashMap<String, String>();
+        labels.put("project_id", params.getProjectName());
+        monitoredResource.setType("global");
+        monitoredResource.setLabels(labels);
+      }
+
+      public MonitoredResource peekMonitoredResource() {
+          return monitoredResource;
+      }
+  };
+
+  private long millis = 12345L;
+  private Clock clock = new Clock() {
+      public long wallTime() {
+          return millis;
+      }
+
+      public long monotonicTime() {
+          return millis;
+      }
+  };
+
+  static final String INSTANCE_ID = "TestUID";
+
+  DefaultRegistry registry = new DefaultRegistry(clock);
+
+  String projectName = "test-project";
+  String applicationName = "test-application";
+
+  Id idInternalTimerCount
+      = registry.createId(StackdriverWriter.WRITE_TIMER_NAME + "__count");
+  Id idInternalTimerTotal
+      = registry.createId(StackdriverWriter.WRITE_TIMER_NAME + "__totalTime");
+
+  Id idA = registry.createId("idA");
+  Id idB = registry.createId("idB");
+  Id idAXY = idA.withTag("tagA", "X").withTag("tagB", "Y");
+  Id idAYX = idA.withTag("tagA", "Y").withTag("tagB", "X");
+  Id idBXY = idB.withTag("tagA", "X").withTag("tagB", "Y");
+
+  Predicate<Measurement> allowAll = new Predicate<Measurement>() {
+      public boolean test(Measurement measurement) {
+          return true;
+      }
+  };
+
+  @Mock Monitoring monitoringApi;
+  @Mock Monitoring.Projects projectsApi;
+  @Mock Monitoring.Projects.MetricDescriptors descriptorsApi;
+  @Mock Monitoring.Projects.TimeSeries timeseriesApi;
+
+  ConfigParams.Builder writerConfig;
+  TestableStackdriverWriter writer;
+  MetricDescriptorCacheTest.TestableMetricDescriptorCache
+      descriptorRegistrySpy;
+
+  MetricDescriptor descriptorA;
+  MetricDescriptor descriptorB;
+  MetricDescriptor timerCountDescriptor;  // for timer within StackdriverWriter
+  MetricDescriptor timerTimeDescriptor;  // for timer within StackdriverWriter
+
+  private MetricDescriptor makeDescriptor(Id id, List<String> tagNames) {
+      MetricDescriptor descriptor = new MetricDescriptor();
+      descriptor.setName(descriptorRegistrySpy.idToDescriptorName(id));
+      descriptor.setType(descriptorRegistrySpy.idToDescriptorType(id));
+      descriptor.setValueType("DOUBLE");
+      descriptor.setMetricKind("GAUGE");
+
+      List<LabelDescriptor> labels = new ArrayList<LabelDescriptor>();
+      LabelDescriptor labelDescriptor = new LabelDescriptor();
+      labelDescriptor.setKey(MetricDescriptorCache.APPLICATION_LABEL);
+      labelDescriptor.setValueType("STRING");
+      labelDescriptor.setKey(MetricDescriptorCache.INSTANCE_LABEL);
+      labelDescriptor.setValueType("STRING");
+      labels.add(labelDescriptor);
+      for (String key : tagNames) {
+          labelDescriptor = new LabelDescriptor();
+          labelDescriptor.setKey(key);
+          labelDescriptor.setValueType("STRING");
+          labels.add(labelDescriptor);
+      }
+      descriptor.setLabels(labels);
+      return descriptor;
+  }
+
+  Set<String> getLabelKeys(Iterable<LabelDescriptor> labels) {
+      Set<String> result = new HashSet<String>();
+      for (LabelDescriptor label : labels) {
+          result.add(label.getKey());
+      }
+      return result;
+  }
+
+  @Before
+  public void setup() {
+      MockitoAnnotations.initMocks(this);
+      when(monitoringApi.projects()).thenReturn(projectsApi);
+      when(projectsApi.metricDescriptors()).thenReturn(descriptorsApi);
+      when(projectsApi.timeSeries()).thenReturn(timeseriesApi);
+
+      writerConfig = new ConfigParams.Builder()
+              .setStackdriverStub(monitoringApi)
+              .setCustomTypeNamespace("TESTNAMESPACE")
+              .setProjectName(projectName)
+              .setApplicationName(applicationName)
+              .setInstanceId(INSTANCE_ID)
+              .setMeasurementFilter(allowAll);
+
+      descriptorRegistrySpy = spy(
+          new MetricDescriptorCacheTest.TestableMetricDescriptorCache(
+                  writerConfig.build()));
+      writerConfig.setDescriptorCache(descriptorRegistrySpy);
+
+      writer = new TestableStackdriverWriter(writerConfig.build());
+      List<String> testTags = Arrays.asList("tagA", "tagB");
+      descriptorA = makeDescriptor(idA, testTags);
+      descriptorB = makeDescriptor(idB, testTags);
+      timerCountDescriptor
+          = makeDescriptor(idInternalTimerCount, new ArrayList<String>());
+      timerTimeDescriptor
+          = makeDescriptor(idInternalTimerTotal, new ArrayList<String>());
+  }
+
+  @Test
+  public void testConfigParamsDefaultInstanceId() {
+    ConfigParams config = new ConfigParams.Builder()
+            .setStackdriverStub(monitoringApi)
+            .setCustomTypeNamespace("TESTNAMESPACE")
+            .setProjectName(projectName)
+            .setApplicationName(applicationName)
+            .setMeasurementFilter(allowAll)
+            .build();
+    Assert.assertTrue(!config.getInstanceId().isEmpty());
+  }
+
+  @Test
+  public void testFindBadTimeSeriesInError() {
+      TimeSeries tsA = new TimeSeries();
+      TimeSeries tsB = new TimeSeries();
+      TimeSeries tsC = new TimeSeries();
+      TimeSeries tsD = new TimeSeries();
+      tsA.setValueType("A");  // these are bogus values to distinguish them
+      tsB.setValueType("B");
+      tsC.setValueType("C");
+      tsD.setValueType("D");
+
+      List<TimeSeries> tsList = Arrays.asList(tsA, tsB, tsC, tsD);
+      String prefix = "Bogus text\n  thing 1\n  more babble ";
+
+      Assert.assertEquals(
+          tsList.get(1),
+          StackdriverWriter.findProblematicTimeSeriesElement(
+                  prefix + " timeSeries[1].metric.labels[2] one", tsList));
+      Assert.assertEquals(
+          tsList.get(2),
+          StackdriverWriter.findProblematicTimeSeriesElement(
+                  prefix + " timeSeries[2].metric.labels[1] one", tsList));
+      Assert.assertEquals(
+          null,
+          StackdriverWriter.findProblematicTimeSeriesElement(prefix, tsList));
+  }
+
+  TimeSeries makeTimeSeries(MetricDescriptor descriptor,
+                            Id id, double value, String time) {
+    TypedValue tv = new TypedValue();
+    tv.setDoubleValue(value);
+    TimeInterval timeInterval = new TimeInterval();
+    timeInterval.setEndTime(time);
+
+    Point point = new Point();
+    point.setValue(tv);
+    point.setInterval(timeInterval);
+
+    HashMap<String, String> labels = new HashMap<String, String>();
+    labels.put(MetricDescriptorCache.APPLICATION_LABEL, applicationName);
+    labels.put(MetricDescriptorCache.INSTANCE_LABEL, INSTANCE_ID);
+    for (Tag tag : id.tags()) {
+      labels.put(tag.key(), tag.value());
+    }
+
+    Metric metric = new Metric();
+    metric.setType(descriptor.getType());
+    metric.setLabels(labels);
+
+    TimeSeries ts = new TimeSeries();
+    ts.setResource(writer.peekMonitoredResource());
+    ts.setMetric(metric);
+    ts.setPoints(Arrays.asList(point));
+    ts.setMetricKind("GAUGE");
+    ts.setValueType("DOUBLE");
+
+    return ts;
+  }
+
+  @Test
+  public void testMeasurementsToTimeSeries() throws IOException {
+      Measurement measureAXY
+          = new Measurement(idAXY, clock.monotonicTime(), 1);
+      Measurement measureBXY
+          = new Measurement(idBXY, clock.monotonicTime(), 2);
+
+    DefaultRegistry testRegistry = new DefaultRegistry(clock);
+    testRegistry.counter(idAXY).increment();
+    testRegistry.counter(idBXY).increment(2);
+
+    // Note this writer is still using the mock Monitoring client stub.
+    TestableStackdriverWriter spy
+        = spy(new TestableStackdriverWriter(writerConfig.build()));
+
+    doNothing().when(descriptorRegistrySpy)
+        .initKnownDescriptors();
+    doThrow(new IOException()).when(descriptorRegistrySpy)
+        .fetchDescriptorFromService(any(), any());
+    doAnswer(new Answer<Void>() {
+             public Void answer(InvocationOnMock invocation) {
+                descriptorRegistrySpy
+                    .injectDescriptor(descriptorA.getType(), descriptorA);
+                return null;
+             }}).when(descriptorRegistrySpy)
+                .createDescriptorInServer(eq(idAXY), eq(testRegistry), any());
+    doAnswer(new Answer<Void>() {
+             public Void answer(InvocationOnMock invocation) {
+                descriptorRegistrySpy
+                    .injectDescriptor(descriptorB.getType(), descriptorB);
+                return null;
+             }}).when(descriptorRegistrySpy)
+                .createDescriptorInServer(eq(idBXY), eq(testRegistry), any());
+
+    Meter counterA = testRegistry.counter(idAXY);
+    Meter counterB = testRegistry.counter(idBXY);
+
+    descriptorRegistrySpy.descriptorOrNull(
+        testRegistry, counterA, counterA.measure().iterator().next());
+    descriptorRegistrySpy.descriptorOrNull(
+        testRegistry, counterB, counterB.measure().iterator().next());
+
+    Assert.assertTrue(descriptorA
+                      == descriptorRegistrySpy.peekDescriptor(idAXY));
+    Assert.assertTrue(descriptorB
+                      == descriptorRegistrySpy.peekDescriptor(idBXY));
+
+    doReturn(new TimeSeries()).when(spy).measurementToTimeSeries(
+        eq(descriptorA), eq(measureAXY));
+    doReturn(new TimeSeries()).when(spy).measurementToTimeSeries(
+        eq(descriptorB), eq(measureBXY));
+
+    // Just testing the call flow produces descriptors since
+    // we return empty TimeSeries values.
+    spy.registryToTimeSeries(testRegistry);
+
+  }
+
+  @Test
+  public void testAddMeasurementsToTimeSeries() {
+    long millisA = TimeUnit.MILLISECONDS.convert(1472394975L, TimeUnit.SECONDS);
+    long millisB = millisA + 987;
+    String timeA = "2016-08-28T14:36:15.000000000Z";
+    String timeB = "2016-08-28T14:36:15.987000000Z";
+    Measurement measureAXY = new Measurement(idAXY, millisA, 1);
+    Measurement measureBXY = new Measurement(idBXY, millisB, 20.1);
+
+    Assert.assertEquals(
+        makeTimeSeries(descriptorA, idAXY, 1, timeA),
+        writer.measurementToTimeSeries(descriptorA, measureAXY));
+    Assert.assertEquals(
+        makeTimeSeries(descriptorB, idBXY, 20.1, timeB),
+        writer.measurementToTimeSeries(descriptorB, measureBXY));
+  }
+
+  @Test
+  public void writeRegistryWithSmallRegistry() throws IOException {
+    TestableStackdriverWriter spy
+        = spy(new TestableStackdriverWriter(writerConfig.build()));
+    Monitoring.Projects.TimeSeries.Create mockCreateMethod
+        = Mockito.mock(Monitoring.Projects.TimeSeries.Create.class);
+
+    DefaultRegistry registry = new DefaultRegistry(clock);
+    Counter counterA = registry.counter(idAXY);
+    Counter counterB = registry.counter(idBXY);
+    counterA.increment(4);
+    counterB.increment(10);
+
+    doNothing().when(descriptorRegistrySpy).initKnownDescriptors();
+    doNothing().when(descriptorRegistrySpy)
+        .createDescriptorInServer(eq(idAXY), eq(registry), any());
+    doNothing().when(descriptorRegistrySpy)
+        .createDescriptorInServer(eq(idBXY), eq(registry), any());
+    doNothing().when(descriptorRegistrySpy)
+        .createDescriptorInServer(
+               eq(idInternalTimerCount), eq(registry), any());
+    doNothing().when(descriptorRegistrySpy)
+        .createDescriptorInServer(
+               eq(idInternalTimerTotal), eq(registry), any());
+
+    // First fetch fails (forcing the create) second fetch succeeds.
+    doThrow(new IOException())
+        .doAnswer(new Answer<MetricDescriptor>() {
+            public MetricDescriptor answer(InvocationOnMock invocation) {
+                descriptorRegistrySpy
+                    .injectDescriptor(descriptorA.getType(), descriptorA);
+                return descriptorA;
+            }})
+        .when(descriptorRegistrySpy)
+        .fetchDescriptorFromService(descriptorA.getName(), descriptorA.getType());
+    doThrow(new IOException())
+        .doAnswer(new Answer<MetricDescriptor>() {
+            public MetricDescriptor answer(InvocationOnMock invocation) {
+                descriptorRegistrySpy
+                    .injectDescriptor(descriptorB.getType(), descriptorB);
+                return descriptorA;
+            }})
+        .when(descriptorRegistrySpy)
+        .fetchDescriptorFromService(descriptorB.getName(), descriptorB.getType());
+    doThrow(new IOException())
+        .doAnswer(new Answer<MetricDescriptor>() {
+            public MetricDescriptor answer(InvocationOnMock invocation) {
+                descriptorRegistrySpy
+                    .injectDescriptor(timerCountDescriptor.getType(),
+                                      timerCountDescriptor);
+                return timerCountDescriptor;
+            }})
+        .when(descriptorRegistrySpy)
+        .fetchDescriptorFromService(
+            timerCountDescriptor.getName(), timerCountDescriptor.getType());
+
+    doThrow(new IOException())
+        .doAnswer(new Answer<MetricDescriptor>() {
+            public MetricDescriptor answer(InvocationOnMock invocation) {
+                descriptorRegistrySpy
+                    .injectDescriptor(timerTimeDescriptor.getType(),
+                                      timerTimeDescriptor);
+                return timerTimeDescriptor;
+            }})
+        .when(descriptorRegistrySpy)
+        .fetchDescriptorFromService(
+            timerTimeDescriptor.getName(), timerTimeDescriptor.getType());
+
+    when(timeseriesApi.create(eq("projects/test-project"),
+                              any(CreateTimeSeriesRequest.class)))
+        .thenReturn(mockCreateMethod);
+    when(mockCreateMethod.execute())
+        .thenReturn(null);
+
+    spy.writeRegistry(registry);
+    verify(mockCreateMethod, times(1)).execute();
+
+    ArgumentCaptor<CreateTimeSeriesRequest> captor
+          = ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
+    verify(timeseriesApi, times(1)).create(eq("projects/test-project"),
+                                           captor.capture());
+      // A, B, timer count and totalTime.
+    Assert.assertEquals(4, captor.getValue().getTimeSeries().size());
+  }
+
+  @Test
+  public void writeRegistryWithLargeRegistry() throws IOException {
+    TestableStackdriverWriter spy
+        = spy(new TestableStackdriverWriter(writerConfig.build()));
+    Monitoring.Projects.TimeSeries.Create mockCreateMethod
+        = Mockito.mock(Monitoring.Projects.TimeSeries.Create.class);
+
+    DefaultRegistry registry = new DefaultRegistry(clock);
+
+    // The contents of this timeseries doesnt matter.
+    // It is technically invalid to have null entries in the list,
+    // but since we're mocking out the access the values does not matter.
+    // What is important is the size of the list, so we can verify chunking.
+    List<TimeSeries> tsList = new ArrayList<TimeSeries>();
+    for (int i = 0; i < 200; ++i) {
+        tsList.add(null);
+    }
+    tsList.add(new TimeSeries());  // make last one different to test chunking
+
+    doNothing().when(descriptorRegistrySpy).initKnownDescriptors();
+    doReturn(tsList).when(spy).registryToTimeSeries(registry);
+
+    // We are bypassing the registry here and never actually created any
+    // meters so there is nothing in the registry. However the writeRegistry
+    // call itself adds some additional metrics. Here we'll throw exceptions
+    // trying to get descriptors for them so they will not be included in the
+    // results. The small registry test already validated their use.
+    doThrow(new IOException()).when(descriptorRegistrySpy)
+        .fetchDescriptorFromService(any(), any());
+    doThrow(new IOException()).when(descriptorRegistrySpy)
+        .createDescriptorInServer(any(), any(), any());
+
+    // The Mockito ArgumentCaptor to verify the calls wont work here
+    // because each call is referencing the same instance but with
+    // different TimeSeries list. Since the values arent copied, all
+    // the calls point to the same instance with the final mutated value.
+    class MatchN extends ArgumentMatcher<CreateTimeSeriesRequest> {
+      public int found = 0;
+      private int n;
+      public MatchN(int n) { super(); this.n = n; }
+      @Override public String toString() { return "Match n=" + n; }
+      @Override public boolean matches(Object obj) {
+          boolean eq = ((CreateTimeSeriesRequest) obj)
+              .getTimeSeries().size() == n;
+          found += eq ? 1 : 0;
+          return eq;
+      }
+    };
+
+    MatchN match200 = new MatchN(200);
+    MatchN match1 = new MatchN(1);
+    when(timeseriesApi.create(eq("projects/test-project"), argThat(match200)))
+        .thenReturn(mockCreateMethod);
+    when(timeseriesApi.create(eq("projects/test-project"), argThat(match1)))
+        .thenReturn(mockCreateMethod);
+    when(mockCreateMethod.execute())
+        .thenReturn(null);
+
+    spy.writeRegistry(registry);
+
+    verify(mockCreateMethod, times(2)).execute();
+    Assert.assertEquals(1, match200.found);
+    Assert.assertEquals(1, match1.found);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-include 'kork-core', 'kork-cassandra', 'kork-jedis-test', 'kork-swagger', 'kork-security', 'kork-web', 'kork-hystrix'
+include 'kork-core', 'kork-cassandra', 'kork-jedis-test', 'kork-swagger', 'kork-security', 'kork-web', 'kork-hystrix, kork-stackdriver'
 
 rootProject.name='kork'
 


### PR DESCRIPTION

This also pulls in spectator-web-spring which is in review but expect it
to be available soon.

@cfieber 
This is really two modules in one:
(1) A "spectator-ext-stackdriver", which conceptually belongs in spectator but logistically wont work out because I dont have access to that repo to maintain.
(2) A kork-spectator module that just adds a StackdriverConfig class to wire up an optional stackdriver writer and a metrics web endpoint provided by spectator-web-spring. I dont actually need the web endpoint from a production standpoint, but it is convenient for debugging, offers another option for grabbing metrics for all spinnaker deployments, and I do reference a couple classes I added into that package.

I'm only asking you to review (2) keeping in mind that I'm going to add this dependency to all the spinnaker microservices. You are welcome to review (1) as well, but I can get other people to review that to distribute the load.

The local reference to :spectator-web-spring is temporary while I am waiting for that module to get approved and published. I'll consume the published version before ultimately merging the PR.

@duftler 
If you are curious to know more about Stackdriver, you can review (1).
Otherwise I can find someone else.


