### PR TITLE
feat(artifacts): Add useDefaultArtifact flag

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.StringUtils;
 public class ExpectedArtifact {
   Artifact matchArtifact;
   boolean usePriorArtifact;
+  boolean useDefaultArtifact;
   Artifact defaultArtifact;
 
   /**


### PR DESCRIPTION
I realized this makes rendering the artifacts a lot easier. Without this flag, a user would have to delete/clear the "DefaultArtifact" contents to avoid specifying a default. If they change their mind, they need to go back and add all the fields in again.