### PR TITLE
chore(swagger): Upgrade swagger libraries to ones that don't produce …

### DIFF
--- a/kork-swagger/kork-swagger.gradle
+++ b/kork-swagger/kork-swagger.gradle
@@ -1,6 +1,5 @@
 dependencies {
   compile spinnaker.dependency('bootAutoConfigure')
-  compile "io.springfox:springfox-swagger2:2.2.2"
-  compile "io.springfox:springfox-swagger-ui:2.2.2"
-  compile "com.wordnik:swagger-annotations:1.3.13"
+  compile "io.springfox:springfox-swagger2:2.7.0"
+  compile "io.springfox:springfox-swagger-ui:2.7.0"
 }


### PR DESCRIPTION
…crappy HTML

I removed the wordnik dep because [this search](https://github.com/search?q=org%3Aspinnaker+wordnik&type=Code) only revealed that it's used in Tide. 

tag: https://github.com/spinnaker/spinnaker.github.io/issues/196