### PR TITLE
fix(security): Filter out empty roles when building authorities

### DIFF
--- a/kork-security/src/main/java/com/netflix/spinnaker/security/User.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/User.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+
 import static java.util.Collections.unmodifiableCollection;
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
@@ -44,7 +46,11 @@ public class User implements UserDetails {
 
   @Override
   public List<? extends GrantedAuthority> getAuthorities() {
-    return roles.stream().map(SimpleGrantedAuthority::new).collect(toList());
+    return roles
+      .stream()
+      .filter(StringUtils::hasText)
+      .map(SimpleGrantedAuthority::new)
+      .collect(toList());
   }
 
   /**

--- a/kork-security/src/test/groovy/com/netflix/spinnaker/security/UserSpec.groovy
+++ b/kork-security/src/test/groovy/com/netflix/spinnaker/security/UserSpec.groovy
@@ -65,4 +65,11 @@ class UserSpec extends Specification {
     then:
       user.username == "username"
   }
+
+  def "should filter out empty roles"() {
+    expect:
+      new User(roles: [""]).getAuthorities().isEmpty()
+      new User(roles: ["", "bar"]).getAuthorities()*.getAuthority() == ["bar"]
+      new User(roles: ["foo", "", "bar"]).getAuthorities()*.getAuthority() == ["foo", "bar"]
+  }
 }


### PR DESCRIPTION
`new SimpleGrantedAuthority()` will fail when passed `""`.