### PR TITLE
fix(ssl): improve TLS configuration

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy
@@ -49,6 +49,9 @@ class TomcatConfiguration {
   EmbeddedServletContainerCustomizer containerCustomizer(OkHttpClientConfigurationProperties okHttpClientConfigurationProperties,
                                                          TomcatConfigurationProperties tomcatConfigurationProperties,
                                                          SslExtensionConfigurationProperties sslExtensionConfigurationProperties) throws Exception {
+    System.setProperty("jdk.tls.rejectClientInitiatedRenegotiation", "true")
+    System.setProperty("jdk.tls.ephemeralDHKeySize", "2048")
+
     return { ConfigurableEmbeddedServletContainer container ->
       TomcatEmbeddedServletContainerFactory tomcat = (TomcatEmbeddedServletContainerFactory) container
       //this will only handle the case where SSL is enabled on the main tomcat connector
@@ -58,6 +61,7 @@ class TomcatConfiguration {
           def handler = connector.getProtocolHandler()
           if (handler instanceof AbstractHttp11JsseProtocol) {
             if (handler.isSSLEnabled()) {
+              handler.setProperty("useServerCipherSuitesOrder", "true")
               handler.setProperty("sslEnabledProtocols", okHttpClientConfigurationProperties.tlsVersions.join(","))
               handler.setCiphers(okHttpClientConfigurationProperties.cipherSuites.join(","))
               handler.setSslImplementationName(BlacklistingSSLImplementation.name)

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
@@ -38,20 +38,24 @@ class OkHttpClientConfigurationProperties {
 
   String secureRandomInstanceType = "NativePRNGNonBlocking"
 
-  List<String> tlsVersions = ["TLSv1.2", "TLSv1.1", "TLSv1"]
+  List<String> tlsVersions = ["TLSv1.2", "TLSv1.1"]
+  //Defaults from https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+  // with some extra ciphers (non SHA384/256) to support TLSv1.1 and some non EC ciphers
   List<String> cipherSuites = [
-    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-    "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
     "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
     "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-    "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
-    "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
-    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
-    "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA"
+    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"
   ]
 
   @Canonical


### PR DESCRIPTION
* update default cipher suites to mozilla modern TLS recommendation.
* prefer server cipher suite order
* add jdk.tls System properties to Tomcat initializer (reject client renegotiation and increase DH key size)