### PR TITLE
Adds Stackdriver config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,6 @@ allprojects {
   }
 
   jacoco {
-    toolVersion = '0.7.0.201403182114'
+    toolVersion = '0.7.7.201606060606'
   }
 }

--- a/kork-stackdriver/kork-stackdriver.gradle
+++ b/kork-stackdriver/kork-stackdriver.gradle
@@ -15,11 +15,16 @@
  */
 
 dependencies {
-  compile spinnaker.dependency('spectatorApi')
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('bootDataRest')
+  compile spinnaker.dependency('rxJava')
 
-  // googleMonitoring is not yet in spinnaker-dependencies
-  // compile spinnaker.dependency('googleMonitoring')
-  compile compile('com.google.apis:google-api-services-monitoring:v3-rev9-1.22.0')
+  compile spinnaker.dependency('spectatorApi')
+  // TODO(ewiseblatt): need to update spinnaker-dependencies first
+  // compile spinnaker.dependency('spectatorWebSpring')
+  compile "com.netflix.spectator:spectator-web-spring:${spinnaker.version('spectator')}"
+
+  compile spinnaker.dependency('googleMonitoring')
 
   testCompile 'org.mockito:mockito-core:2.+'
   testCompile 'junit:junit:4.+'

--- a/kork-stackdriver/src/main/java/com/netflix/spinnaker/config/StackdriverConfig.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spinnaker/config/StackdriverConfig.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config;
+
+import com.netflix.spectator.controllers.filter.PrototypeMeasurementFilter;
+import com.netflix.spectator.controllers.MetricsController;
+import com.netflix.spectator.stackdriver.ConfigParams;
+import com.netflix.spectator.stackdriver.MetricDescriptorCache;
+import com.netflix.spectator.stackdriver.StackdriverWriter;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Spectator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import rx.Observable;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
+
+
+@Configuration
+@EnableConfigurationProperties
+@Import({MetricsController.class})
+@ConditionalOnExpression("${spectator.stackdriver.enabled:false}")
+class StackdriverConfig {
+
+  @Value("${spectator.applicationName:${spring.application.name}}")
+  private String applicationName;
+
+  @Value("${spectator.stackdriver.credentialsPath:}")
+  private String credentialsPath;
+
+  @Value("${spectator.stackdriver.projectName:}")
+  private String projectName;
+
+  @Value("${spectator.stackdriver.uniqueMetricsPerApplication:true}")
+  private boolean uniqueMetricsPerApplication;
+
+  // If provided, takes precedence over the *Regex filters above.
+  @Value("${spectator.webEndpoint.prototypeFilter.path:}")
+  private String prototypeFilterPath;
+
+  @Value("${spectator.stackdriver.period:60}")
+  private int pushPeriodSecs;
+
+  private StackdriverWriter stackdriver;
+
+  @Configuration
+  @ConfigurationProperties(prefix="stackdriver")
+  static public class StackdriverConfigurationHints {
+    /**
+     * This class lets spring load from our YAML file into a Hint instance.
+     */
+    static public class MutableHint extends MetricDescriptorCache.CustomDescriptorHint {
+        public void setLabels(List<String> labels) {
+            this.labels = labels;
+        }
+        public void setRedacted(List<String> labels) {
+            this.redacted = labels;
+        }
+        public void setName(String name) {
+            this.name = name;
+        }
+    };
+
+    public List<MutableHint> hints;
+    public void setHints(List<MutableHint> hints) { this.hints = hints; }
+    public List<MutableHint> getHints() { return hints; }
+  };
+
+  @Autowired
+  StackdriverConfigurationHints stackdriverHints;
+
+  @Autowired
+  Registry registry;
+
+  /**
+   * Schedule a thread to flush our registry into stackdriver periodically.
+   *
+   * This configures our StackdriverWriter as well.
+   */
+  @Bean
+  public StackdriverWriter defaultStackdriverWriter() throws IOException {
+    Logger log = LoggerFactory.getLogger("StackdriverConfig");
+    log.info("Creating StackdriverWriter.");
+    Predicate<Measurement> filterNotSpring = new Predicate<Measurement>() {
+      public boolean test(Measurement measurement) {
+        // Dont store measurements that dont have tags.
+        // These are from spring; those of interest were replicated in spectator.
+        if (measurement.id().tags().iterator().hasNext()) {
+          return true;
+        }
+
+        return false;
+      }
+    };
+    Predicate<Measurement> measurementFilter;
+
+    if (!prototypeFilterPath.isEmpty()) {
+      log.error("Ignoring prototypeFilterPath because it is not yet supported.");
+      measurementFilter = null;
+      log.info("Configuring stackdriver filter from {}", prototypeFilterPath);
+      measurementFilter = PrototypeMeasurementFilter.loadFromPath(
+           prototypeFilterPath).and(filterNotSpring);
+    } else {
+      measurementFilter = filterNotSpring;
+    }
+
+    ConfigParams params = new ConfigParams.Builder()
+        .setCounterStartTime(new Date().getTime())
+        .setUniqueMetricsPerApplication(uniqueMetricsPerApplication)
+        .setCustomTypeNamespace("spinnaker")
+        .setProjectName(projectName)
+        .setApplicationName(applicationName)
+        .setCredentialsPath(credentialsPath)
+        .setMeasurementFilter(measurementFilter)
+        .build();
+
+    stackdriver = new StackdriverWriter(params);
+
+    if (stackdriverHints != null && stackdriverHints.hints != null) {
+        log.info("Adding {} custom descriptor hints",
+                 stackdriverHints.hints.size());
+        stackdriver.getDescriptorCache()
+            .addCustomDescriptorHints(stackdriverHints.hints);
+    } else {
+        log.info("No custom descriptor hints");
+    }
+    Scheduler scheduler = Schedulers.from(Executors.newFixedThreadPool(1));
+
+    Observable.timer(pushPeriodSecs, TimeUnit.SECONDS)
+        .repeat()
+        .subscribe(interval -> { stackdriver.writeRegistry(registry); });
+
+    return stackdriver;
+  }
+};

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-include 'kork-core', 'kork-cassandra', 'kork-jedis-test', 'kork-swagger', 'kork-security', 'kork-web', 'kork-hystrix'
-//TODO(ewiseblatt) - fix for spectator 0.41.0: , 'kork-stackdriver'
+include 'kork-core', 'kork-cassandra', 'kork-jedis-test', 'kork-swagger', 'kork-security', 'kork-web', 'kork-hystrix', 'kork-stackdriver'
 
 rootProject.name='kork'
 


### PR DESCRIPTION
@cfieber 
This is the PR from earlier this week. I went to update it against head and did something that caused the PR to get dropped for some reason.

This adds a bean that can get picked up by all the microservices to add stackdriver support in (false by default). I'd like it to also add in the web metrics API I added into spectator 0.41 but commented it out because spinnaker is only on 0.36. I originally wrote it against the source so it had been working until I stopped building against source and started consuming spectator as spinnaker dependencies. I'm leaving it in.

There are a couple comments in the config with questions to you basically asking whether I can delete the commented out block or if in fact there is an issue I need to consider. Should be straightforward.

Thanks.