### PR TITLE
Remove Autowiring and Value in Configurations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ build/
 *.iml
 *.ipr
 *.iws
-
+/out/
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     maven { url 'http://dl.bintray.com/spinnaker/gradle/' }
   }
   dependencies {
-    classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:3.9.0'
+    classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:3.10.0'
   }
 }
 
@@ -33,7 +33,7 @@ allprojects {
   group = 'com.netflix.spinnaker.kork'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.63.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.65.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/CassandraConfigurationProperties.java
+++ b/kork-cassandra/src/main/java/com/netflix/spinnaker/kork/astyanax/CassandraConfigurationProperties.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.astyanax;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("cassandra")
+public class CassandraConfigurationProperties {
+  private String host = "127.0.0.1";
+  private int port = 9160;
+  private int storagePort = 7000;
+  private int asyncExecutorPoolSize = 5;
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  public int getStoragePort() {
+    return storagePort;
+  }
+
+  public void setStoragePort(int storagePort) {
+    this.storagePort = storagePort;
+  }
+
+  public int getAsyncExecutorPoolSize() {
+    return asyncExecutorPoolSize;
+  }
+
+  public void setAsyncExecutorPoolSize(int asyncExecutorPoolSize) {
+    this.asyncExecutorPoolSize = asyncExecutorPoolSize;
+  }
+}

--- a/kork-cassandra/src/test/java/com/netflix/spinnaker/kork/astyanax/DefaultAstyanaxKeyspaceFactoryTest.java
+++ b/kork-cassandra/src/test/java/com/netflix/spinnaker/kork/astyanax/DefaultAstyanaxKeyspaceFactoryTest.java
@@ -68,9 +68,10 @@ public class DefaultAstyanaxKeyspaceFactoryTest {
     private static class TestDAKF extends DefaultAstyanaxKeyspaceFactory implements Closeable {
         public final AtomicInteger createCount = new AtomicInteger();
         public final AtomicInteger removeCount = new AtomicInteger();
+        public static final CassandraConfigurationProperties configurationProperties = new CassandraConfigurationProperties();
 
         public TestDAKF(AstyanaxComponents comp) {
-            super(comp.astyanaxConfiguration(comp.cassandraAsyncExecutor(5)), comp.connectionPoolConfiguration(), comp.countingConnectionPoolMonitor(), comp.clusterHostSupplierFactory(), comp.noopKeyspaceInitializer());
+            super(comp.astyanaxConfiguration(comp.cassandraAsyncExecutor(configurationProperties)), comp.connectionPoolConfiguration(configurationProperties), comp.countingConnectionPoolMonitor(), comp.clusterHostSupplierFactory(), comp.noopKeyspaceInitializer());
         }
 
         @Override

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/archaius/SpringEnvironmentPolledConfigurationSource.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/archaius/SpringEnvironmentPolledConfigurationSource.java
@@ -18,20 +18,19 @@ package com.netflix.spinnaker.kork.archaius;
 
 import com.netflix.config.PollResult;
 import com.netflix.config.PolledConfigurationSource;
-import com.netflix.spinnaker.kork.internal.Precondition;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
 
 public class SpringEnvironmentPolledConfigurationSource implements PolledConfigurationSource {
 
   private final ConfigurableEnvironment environment;
 
   public SpringEnvironmentPolledConfigurationSource(ConfigurableEnvironment environment) {
-    this.environment = Precondition.notNull(environment, "environment");
+    this.environment = Objects.requireNonNull(environment, "environment");
   }
 
   @Override

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/aws/AwsComponents.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/aws/AwsComponents.java
@@ -24,6 +24,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.aws.SpectatorMetricCollector;
 import com.netflix.spinnaker.kork.metrics.SpectatorConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -48,6 +49,7 @@ public class AwsComponents {
   }
 
   @Bean
+  @ConditionalOnProperty(value = "aws.metrics.enabled", matchIfMissing = true)
   SpectatorMetricCollector spectatorMetricsCollector(Registry registry) {
     SpectatorMetricCollector collector = new SpectatorMetricCollector(registry);
     AwsSdkMetrics.setMetricCollector(collector);

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/aws/InstrumentedBackoffStrategy.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/aws/InstrumentedBackoffStrategy.java
@@ -21,7 +21,8 @@ import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.RetryPolicy;
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.kork.internal.Precondition;
+
+import java.util.Objects;
 
 public class InstrumentedBackoffStrategy implements RetryPolicy.BackoffStrategy {
   private final Registry registry;
@@ -32,8 +33,8 @@ public class InstrumentedBackoffStrategy implements RetryPolicy.BackoffStrategy 
   }
 
   public InstrumentedBackoffStrategy(Registry registry, RetryPolicy.BackoffStrategy delegate) {
-    this.registry = Precondition.notNull(registry, "registry");
-    this.delegate = Precondition.notNull(delegate, "delegate");
+    this.registry = Objects.requireNonNull(registry, "registry");
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
   }
 
   public long delayBeforeNextRetry(AmazonWebServiceRequest originalRequest, AmazonClientException exception, int retriesAttempted) {

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/aws/InstrumentedRetryCondition.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/aws/InstrumentedRetryCondition.java
@@ -21,7 +21,8 @@ import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.RetryPolicy;
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.kork.internal.Precondition;
+
+import java.util.Objects;
 
 public class InstrumentedRetryCondition implements RetryPolicy.RetryCondition {
   private final Registry registry;
@@ -32,8 +33,8 @@ public class InstrumentedRetryCondition implements RetryPolicy.RetryCondition {
   }
 
   public InstrumentedRetryCondition(Registry registry, RetryPolicy.RetryCondition delegate) {
-    this.registry = Precondition.notNull(registry, "registry");
-    this.delegate = Precondition.notNull(delegate, "delegate");
+    this.registry = Objects.requireNonNull(registry, "registry");
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
   }
 
   @Override

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/eureka/BootHealthCheckHandler.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/eureka/BootHealthCheckHandler.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.kork.eureka;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.appinfo.InstanceInfo;
-import com.netflix.spinnaker.kork.internal.Precondition;
 import org.springframework.boot.actuate.health.CompositeHealthIndicator;
 import org.springframework.boot.actuate.health.HealthAggregator;
 import org.springframework.boot.actuate.health.HealthIndicator;
@@ -28,6 +27,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class BootHealthCheckHandler implements HealthCheckHandler, ApplicationListener<ContextRefreshedEvent> {
 
@@ -37,7 +37,7 @@ public class BootHealthCheckHandler implements HealthCheckHandler, ApplicationLi
   public BootHealthCheckHandler(ApplicationInfoManager applicationInfoManager,
                                 HealthAggregator aggregator,
                                 Map<String, HealthIndicator> healthIndicators) {
-    this.applicationInfoManager = Precondition.notNull(applicationInfoManager, "applicationInfoManager");
+    this.applicationInfoManager = Objects.requireNonNull(applicationInfoManager, "applicationInfoManager");
     this.aggregateHealth = new CompositeHealthIndicator(aggregator, healthIndicators);
   }
 

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaConfigurationProperties.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaConfigurationProperties.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.eureka;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+import java.util.Objects;
+
+@ConfigurationProperties("eureka")
+public class EurekaConfigurationProperties {
+  public static class Namespace {
+    private String namespace;
+
+    public Namespace(String namespace) {
+      this.namespace = fixNamespace(namespace);
+    }
+
+    public String getNamespace() {
+      return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+      this.namespace = fixNamespace(namespace);
+    }
+
+    private static String fixNamespace(String namespace) {
+      Objects.requireNonNull(namespace, "namespace");
+      return namespace.endsWith(".") ? namespace : namespace + ".";
+    }
+  }
+
+  @NestedConfigurationProperty
+  private final Namespace instance = new Namespace("netflix.appinfo.");
+
+  @NestedConfigurationProperty
+  private final Namespace client = new Namespace("netflix.discovery.");
+
+  public Namespace getInstance() {
+    return instance;
+  }
+
+  public Namespace getClient() {
+    return client;
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/metrics/SpectatorConfiguration.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/metrics/SpectatorConfiguration.java
@@ -22,12 +22,12 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
 import com.netflix.spectator.gc.GcLogger;
 import com.netflix.spectator.jvm.Jmx;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.metrics.writer.CompositeMetricWriter;
 import org.springframework.boot.actuate.metrics.writer.MetricWriter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -37,10 +37,8 @@ import java.util.List;
 
 @Configuration
 @ConditionalOnClass(Registry.class)
+@EnableConfigurationProperties(SpectatorGcLoggingConfiguration.class)
 public class SpectatorConfiguration {
-
-  @Value("${spectator.gc.loggingEnabled:true}")
-  boolean jmxLoggingEnabled = true;
 
   @Bean
   @ConditionalOnMissingBean(Registry.class)
@@ -62,8 +60,8 @@ public class SpectatorConfiguration {
   }
 
   @Bean
-  RegistryInitializer registryInitializer(Registry registry) {
-    return new RegistryInitializer(registry, jmxLoggingEnabled);
+  RegistryInitializer registryInitializer(Registry registry, SpectatorGcLoggingConfiguration spectatorConfigurationProperties) {
+    return new RegistryInitializer(registry, spectatorConfigurationProperties.isLoggingEnabled());
   }
 
   private static class RegistryInitializer {

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/metrics/SpectatorGcLoggingConfiguration.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/metrics/SpectatorGcLoggingConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,22 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.archaius;
+package com.netflix.spinnaker.kork.metrics;
 
-import java.util.Objects;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-public class DefaultClasspathPropertySource implements ClasspathPropertySource {
-  private final String baseName;
+/**
+ * SpectatorGcLoggingConfiguration.
+ */
+@ConfigurationProperties("spectator.gc")
+public class SpectatorGcLoggingConfiguration {
+  private boolean loggingEnabled = true;
 
-  public DefaultClasspathPropertySource(String baseName) {
-    this.baseName = Objects.requireNonNull(baseName, "baseName");
-  }
+  public boolean isLoggingEnabled() {
+      return loggingEnabled;
+    }
 
-  @Override
-  public String getBaseName() {
-    return baseName;
-  }
+  public void setLoggingEnabled(boolean loggingEnabled) {
+      this.loggingEnabled = loggingEnabled;
+    }
 }

--- a/kork-hystrix/src/main/groovy/com/netflix/spinnaker/config/HystrixSpectatorConfig.groovy
+++ b/kork-hystrix/src/main/groovy/com/netflix/spinnaker/config/HystrixSpectatorConfig.groovy
@@ -21,22 +21,18 @@ import com.netflix.hystrix.strategy.HystrixPlugins
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.hystrix.spectator.HystrixSpectatorPublisher
 import groovy.util.logging.Slf4j
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-import javax.annotation.PostConstruct
 
 @Slf4j
 @Configuration
 class HystrixSpectatorConfig {
-  @Autowired
-  Registry registry
-
-  @PostConstruct
-  void enableSpecatorPublisher() {
+  @Bean
+  HystrixSpectatorPublisher hystrixSpectatorPublisher(Registry registry) {
+    def publisher = new HystrixSpectatorPublisher(registry)
     log.info("Enabling HystrixSpectatorPublisher")
-    HystrixPlugins.getInstance().registerMetricsPublisher(
-      new HystrixSpectatorPublisher(registry)
-    )
+    HystrixPlugins.getInstance().registerMetricsPublisher(publisher)
+    return publisher;
   }
 }

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/ErrorConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/ErrorConfiguration.groovy
@@ -25,10 +25,9 @@ import org.springframework.web.context.request.RequestAttributes
 @Configuration
 class ErrorConfiguration {
 
-  DefaultErrorAttributes defaultErrorAttributes = new DefaultErrorAttributes()
-
   @Bean
   ErrorAttributes errorAttributes() {
+    final DefaultErrorAttributes defaultErrorAttributes = new DefaultErrorAttributes()
     return new ErrorAttributes() {
 
       @Override

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttpClientComponents.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttpClientComponents.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config
+
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
+import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(OkHttpClientConfigurationProperties)
+class OkHttpClientComponents {
+  @Bean
+  SpinnakerRequestInterceptor spinnakerRequestInterceptor(OkHttpClientConfigurationProperties okHttpClientConfigurationProperties) {
+    return new SpinnakerRequestInterceptor(okHttpClientConfigurationProperties)
+  }
+}

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttpClientConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttpClientConfiguration.groovy
@@ -16,16 +16,15 @@
 
 package com.netflix.spinnaker.config
 
-import com.netflix.spinnaker.security.AuthenticatedRequest
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
+import com.squareup.okhttp.ConnectionPool
 import com.squareup.okhttp.ConnectionSpec
 import com.squareup.okhttp.OkHttpClient
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
-import retrofit.RequestInterceptor
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
 
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
@@ -37,96 +36,54 @@ import java.util.concurrent.TimeUnit
 
 @Slf4j
 @CompileStatic
-@Configuration
-@ConfigurationProperties(prefix="okHttpClient")
+@Component
 class OkHttpClientConfiguration {
-  long connectTimoutMs = 15000
-  long readTimeoutMs = 20000
 
-  boolean propagateSpinnakerHeaders = true
+  private final OkHttpClientConfigurationProperties okHttpClientConfigurationProperties
 
-  File keyStore
-  String keyStoreType = 'PKCS12'
-  String keyStorePassword = 'changeit'
-
-  File trustStore
-  String trustStoreType = 'PKCS12'
-  String trustStorePassword = 'changeit'
-
-  String secureRandomInstanceType = "NativePRNGNonBlocking"
-
-  List<String> tlsVersions = ["TLSv1.2", "TLSv1.1", "TLSv1"]
-  List<String> cipherSuites = [
-    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-    "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
-    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
-    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-    "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
-    "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
-    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
-    "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA"
-  ]
-
-  /**
-   * @return RequestInterceptor that will propagate Spinnaker headers if <code>propagateSpinnakerHeaders</code> is true
-   */
-  @Bean
-  RequestInterceptor spinnakerRequestInterceptor() {
-    return new RequestInterceptor() {
-      @Override
-      void intercept(RequestInterceptor.RequestFacade request) {
-        if (!propagateSpinnakerHeaders) {
-          // noop
-          return
-        }
-
-        AuthenticatedRequest.authenticationHeaders.each { String key, Optional<String> value ->
-          if (value.present) {
-            request.addHeader(key, value.get())
-          }
-        }
-      }
-    }
+  @Autowired
+  public OkHttpClientConfiguration(OkHttpClientConfigurationProperties okHttpClientConfigurationProperties) {
+    this.okHttpClientConfigurationProperties = okHttpClientConfigurationProperties
   }
 
   /**
    * @return OkHttpClient w/ <optional> key and trust stores
    */
   OkHttpClient create() {
-    def okHttpClient = new OkHttpClient()
-    okHttpClient.setConnectTimeout(connectTimoutMs, TimeUnit.MILLISECONDS)
-    okHttpClient.setReadTimeout(readTimeoutMs, TimeUnit.MILLISECONDS)
-    okHttpClient.setRetryOnConnectionFailure(false)
 
-    if (!keyStore && !trustStore) {
+    def okHttpClient = new OkHttpClient()
+    okHttpClient.setConnectTimeout(okHttpClientConfigurationProperties.connectTimoutMs, TimeUnit.MILLISECONDS)
+    okHttpClient.setReadTimeout(okHttpClientConfigurationProperties.readTimeoutMs, TimeUnit.MILLISECONDS)
+    okHttpClient.setRetryOnConnectionFailure(okHttpClientConfigurationProperties.retryOnConnectionFailure)
+    okHttpClient.connectionPool = new ConnectionPool(
+      okHttpClientConfigurationProperties.connectionPool.maxIdleConnections,
+      okHttpClientConfigurationProperties.connectionPool.keepAliveDurationMs)
+
+    if (!okHttpClientConfigurationProperties.keyStore && !okHttpClientConfigurationProperties.trustStore) {
       return okHttpClient
     }
 
     def sslContext = SSLContext.getInstance('TLS')
 
     def keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
-    def ks = KeyStore.getInstance(keyStoreType)
-    keyStore.withInputStream {
-      ks.load(it as InputStream, keyStorePassword.toCharArray())
+    def ks = KeyStore.getInstance(okHttpClientConfigurationProperties.keyStoreType)
+    okHttpClientConfigurationProperties.keyStore.withInputStream {
+      ks.load(it as InputStream, okHttpClientConfigurationProperties.keyStorePassword.toCharArray())
     }
-    keyManagerFactory.init(ks, keyStorePassword.toCharArray())
+    keyManagerFactory.init(ks, okHttpClientConfigurationProperties.keyStorePassword.toCharArray())
 
     def trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
-    def ts = KeyStore.getInstance(trustStoreType)
-    trustStore.withInputStream {
-      ts.load(it as InputStream, trustStorePassword.toCharArray())
+    def ts = KeyStore.getInstance(okHttpClientConfigurationProperties.trustStoreType)
+    okHttpClientConfigurationProperties.trustStore.withInputStream {
+      ts.load(it as InputStream, okHttpClientConfigurationProperties.trustStorePassword.toCharArray())
     }
     trustManagerFactory.init(ts)
 
     def secureRandom = new SecureRandom()
     try {
-      secureRandom = SecureRandom.getInstance(secureRandomInstanceType)
+      secureRandom = SecureRandom.getInstance(okHttpClientConfigurationProperties.secureRandomInstanceType)
     } catch (NoSuchAlgorithmException e) {
-      log.error("Unable to fetch secure random instance for ${secureRandomInstanceType}", e)
+      log.error("Unable to fetch secure random instance for ${okHttpClientConfigurationProperties.secureRandomInstanceType}", e)
     }
 
     sslContext.init(keyManagerFactory.keyManagers, trustManagerFactory.trustManagers, secureRandom)
@@ -137,8 +94,8 @@ class OkHttpClientConfiguration {
 
   @CompileDynamic
   private OkHttpClient applyConnectionSpecs(OkHttpClient okHttpClient) {
-    def cipherSuites = (cipherSuites ?: ConnectionSpec.MODERN_TLS.cipherSuites()*.javaName) as String[]
-    def tlsVersions = (tlsVersions ?: ConnectionSpec.MODERN_TLS.tlsVersions()*.javaName) as String[]
+    def cipherSuites = (okHttpClientConfigurationProperties.cipherSuites ?: ConnectionSpec.MODERN_TLS.cipherSuites()*.javaName) as String[]
+    def tlsVersions = (okHttpClientConfigurationProperties.tlsVersions ?: ConnectionSpec.MODERN_TLS.tlsVersions()*.javaName) as String[]
 
     def connectionSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
       .cipherSuites(cipherSuites)

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/RetrofitConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/RetrofitConfiguration.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config
+
+import com.netflix.spinnaker.retrofit.RetrofitConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import retrofit.RestAdapter
+
+@Configuration
+@EnableConfigurationProperties(RetrofitConfigurationProperties)
+class RetrofitConfiguration {
+  @Bean
+  RestAdapter.LogLevel retrofitLogLevel(RetrofitConfigurationProperties retrofitConfigurationProperties) {
+    return retrofitConfigurationProperties.logLevel
+  }
+}

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfigurationProperties.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfigurationProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("default")
+public class TomcatConfigurationProperties {
+  private int legacyServerPort = -1;
+
+  private int apiPort = -1;
+
+  public int getLegacyServerPort() {
+    return legacyServerPort;
+  }
+
+  public void setLegacyServerPort(int legacyServerPort) {
+    this.legacyServerPort = legacyServerPort;
+  }
+
+  public int getApiPort() {
+    return apiPort;
+  }
+
+  public void setApiPort(int apiPort) {
+    this.apiPort = apiPort;
+  }
+}

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.okhttp
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.NestedConfigurationProperty
+
+@Canonical
+@ConfigurationProperties(prefix="okHttpClient")
+class OkHttpClientConfigurationProperties {
+  long connectTimoutMs = 15000
+  long readTimeoutMs = 20000
+
+  boolean propagateSpinnakerHeaders = true
+
+  File keyStore
+  String keyStoreType = 'PKCS12'
+  String keyStorePassword = 'changeit'
+
+  File trustStore
+  String trustStoreType = 'PKCS12'
+  String trustStorePassword = 'changeit'
+
+  String secureRandomInstanceType = "NativePRNGNonBlocking"
+
+  List<String> tlsVersions = ["TLSv1.2", "TLSv1.1", "TLSv1"]
+  List<String> cipherSuites = [
+    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+    "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+    "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+    "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA"
+  ]
+
+  @Canonical
+  static class ConnectionPoolProperties {
+    int maxIdleConnections = 5
+    int keepAliveDurationMs = 30000
+  }
+
+  @NestedConfigurationProperty
+  final ConnectionPoolProperties connectionPool = new ConnectionPoolProperties()
+
+  boolean retryOnConnectionFailure = true
+
+}

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/SpinnakerRequestInterceptor.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/SpinnakerRequestInterceptor.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.okhttp
+
+import com.netflix.spinnaker.security.AuthenticatedRequest
+import retrofit.RequestInterceptor
+
+class SpinnakerRequestInterceptor implements RequestInterceptor {
+  private final OkHttpClientConfigurationProperties okHttpClientConfigurationProperties
+
+  SpinnakerRequestInterceptor(OkHttpClientConfigurationProperties okHttpClientConfigurationProperties) {
+    this.okHttpClientConfigurationProperties = okHttpClientConfigurationProperties
+  }
+
+  void intercept(RequestInterceptor.RequestFacade request) {
+    if (!okHttpClientConfigurationProperties.propagateSpinnakerHeaders) {
+      // noop
+      return
+    }
+
+    AuthenticatedRequest.authenticationHeaders.each { String key, Optional<String> value ->
+      if (value.present) {
+        request.addHeader(key, value.get())
+      }
+    }
+  }
+}

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/retrofit/RetrofitConfigurationProperties.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/retrofit/RetrofitConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.archaius;
+package com.netflix.spinnaker.retrofit;
 
-import java.util.Objects;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import retrofit.RestAdapter;
 
-public class DefaultClasspathPropertySource implements ClasspathPropertySource {
-  private final String baseName;
+@ConfigurationProperties("retrofit")
+public class RetrofitConfigurationProperties {
+  RestAdapter.LogLevel logLevel = RestAdapter.LogLevel.BASIC;
 
-  public DefaultClasspathPropertySource(String baseName) {
-    this.baseName = Objects.requireNonNull(baseName, "baseName");
+  public RestAdapter.LogLevel getLogLevel() {
+    return logLevel;
   }
 
-  @Override
-  public String getBaseName() {
-    return baseName;
+  public void setLogLevel(RestAdapter.LogLevel logLevel) {
+    this.logLevel = logLevel;
   }
 }

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/retrofit/Slf4jRetrofitLogger.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/retrofit/Slf4jRetrofitLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,27 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.archaius;
+package com.netflix.spinnaker.retrofit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import retrofit.RestAdapter;
 
 import java.util.Objects;
 
-public class DefaultClasspathPropertySource implements ClasspathPropertySource {
-  private final String baseName;
+public class Slf4jRetrofitLogger implements RestAdapter.Log {
+  private final Logger logger;
 
-  public DefaultClasspathPropertySource(String baseName) {
-    this.baseName = Objects.requireNonNull(baseName, "baseName");
+  public Slf4jRetrofitLogger(Class<?> type) {
+    this(LoggerFactory.getLogger(type));
+  }
+
+  public Slf4jRetrofitLogger(Logger logger) {
+    this.logger = Objects.requireNonNull(logger);
   }
 
   @Override
-  public String getBaseName() {
-    return baseName;
+  public void log(String message) {
+    logger.info(message);
   }
 }

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/SslExtensionConfigurationProperties.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/x509/SslExtensionConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.internal;
+package com.netflix.spinnaker.tomcat.x509;
 
-public class Precondition {
-  public static <T> T notNull(T instance, String name) {
-    if (instance == null) {
-      throw new NullPointerException(name);
-    }
-    return instance;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("server.ssl")
+public class SslExtensionConfigurationProperties {
+  private String crlFile = null;
+
+  public String getCrlFile() {
+    return crlFile;
+  }
+
+  public void setCrlFile(String crlFile) {
+    this.crlFile = crlFile;
   }
 }


### PR DESCRIPTION
Step towards working with newer Spring versions that have problems working with `@Value` annotated properties, particularly at the `@Configuration` class level.

There are some changes in the lifecycle in Spring 4.3 that manifest in `@Value` annotations not reading from configuration if they have defaults set. This moves all the configuration into `@ConfigurationProperties` beans instead. Additionally it is recommended to keep `@Configuration` classes simple - to that end I've removed `@Autowired` fields in those classes and replaced with adding the appropriate parameter to whatever `@Bean` method was using the autowired value.

Other noise in this PR: removed a `Precondition` class in favor of the same functionality that is native in java 8 (`Objects.requireNonNull`)
