### PR TITLE
Upgrade to Spring Boot 1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@
  */
 
 buildscript {
-
   repositories {
     jcenter()
     maven { url 'http://dl.bintray.com/spinnaker/gradle/' }
@@ -33,7 +32,7 @@ allprojects {
   group = 'com.netflix.spinnaker.kork'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.57.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.61.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]
@@ -59,4 +58,18 @@ allprojects {
   jacoco {
     toolVersion = '0.7.7.201606060606'
   }
+
+  configurations {
+    all {
+      resolutionStrategy {
+        eachDependency {
+          if (it.requested.group.startsWith('org.apache.tomcat')) {
+            it.useVersion spinnaker.version('tomcat')
+          }
+        }
+      }
+    }
+  }
+
+
 }

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/metrics/SpectatorConfiguration.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/metrics/SpectatorConfiguration.java
@@ -55,7 +55,7 @@ public class SpectatorConfiguration {
 
   @Bean
   @Primary
-  @ConditionalOnMissingClass(name = "org.springframework.messaging.MessageChannel")
+  @ConditionalOnMissingClass("org.springframework.messaging.MessageChannel")
   @ConditionalOnMissingBean(name = "primaryMetricWriter")
   public MetricWriter primaryMetricWriter(List<MetricWriter> writers) {
     return new CompositeMetricWriter(writers);

--- a/kork-swagger/kork-swagger.gradle
+++ b/kork-swagger/kork-swagger.gradle
@@ -1,6 +1,6 @@
 dependencies {
   compile spinnaker.dependency('bootAutoConfigure')
-  compile "io.springfox:springfox-swagger2:2.2.2"
-  compile "io.springfox:springfox-swagger-ui:2.2.2"
-  compile "com.wordnik:swagger-annotations:1.3.13"
+  compile "io.springfox:springfox-swagger2:2.6.0"
+  compile "io.springfox:springfox-swagger-ui:2.6.0"
+  compile "io.swagger:swagger-annotations:1.5.10"
 }

--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -11,6 +11,7 @@ dependencies {
 
   compileOnly spinnaker.dependency('bootActuator')
 
+  spinnaker.group('tomcatEmbedded')
   spinnaker.group('spockBase')
 }
 

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/BlacklistingJSSESocketFactory.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/BlacklistingJSSESocketFactory.java
@@ -23,6 +23,9 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.util.Optional;
 
+/**
+ * TODO: Handle Tomcat 8.5 refactoring that removes low level JSSESocketFactory. See https://github.com/spring-projects/spring-boot/issues/6164 for more details.
+ */
 public class BlacklistingJSSESocketFactory extends JSSESocketFactory {
   private static final String BLACKLIST_PREFIX = "blacklist:";
 


### PR DESCRIPTION
Using the update to spinnaker-dependencies, migrate kork to Spring Boot 1.4 and related dependencies

NOTE: Spring Boot 1.4 automatically uses Tomcat 8.5.5. In 8.5, several APIs were refactored including JSSESocketFactory. This patch pins Tomcat to 8.0.24, latest stable version of 8.0 until this refactoring can be dealt with.