### PR TITLE
feat(core): Jackson subtype configurer

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/InvalidSubtypeConfigurationException.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/InvalidSubtypeConfigurationException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jackson;
+
+/**
+ * Thrown when an ObjectMapperSubtypeConfigurer finds a subtype without a JsonTypeName annotation.
+ */
+public class InvalidSubtypeConfigurationException extends IllegalStateException {
+
+  public InvalidSubtypeConfigurationException(String s) {
+    super(s);
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/ObjectMapperSubtypeConfigurer.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/ObjectMapperSubtypeConfigurer.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jackson;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.util.ClassUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Handles discovery and registration of ObjectMapper subtypes.
+ *
+ * Using the NAME JsonTypeInfo strategy, each subtype needs to be defined
+ * explicitly. If all subtypes are known at compile time, the subtypes should
+ * be defined on the root type. However, Spinnaker often times offers
+ * addition of new types, which may require scanning different packages for
+ * additional subtypes. This class will assist this specific task.
+ */
+public class ObjectMapperSubtypeConfigurer {
+
+  private final static Logger log = LoggerFactory.getLogger(ObjectMapperSubtypeConfigurer.class);
+
+  private boolean strictSerialization;
+
+  public ObjectMapperSubtypeConfigurer(boolean strictSerialization) {
+    this.strictSerialization = strictSerialization;
+  }
+
+  public void registerSubtypes(ObjectMapper mapper, List<SubtypeLocator> subtypeLocators) {
+    subtypeLocators.forEach(locator -> registerSubtype(mapper, locator));
+  }
+
+  public void registerSubtype(ObjectMapper mapper, SubtypeLocator subtypeLocator) {
+    subtypeLocator.searchPackages().forEach(pkg -> mapper.registerSubtypes(findSubtypes(subtypeLocator.rootType(), pkg)));
+  }
+
+  private NamedType[] findSubtypes(Class<?> clazz, String pkg) {
+    ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false);
+    provider.addIncludeFilter(new AssignableTypeFilter(clazz));
+
+    return provider.findCandidateComponents(pkg).stream()
+      .map(bean -> {
+        Class<?> cls = ClassUtils.resolveClassName(bean.getBeanClassName(), ClassUtils.getDefaultClassLoader());
+
+        JsonTypeName nameAnnotation = cls.getAnnotation(JsonTypeName.class);
+        if (nameAnnotation == null || "".equals(nameAnnotation.value())) {
+          String message = "Subtype " + cls.getSimpleName() + " does not have a JsonTypeName annotation";
+          if (strictSerialization) {
+            throw new InvalidSubtypeConfigurationException(message);
+          }
+          log.warn(message);
+          return null;
+        }
+
+        return new NamedType(cls, nameAnnotation.value());
+      })
+      .filter(Objects::nonNull)
+      .toArray(NamedType[]::new);
+  }
+
+  /**
+   * Allows configuring subtypes either programmatically with Class or configuration-backed strings.
+   */
+  public interface SubtypeLocator {
+    Class<?> rootType();
+    List<String> searchPackages();
+  }
+
+  public static class ClassSubtypeLocator implements SubtypeLocator {
+
+    private final Class<?> rootType;
+    private final List<String> searchPackages;
+
+    public ClassSubtypeLocator(Class<?> rootType, List<String> searchPackages) {
+      this.rootType = rootType;
+      this.searchPackages = searchPackages;
+    }
+
+    @Override
+    public Class<?> rootType() {
+      return rootType;
+    }
+
+    @Override
+    public List<String> searchPackages() {
+      return searchPackages;
+    }
+  }
+
+  public static class StringSubtypeLocator implements SubtypeLocator {
+
+    private final String rootTypeName;
+    private final List<String> searchPackages;
+
+    public StringSubtypeLocator(String rootTypeName, List<String> searchPackages) {
+      this.rootTypeName = rootTypeName;
+      this.searchPackages = searchPackages;
+    }
+
+    @Override
+    public Class<?> rootType() {
+      return ClassUtils.resolveClassName(rootTypeName, ClassUtils.getDefaultClassLoader());
+    }
+
+    @Override
+    public List<String> searchPackages() {
+      return searchPackages;
+    }
+  }
+}

--- a/kork-core/src/test/java/com/netflix/spinnaker/kork/jackson/ObjectMapperSubtypeConfigurerTest.java
+++ b/kork-core/src/test/java/com/netflix/spinnaker/kork/jackson/ObjectMapperSubtypeConfigurerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jackson;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer.ClassSubtypeLocator;
+import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer.StringSubtypeLocator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ObjectMapperSubtypeConfigurerTest {
+
+  ObjectMapper mapper;
+
+  @Before
+  public void setup() {
+    mapper = new ObjectMapper();
+  }
+
+  @Test
+  public void shouldRegisterSubtypesByClass() throws JsonProcessingException {
+    new ObjectMapperSubtypeConfigurer(true).registerSubtype(
+      mapper,
+      new ClassSubtypeLocator(RootType.class, searchPackages())
+    );
+
+    assertEquals("{\"kind\":\"child\"}", mapper.writeValueAsString(new ChildType()));
+  }
+
+  @Test
+  public void shouldRegisterSubtypesByName() throws JsonProcessingException {
+    new ObjectMapperSubtypeConfigurer(true).registerSubtype(
+      mapper,
+      new StringSubtypeLocator("com.netflix.spinnaker.kork.jackson.RootType", searchPackages())
+    );
+
+    assertEquals("{\"kind\":\"child\"}", mapper.writeValueAsString(new ChildType()));
+  }
+
+  @Test(expected = InvalidSubtypeConfigurationException.class)
+  public void shouldThrowWhenSubtypeNameIsUndefined() {
+    new ObjectMapperSubtypeConfigurer(true).registerSubtype(
+      mapper,
+      new ClassSubtypeLocator(UndefinedRootType.class, searchPackages())
+    );
+  }
+
+  List<String> searchPackages() {
+    List<String> searchPackages = new ArrayList<>();
+    searchPackages.add("com.netflix.spinnaker.kork.jackson");
+    return searchPackages;
+  }
+}
+
+@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "kind")
+abstract class RootType {}
+
+@JsonTypeName("child")
+class ChildType extends RootType {}
+
+@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "kind")
+class UndefinedRootType {}
+
+class UndefinedType extends UndefinedRootType {}


### PR DESCRIPTION
Lifting the same functionality out from Keiko into kork. Swabbie has need for this, but not Keiko, and Keel needs this in `keel-core`, but doesn't have Keiko in that module. Ported from Kotlin to avoid any weirdness.

https://github.com/spinnaker/keiko/blob/master/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/SpringObjectMapperConfigurer.kt