### PR TITLE
feat(swagger): makes base and documentation paths configurable

### DIFF
--- a/kork-swagger/src/main/java/com/netflix/spinnaker/config/SwaggerConfig.java
+++ b/kork-swagger/src/main/java/com/netflix/spinnaker/config/SwaggerConfig.java
@@ -24,6 +24,7 @@ import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.paths.AbstractPathProvider;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 import com.google.common.base.Predicate;
@@ -42,10 +43,13 @@ public class SwaggerConfig {
   private String description;
   private String contact;
   private List<String> patterns;
+  private String basePath = "";
+  private String documentationPath = "/";
 
   @Bean
   public Docket gateApi() {
     return new Docket(DocumentationType.SWAGGER_2)
+      .pathProvider(new BasePathProvider(basePath, documentationPath))
       .select()
       .apis(RequestHandlerSelectors.any())
       .paths(paths())
@@ -89,5 +93,33 @@ public class SwaggerConfig {
 
   public void setPatterns(List<String> patterns) {
     this.patterns = patterns;
+  }
+
+  public void setBasePath(String basePath) { this.basePath = basePath; }
+
+  public String getBasePath() { return basePath; }
+
+  public void setDocumentationPath(String documentationPath) { this.documentationPath = documentationPath; }
+
+  public String getDocumentationPath() { return documentationPath; }
+
+  public class BasePathProvider extends AbstractPathProvider {
+    private String basePath;
+    private String documentationPath;
+
+    private BasePathProvider(String basePath, String documentationPath) {
+      this.basePath = basePath;
+      this.documentationPath = documentationPath;
+    }
+
+    @Override
+    protected String applicationPath() {
+      return basePath;
+    }
+
+    @Override
+    protected String getDocumentationPath() {
+      return documentationPath;
+    }
   }
 }


### PR DESCRIPTION
@duftler or @jtk54 please review.

The generated API doc endpoints have an extra slash (e.g. `localhost:8084//applications`), since `basePath` is `/` by default.

The swagger UI seems to be a little smarter and isn't affected by this change.