### PR TITLE
Adds /resolvedEnv endpoint

### DIFF
--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -9,6 +9,7 @@ dependencies {
   compile spinnaker.dependency('retrofit')
   compile spinnaker.dependency('guava')
 
+  compileOnly spinnaker.dependency('bootActuator')
 
   spinnaker.group('spockBase')
 }

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/ResolvedEnvironmentEndpoint.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/ResolvedEnvironmentEndpoint.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config
+
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.EnumerablePropertySource
+import org.springframework.core.env.Environment
+import org.springframework.core.env.MutablePropertySources
+import org.springframework.core.env.StandardEnvironment
+
+@ConfigurationProperties(prefix = "endpoints.resolvedEnv")
+class ResolvedEnvironmentEndpoint extends AbstractEndpoint<Map<String, Object>> {
+
+  public ResolvedEnvironmentEndpoint() {
+    super("resolvedEnv")
+  }
+
+  @Override
+  Map<String, Object> invoke() {
+    def result = [:]
+    Environment environment = getEnvironment()
+    getPropertyKeys().each {
+      result.put(it, environment.getProperty(it))
+    }
+    return result
+  }
+
+  /**
+   * Impl paritially copied from
+   * {@link org.springframework.boot.actuate.endpoint.EnvironmentEndpoint}
+   *
+   * This gathers all defined properties in the system (no matter the source)
+   */
+  private SortedSet<String> getPropertyKeys() {
+    SortedSet<String> result = new TreeSet<String>()
+    Environment environment = getEnvironment()
+
+    MutablePropertySources sources
+    if (environment && environment instanceof ConfigurableEnvironment) {
+      sources = ((ConfigurableEnvironment) environment).getPropertySources()
+    } else {
+      sources = new StandardEnvironment().getPropertySources()
+    }
+
+    sources.each {
+      if (it instanceof EnumerablePropertySource) {
+        ((EnumerablePropertySource) it).propertyNames.each {
+          result.add(it)
+        }
+      }
+    }
+
+    return result
+  }
+}

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy
@@ -28,11 +28,13 @@ import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomi
 import org.springframework.boot.context.embedded.Ssl
 import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Slf4j
 @Configuration
+@EnableConfigurationProperties(ResolvedEnvironmentEndpoint)
 class TomcatConfiguration {
   @Value('${default.legacyServerPort:-1}')
   int legacyServerPort

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy
@@ -22,6 +22,7 @@ import org.apache.catalina.connector.Connector
 import org.apache.coyote.http11.AbstractHttp11JsseProtocol
 import org.apache.coyote.http11.Http11NioProtocol
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.actuate.endpoint.ResolvedEnvironmentEndpoint
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer


### PR DESCRIPTION
A super handy debugging tool, `/resolveEnv` is different from the `/env` endpoint, which potentially lists the same value multiple times across different PropertySources. This endpoint prints the value once fully resolved.

Example output snippet from Gate:

```
{
  ...
  "server.address": "localhost",
  "server.port": "8084",
  "services.bakery.allowMissingPackageInstallation": "false",
  "services.bakery.baseUrl": "http://localhost:8087",
  "services.bakery.extractBuildDetails": "true",
  "services.bakery.host": "localhost",
  "services.bakery.port": "8087",
  "services.cassandra.cluster": "CASS_SPINNAKER",
  "services.cassandra.embedded": "false",
  "services.cassandra.host": "localhost",
  "services.cassandra.port": "9042",
  "services.clouddriver.aws.udf.enabled": "true",
  "services.clouddriver.baseUrl": "http://localhost:7002",
  "services.clouddriver.host": "localhost",
  "services.clouddriver.port": "7002",
  "services.deck.auth.enabled": "true",
  "services.deck.bakeryUrl": "http://localhost:8087",
  "services.deck.baseUrl": "https://localhost:9000",
  "services.deck.gateUrl": "https://localhost:8084",
  "services.deck.host": "localhost",
  "services.deck.port": "9000",
  "services.deck.timezone": "America/Los_Angeles",
  "services.default.host": "localhost",
  "services.default.primaryAccountName": "my-google-account",
  "services.default.protocol": "http",
  "services.docker.baseUrl": "http://my-docker-instance:7104",
  "services.docker.enabled": "true",
  "services.docker.primaryAccount.name": "my-google-account",
  "services.docker.primaryAccount.registry": "http://localhost:5000",
  "services.docker.primaryAccount.url": "http://my-docker-instance:7104",
  "services.docker.targetRepository": "my-docker-instance:5000",
  "services.dockerRegistry.baseUrl": "http://localhost:5000",
  "services.echo.baseUrl": "http://localhost:8089",
  "services.echo.cassandra.enabled": "true",
  "services.echo.cron.enabled": "true",
  "services.echo.cron.timezone": "America/Los_Angeles",
  "services.echo.enabled": "true",
  "services.echo.host": "localhost",
  "services.echo.inMemory.enabled": "false",
  "services.echo.notifications.hipchat.botName": "",
  "services.echo.notifications.hipchat.enabled": "false",
  "services.echo.notifications.hipchat.token": "",
  "services.echo.notifications.hipchat.url": "",
  "services.echo.notifications.mail.enabled": "false",
  "services.echo.notifications.mail.fromAddress": "",
  "services.echo.notifications.mail.host": "",
  "services.echo.notifications.slack.botName": "",
  "services.echo.notifications.slack.enabled": "false",
  "services.echo.notifications.slack.token": "",
  "services.echo.notifications.sms.account": "",
  "services.echo.notifications.sms.enabled": "false",
  "services.echo.notifications.sms.from": "",
  "services.echo.notifications.sms.token": "",
  "services.echo.port": "8089",
  "services.fiat.autoConfig": "false",
  "services.fiat.baseUrl": "http://localhost:7003",
  "services.fiat.enabled": "false",
  "services.fiat.host": "localhost",
  "services.fiat.port": "7003",
  "services.flapjack.enabled": "false",
  "services.front50.baseUrl": "http://localhost:8080",
  "services.front50.bucket_location": "",
  "services.front50.bucket_root": "front50",
  "services.front50.cassandra.enabled": "true",
  "services.front50.gcs.enabled": "false",
  "services.front50.host": "localhost",
  "services.front50.port": "8080",
  "services.front50.redis.enabled": "false",
  "services.front50.s3.enabled": "false",
  "services.front50.storage_bucket": "",
  "services.gate.baseUrl": "http://localhost:8084",
  "services.gate.host": "localhost",
  "services.gate.port": "8084",
  "services.igor.baseUrl": "http://localhost:8088",
  "services.igor.enabled": "true",
  "services.igor.host": "localhost",
  "services.igor.port": "8088",
  "services.jenkins.defaultMaster.baseUrl": "http://jenkins-1:80/jenkins",
  "services.jenkins.defaultMaster.name": "Jenkins",
  ...
}
```

@jtk54 @duftler @lwander @ewiseblatt @cfieber @ajordens, and anyone else who helps Slack users debug their installations, PTAL