### PR TITLE
Stackdriver fixes.

### DIFF
--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/ConfigParams.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/ConfigParams.java
@@ -111,8 +111,10 @@ public class ConfigParams {
     public ConfigParams build() {
       ConfigParams result = new ConfigParams();
 
+      String actualProjectName = new MonitoredResourceBuilder().determineProjectName(projectName);
+
       result.projectName
-          = validateString(projectName, "stackdriver projectName");
+          = validateString(actualProjectName, "stackdriver projectName");
       result.applicationName
           = validateString(applicationName, "applicationName");
       result.customTypeNamespace

--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/MetricDescriptorCache.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/MetricDescriptorCache.java
@@ -623,13 +623,18 @@ public class MetricDescriptorCache {
     descriptor.setDisplayName(id.name());
     descriptor.setType(descriptorType);
     descriptor.setValueType("DOUBLE");
+
+    String untransformedDescriptorType;
     if (meterIsTimer(registry, meter)) {
-      if (id.name().endsWith("_totalTime")) {
+      if (id.name().endsWith("__totalTime")) {
         descriptor.setUnit("ns");
       }
       descriptor.setMetricKind("CUMULATIVE");
+      int suffixOffset = descriptorType.lastIndexOf("__");
+      untransformedDescriptorType = descriptorType.substring(0, suffixOffset);
     } else {
       descriptor.setMetricKind(meterToKind(registry, meter));
+      untransformedDescriptorType = descriptorType;
     }
 
     List<LabelDescriptor> labels = new ArrayList<LabelDescriptor>();
@@ -647,7 +652,7 @@ public class MetricDescriptorCache {
        labels.add(labelDescriptor);
     }
 
-    maybeAddLabelHints(descriptorType, labels);
+    maybeAddLabelHints(untransformedDescriptorType, labels);
     if (labels.size() > 10) {
         log.error("{} has too many labels for stackdriver to handle: {}",
                   id.name(), labels);

--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/MonitoredResourceBuilder.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/MonitoredResourceBuilder.java
@@ -56,6 +56,20 @@ class MonitoredResourceBuilder {
   }
 
   /**
+   * This is the project that we have to store data under.
+   *
+   * If we are running on GCE, it has to be our project.
+   * Otherwise, it is the project we are given as the default.
+   */
+  public String determineProjectName(String defaultProjectName) {
+    try {
+      return getGoogleMetadataValue("project/project-id");
+    } catch (IOException ioex) {
+      return defaultProjectName;
+    }
+  }
+
+  /**
    * Helper function to read the result from a HTTP GET.
    */
   private String getConnectionValue(HttpURLConnection con) throws IOException {
@@ -85,7 +99,7 @@ class MonitoredResourceBuilder {
     URL url = new URL(String.format(
                 "http://169.254.169.254/computeMetadata/v1/%s", key));
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
-    con.setConnectTimeout(250);
+    con.setConnectTimeout(1000);
     con.setInstanceFollowRedirects(true);
     con.setRequestMethod("GET");
     con.setRequestProperty("Metadata-Flavor", "Google");
@@ -152,7 +166,7 @@ class MonitoredResourceBuilder {
     URL url = new URL(
       "http://169.254.169.254/latest/dynamic/instance-identity/document");
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
-    con.setConnectTimeout(250);
+    con.setConnectTimeout(1000);
     con.setRequestMethod("GET");
     return getConnectionValue(con);
   }

--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/StackdriverWriter.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/StackdriverWriter.java
@@ -454,7 +454,7 @@ public class StackdriverWriter {
   }
 
   /**
-   * Implementatio of writeRegistry wrapped for timing.
+   * Implementation of writeRegistry wrapped for timing.
    */
   private void writeRegistryHelper(Registry registry) {
     MonitoredResource resource = determineMonitoredResource();

--- a/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MetricDescriptorCacheTest.java
+++ b/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MetricDescriptorCacheTest.java
@@ -111,7 +111,8 @@ public class MetricDescriptorCacheTest {
   DefaultRegistry registry = new DefaultRegistry(clock);
 
   TestableMetricDescriptorCache cache;
-  String projectName = "test-project";
+  String projectName = new MonitoredResourceBuilder().determineProjectName("test-project");
+  String projectResourceName = "projects/" + projectName;
   String applicationName = "test-application";
 
   Id idA = registry.createId("idA");
@@ -203,7 +204,7 @@ public class MetricDescriptorCacheTest {
   public void descriptorNamesAreCompliant() {
     // https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors
     Assert.assertEquals(
-        "projects/test-project/metricDescriptors/" + cache.idToDescriptorType(idA),
+        projectResourceName + "/metricDescriptors/" + cache.idToDescriptorType(idA),
         cache.idToDescriptorName(idA));
   }
 
@@ -216,7 +217,7 @@ public class MetricDescriptorCacheTest {
         = Mockito.mock(Monitoring.Projects.MetricDescriptors.Create.class);
 
     when(descriptorsApi.create(
-            eq("projects/test-project"), any(MetricDescriptor.class)))
+            eq(projectResourceName), any(MetricDescriptor.class)))
             .thenAnswer(new ReturnExecuteDescriptorArg(mockCreateMethod));
     cache.createDescriptorInServer(idAXY, registry, counterA);
 
@@ -224,7 +225,7 @@ public class MetricDescriptorCacheTest {
 
     ArgumentCaptor<MetricDescriptor> captor
         = ArgumentCaptor.forClass(MetricDescriptor.class);
-    verify(descriptorsApi, times(1)).create(eq("projects/test-project"),
+    verify(descriptorsApi, times(1)).create(eq(projectResourceName),
                                                captor.capture());
     MetricDescriptor descriptor = captor.getValue();
 
@@ -258,13 +259,13 @@ public class MetricDescriptorCacheTest {
           = Mockito.mock(Monitoring.Projects.MetricDescriptors.Create.class);
 
     when(descriptorsApi.create(
-            eq("projects/test-project"), any(MetricDescriptor.class)))
+            eq(projectResourceName), any(MetricDescriptor.class)))
             .thenAnswer(new ReturnExecuteDescriptorArg(mockCreateMethod));
     cache.createDescriptorInServer(idAXY, registry, counterA);
 
     ArgumentCaptor<MetricDescriptor> captor
         = ArgumentCaptor.forClass(MetricDescriptor.class);
-    verify(descriptorsApi, times(1)).create(eq("projects/test-project"),
+    verify(descriptorsApi, times(1)).create(eq(projectResourceName),
                                                captor.capture());
     verify(mockCreateMethod, times(1)).execute();
 
@@ -280,13 +281,13 @@ public class MetricDescriptorCacheTest {
     reset(mockCreateMethod);
 
     when(descriptorsApi.create(
-            eq("projects/test-project"), any(MetricDescriptor.class)))
+            eq(projectResourceName), any(MetricDescriptor.class)))
             .thenAnswer(new ReturnExecuteDescriptorArg(mockCreateMethod));
     cache.createDescriptorInServer(idBXY, registry, counterB);
     verify(mockCreateMethod, times(1)).execute();
 
     captor = ArgumentCaptor.forClass(MetricDescriptor.class);
-    verify(descriptorsApi, times(1)).create(eq("projects/test-project"),
+    verify(descriptorsApi, times(1)).create(eq(projectResourceName),
                                                captor.capture());
     descriptor = captor.getValue();
 
@@ -312,13 +313,13 @@ public class MetricDescriptorCacheTest {
           = Mockito.mock(Monitoring.Projects.MetricDescriptors.Create.class);
 
     when(descriptorsApi.create(
-            eq("projects/test-project"), any(MetricDescriptor.class)))
+            eq(projectResourceName), any(MetricDescriptor.class)))
             .thenAnswer(new ReturnExecuteDescriptorArg(mockCreateMethod));
     cache.createDescriptorInServer(idAXY, registry, counterA);
 
     ArgumentCaptor<MetricDescriptor> captor
         = ArgumentCaptor.forClass(MetricDescriptor.class);
-    verify(descriptorsApi, times(1)).create(eq("projects/test-project"),
+    verify(descriptorsApi, times(1)).create(eq(projectResourceName),
                                                captor.capture());
     verify(mockCreateMethod, times(1)).execute();
 
@@ -354,7 +355,7 @@ public class MetricDescriptorCacheTest {
 
     cache.injectDescriptor(idB, new MetricDescriptor());
     when(descriptorsApi.create(
-            eq("projects/test-project"), any(MetricDescriptor.class)))
+            eq(projectResourceName), any(MetricDescriptor.class)))
             .thenAnswer(new ReturnExecuteDescriptorArg(mockCreateMethod));
 
     cache.createDescriptorInServer(idA, registry, counterA);
@@ -362,7 +363,7 @@ public class MetricDescriptorCacheTest {
 
     ArgumentCaptor<MetricDescriptor> captor
           = ArgumentCaptor.forClass(MetricDescriptor.class);
-    verify(descriptorsApi, times(1)).create(eq("projects/test-project"),
+    verify(descriptorsApi, times(1)).create(eq(projectResourceName),
                                                captor.capture());
     MetricDescriptor descriptor = captor.getValue();
     Assert.assertTrue(descriptor != null);
@@ -385,7 +386,7 @@ public class MetricDescriptorCacheTest {
         = new ListMetricDescriptorsResponse();
     response.setMetricDescriptors(Arrays.asList(descriptorA));
 
-    when(descriptorsApi.list("projects/test-project"))
+    when(descriptorsApi.list(projectResourceName))
          .thenReturn(mockListMethod);
     when(mockListMethod.execute()).thenReturn(response);
     MetricDescriptor found = cache.descriptorOrNull(
@@ -408,7 +409,7 @@ public class MetricDescriptorCacheTest {
         = Mockito.mock(Monitoring.Projects.MetricDescriptors.List.class);
     Meter counterA = registry.counter(idAXY);
 
-    when(descriptorsApi.list("projects/test-project"))
+    when(descriptorsApi.list(projectResourceName))
         .thenThrow(new IOException());
     Assert.assertTrue(
         null == cache.descriptorOrNull(
@@ -421,7 +422,7 @@ public class MetricDescriptorCacheTest {
         = new ListMetricDescriptorsResponse();
     response.setMetricDescriptors(Arrays.asList(descriptorA));
 
-    when(descriptorsApi.list("projects/test-project"))
+    when(descriptorsApi.list(projectResourceName))
         .thenReturn(mockListMethod);
     when(mockListMethod.execute())
         .thenReturn(response);


### PR DESCRIPTION
@lwander 

If running on gce, you have to store metrics in the project of the managed
resources so force the project. But still need to configure the project if
you are not on gce (and thus dont have a gce managed resource).

When transforming [timer] metrics, lookup the hints for the original metric
name, not the transformed one.