### PR TITLE
refactor(tls): refactor tomcat connector init into util class.

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/TomcatContainerCustomizerUtil.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/TomcatContainerCustomizerUtil.groovy
@@ -1,0 +1,52 @@
+package com.netflix.spinnaker.tomcat
+
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
+import com.netflix.spinnaker.tomcat.x509.BlacklistingSSLImplementation
+import com.netflix.spinnaker.tomcat.x509.SslExtensionConfigurationProperties
+import org.apache.catalina.connector.Connector
+import org.apache.coyote.http11.AbstractHttp11JsseProtocol
+import org.apache.tomcat.util.net.SSLHostConfig
+import org.springframework.boot.context.embedded.Ssl
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory
+
+class TomcatContainerCustomizerUtil {
+
+  private final OkHttpClientConfigurationProperties okHttpClientConfigurationProperties
+  private final SslExtensionConfigurationProperties sslExtensionConfigurationProperties
+
+  TomcatContainerCustomizerUtil(OkHttpClientConfigurationProperties okHttpClientConfigurationProperties,
+                                SslExtensionConfigurationProperties sslExtensionConfigurationProperties) {
+    this.okHttpClientConfigurationProperties = okHttpClientConfigurationProperties
+    this.sslExtensionConfigurationProperties = sslExtensionConfigurationProperties
+  }
+
+  Ssl copySslConfigurationWithClientAuth(TomcatEmbeddedServletContainerFactory tomcat) {
+    def ssl = new Ssl()
+    tomcat.ssl.properties.each { k, v ->
+      try {
+        ssl."${k}" = v
+      } catch (ReadOnlyPropertyException ignored) {}
+    }
+    ssl.clientAuth = Ssl.ClientAuth.NEED
+    ssl.setCiphers(okHttpClientConfigurationProperties.cipherSuites as String[])
+    return ssl
+  }
+
+  void applySSLSettings(Connector connector) {
+    def handler = connector.getProtocolHandler()
+    if (handler instanceof AbstractHttp11JsseProtocol) {
+      if (handler.isSSLEnabled()) {
+        def sslConfigs = connector.findSslHostConfigs()
+        if (sslConfigs.size() != 1) {
+          throw new RuntimeException("Ssl configs: found ${sslConfigs.size()}, expected 1.")
+        }
+        handler.setSslImplementationName(BlacklistingSSLImplementation.name)
+        SSLHostConfig sslHostConfig = sslConfigs.first()
+        sslHostConfig.setHonorCipherOrder("true")
+        sslHostConfig.ciphers = okHttpClientConfigurationProperties.cipherSuites.join(",")
+        sslHostConfig.setProtocols(okHttpClientConfigurationProperties.tlsVersions.join(","))
+        sslHostConfig.setCertificateRevocationListFile(sslExtensionConfigurationProperties.getCrlFile())
+      }
+    }
+  }
+}


### PR DESCRIPTION
Allows for additional connector customizers in extension code to reuse
common TLS configuration code.

Installed this locally in gate and tested via sslyze that allthethings are still right on the SSL front.