### PR TITLE
Always store stackdriver metrics unique per application.

### DIFF
--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/ConfigParams.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/ConfigParams.java
@@ -89,11 +89,6 @@ public class ConfigParams {
   protected long counterStartTime;
 
   /**
-   * Optional.
-   */
-  protected boolean uniqueMetricsPerApplication = true;
-
-  /**
    * Builds an instance of ConfigParams.
    */
   public static class Builder extends ConfigParams {
@@ -122,7 +117,6 @@ public class ConfigParams {
       result.customTypeNamespace
           = validateString(customTypeNamespace, "stackdriver customTypeNamespace");
 
-      result.uniqueMetricsPerApplication = uniqueMetricsPerApplication;
       result.counterStartTime = counterStartTime;
       result.measurementFilter = measurementFilter;
 
@@ -213,7 +207,6 @@ public class ConfigParams {
     /**
      * Sets the application name that we are associating these metrics with.
      *
-     * This will be the APPLICATION_LABEL value for the metrics we store.
      * It distinguishes similar metrics within a system that are coming from
      * different services.
      * (e.g. "clouddriver")
@@ -256,14 +249,6 @@ public class ConfigParams {
      */
     public Builder setDescriptorCache(MetricDescriptorCache cache) {
       descriptorCache = cache;
-      return this;
-    }
-
-    /**
-     * Distinguish application using a distinct metric type, or a Time Series label.
-     */
-    public Builder setUniqueMetricsPerApplication(boolean distinctTypes) {
-      uniqueMetricsPerApplication = distinctTypes;
       return this;
     }
 
@@ -362,13 +347,6 @@ public class ConfigParams {
    */
   public MetricDescriptorCache getDescriptorCache() {
       return descriptorCache;
-  }
-
-  /**
-   * Whether metric type specifies the application, or Time Series data should.
-   */
-  public boolean isMetricUniquePerApplication() {
-      return uniqueMetricsPerApplication;
   }
 
   /**

--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/MetricDescriptorCache.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/MetricDescriptorCache.java
@@ -49,13 +49,6 @@ import java.util.Map;
  */
 public class MetricDescriptorCache {
   /**
-   * Stackdriver Label identifying the application reporting the values.
-   *
-   * This is used when not configured for uniqueMetricsPerApplication
-   */
-  public static final String APPLICATION_LABEL = "MicroserviceSrc";
-
-  /**
    * Stackdriver Label identifying the replica instance reporting the values.
    */
   public static final String INSTANCE_LABEL = "InstanceSrc";
@@ -104,12 +97,9 @@ public class MetricDescriptorCache {
     projectResourceName = "projects/" + configParams.getProjectName();
 
     baseStackdriverMetricTypeName
-        = String.format("custom.googleapis.com/%s/",
-                        configParams.getCustomTypeNamespace());
-    if (configParams.isMetricUniquePerApplication()) {
-        baseStackdriverMetricTypeName
-            += String.format("%s/", configParams.getApplicationName());
-    }
+        = String.format("custom.googleapis.com/%s/%s/",
+                        configParams.getCustomTypeNamespace(),
+                        configParams.getApplicationName());
   }
 
   /**

--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/StackdriverWriter.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/StackdriverWriter.java
@@ -151,12 +151,6 @@ public class StackdriverWriter {
   private Predicate<Measurement> measurementFilter;
 
   /**
-   * Whether to add an APPLICATION_LABEL tag to time series data.
-   * (otherwise the application is presumed to have been captured elsewhere).
-   */
-  private boolean addApplicationLabelToTimeSeriesData;
-
-  /**
    * Constructs a writer instance.
    *
    * @param configParams
@@ -170,8 +164,6 @@ public class StackdriverWriter {
     applicationName = configParams.getApplicationName();
     instanceId = configParams.getInstanceId();
     measurementFilter = configParams.getMeasurementFilter();
-    addApplicationLabelToTimeSeriesData
-        = !configParams.isMetricUniquePerApplication();
 
     rfc3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'000000Z'");
     rfc3339.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -400,10 +392,6 @@ public class StackdriverWriter {
           monitoredResource = new MonitoredResourceBuilder()
               .setStackdriverProject(project)
               .build();
-          if (addApplicationLabelToTimeSeriesData) {
-            cache.addExtraTimeSeriesLabel(
-                MetricDescriptorCache.APPLICATION_LABEL, applicationName);
-          }
           if (monitoredResource.getType().equals("global")) {
             cache.addExtraTimeSeriesLabel(
               MetricDescriptorCache.INSTANCE_LABEL, instanceId);

--- a/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MetricDescriptorCacheTest.java
+++ b/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MetricDescriptorCacheTest.java
@@ -129,8 +129,6 @@ public class MetricDescriptorCacheTest {
 
     List<LabelDescriptor> labels = new ArrayList<LabelDescriptor>();
     LabelDescriptor labelDescriptor = new LabelDescriptor();
-    labelDescriptor.setKey(MetricDescriptorCache.APPLICATION_LABEL);
-    labelDescriptor.setValueType("STRING");
     labelDescriptor.setKey(MetricDescriptorCache.INSTANCE_LABEL);
     labelDescriptor.setValueType("STRING");
     labels.add(labelDescriptor);

--- a/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/StackdriverWriterTest.java
+++ b/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/StackdriverWriterTest.java
@@ -226,7 +226,6 @@ public class StackdriverWriterTest {
     point.setInterval(timeInterval);
 
     HashMap<String, String> labels = new HashMap<String, String>();
-    labels.put(MetricDescriptorCache.APPLICATION_LABEL, applicationName);
     labels.put(MetricDescriptorCache.INSTANCE_LABEL, INSTANCE_ID);
     for (Tag tag : id.tags()) {
       labels.put(tag.key(), tag.value());
@@ -287,8 +286,6 @@ public class StackdriverWriterTest {
     Measurement measureAXY = new Measurement(idAXY, millisA, 1);
     Measurement measureBXY = new Measurement(idBXY, millisB, 20.1);
 
-    descriptorRegistrySpy.addExtraTimeSeriesLabel(
-        MetricDescriptorCache.APPLICATION_LABEL, applicationName);
     descriptorRegistrySpy.addExtraTimeSeriesLabel(
         MetricDescriptorCache.INSTANCE_LABEL, INSTANCE_ID);
     


### PR DESCRIPTION
Also, change the default instanceid to be <server>:<port> which is more
readable than a UUID but still unique at any given point in time.

@ttomsu