### PR TITLE
feat(artifacts): add boundArtifact to expectedArtifact

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -34,6 +34,7 @@ public class ExpectedArtifact {
   boolean useDefaultArtifact;
   Artifact defaultArtifact;
   String id; // UUID to use this ExpectedArtifact by reference in Pipelines.
+  Artifact boundArtifact;
 
   /**
    * Decide if the "matchArtifact" matches the incoming artifact. Any fields not specified


### PR DESCRIPTION
This allows us to associate each expected artifact with the artifact it
matched. The goal is to ensure that the artifacts are resolved only
once, when they are first declared (either in the trigger config, or
stage config).