### PR TITLE
feat(redis): Adding jedis/dynomite client factories

### DIFF
--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientFactory.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.dyno.connectionpool.impl.ConnectionPoolConfigurationImpl;
+import com.netflix.dyno.jedis.DynoJedisClient;
+import com.netflix.spinnaker.kork.jedis.exception.MissingRequiredConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class DynomiteClientFactory {
+
+  private final Logger log = LoggerFactory.getLogger(DynomiteClientFactory.class);
+
+  private DynomiteConfigurationProperties properties;
+  private ConnectionPoolConfigurationImpl connectionPoolConfiguration;
+  private DiscoveryClient discoveryClient;
+
+  public DynomiteClientFactory properties(DynomiteConfigurationProperties properties) {
+    this.properties = properties;
+    return this;
+  }
+
+  public DynomiteClientFactory connectionPoolConfiguration(ConnectionPoolConfigurationImpl connectionPoolConfiguration) {
+    this.connectionPoolConfiguration = connectionPoolConfiguration;
+    return this;
+  }
+
+  public DynomiteClientFactory discoveryClient(DiscoveryClient discoveryClient) {
+    this.discoveryClient = discoveryClient;
+    return this;
+  }
+
+  public DynoJedisClient build() {
+    if (properties == null) {
+      throw new MissingRequiredConfiguration("Dynomite client must have properties to be built");
+    }
+
+    DynoJedisClient.Builder builder = new DynoJedisClient.Builder()
+      .withApplicationName(properties.applicationName)
+      .withDynomiteClusterName(properties.clusterName);
+
+    if (!"{}".equals(connectionPoolConfiguration.getHashtag())) {
+      // I don't really want to make the assumption all of our services will use hashtags, but they probably will...
+      log.warn("Hashtag value has not been set. This will likely lead to inconsistent operations.");
+    }
+
+    Optional<DiscoveryClient> discovery = getDiscoveryClient();
+    if (discovery.isPresent()) {
+      builder.withDiscoveryClient(discovery.get());
+    } else {
+      connectionPoolConfiguration
+        .withTokenSupplier(new StaticTokenMapSupplier(properties.getDynoHostTokens()))
+        .setLocalDataCenter(properties.localDatacenter)
+        .setLocalRack(properties.localRack);
+
+      builder
+        .withHostSupplier(new StaticHostSupplier(properties.getDynoHosts()));
+    }
+
+    builder.withCPConfig(connectionPoolConfiguration);
+
+    return builder.build();
+  }
+
+  private Optional<DiscoveryClient> getDiscoveryClient() {
+    if (properties.forceUseStaticHosts) {
+      return Optional.empty();
+    }
+    return Optional.of(discoveryClient);
+  }
+}

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteConfigurationProperties.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteConfigurationProperties.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.netflix.dyno.connectionpool.Host.DEFAULT_PORT;
+import static com.netflix.dyno.connectionpool.Host.Status;
+
+public class DynomiteConfigurationProperties {
+
+  private final static String LOCAL_RACK = "localrack";
+  private final static String LOCAL_DATACENTER = "localrac";
+
+  public boolean enabled = false;
+
+  public String applicationName;
+  public String clusterName;
+
+  public String localRack = LOCAL_RACK;
+  public String localDatacenter = LOCAL_DATACENTER;
+
+  public boolean forceUseStaticHosts = false;
+  public List<DynoHost> hosts = new ArrayList<>();
+
+  public List<Host> getDynoHosts() {
+    return hosts.stream()
+      .map(it -> new Host(it.hostname, it.ipAddress, it.port, it.rack, it.datacenter, it.status, it.hashtag))
+      .collect(Collectors.toList());
+  }
+
+  public List<HostToken> getDynoHostTokens() {
+    List<HostToken> tokens = new ArrayList<>();
+    List<Host> dynoHosts = getDynoHosts();
+    for (int i = 0; i < dynoHosts.size(); i++) {
+      tokens.add(new HostToken(hosts.get(i).token, dynoHosts.get(i)));
+    }
+    return tokens;
+  }
+
+  static class DynoHost {
+    public String hostname;
+    public String ipAddress;
+    public int port = DEFAULT_PORT;
+    public Status status = Status.Up;
+    public String rack = LOCAL_RACK;
+    public String datacenter = LOCAL_DATACENTER;
+    public Long token = 1000000L;
+    public String hashtag = "{}";
+  }
+}

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteHealthIndicatorFactory.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteHealthIndicatorFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+
+public class DynomiteHealthIndicatorFactory {
+
+  public static HealthIndicator build() {
+    // TODO rz - Haven't really figured out a good healthcheck strategy for dynomite yet.
+    return Health.up()::build;
+  }
+}

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/StaticHostSupplier.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/StaticHostSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.HostSupplier;
+
+import java.util.Collection;
+import java.util.List;
+
+public class StaticHostSupplier implements HostSupplier {
+
+  private final List<Host> hosts;
+
+  public StaticHostSupplier(List<Host> hosts) {
+    this.hosts = hosts;
+  }
+
+  @Override
+  public Collection<Host> getHosts() {
+    return hosts;
+  }
+}

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/StaticTokenMapSupplier.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/StaticTokenMapSupplier.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.TokenMapSupplier;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+
+import java.util.List;
+import java.util.Set;
+
+public class StaticTokenMapSupplier implements TokenMapSupplier {
+
+  private final List<HostToken> hostTokens;
+
+  public StaticTokenMapSupplier(List<HostToken> hostTokens) {
+    this.hostTokens = hostTokens;
+  }
+
+  @Override
+  public List<HostToken> getTokens(Set<Host> activeHosts) {
+    return hostTokens;
+  }
+
+  @Override
+  public HostToken getTokenForHost(final Host host, final Set<Host> activeHosts) {
+    for (HostToken hostToken : hostTokens) {
+      if (hostToken.getHost().compareTo(host) == 0) {
+        return hostToken;
+      }
+    }
+    return null;
+  }
+}

--- a/kork-jedis/kork-jedis.gradle
+++ b/kork-jedis/kork-jedis.gradle
@@ -1,3 +1,5 @@
 dependencies {
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('spectatorApi')
   compile spinnaker.dependency('jedis')
 }

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisHealthIndicatorFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisHealthIndicatorFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import redis.clients.jedis.Jedis;
+import redis.clients.util.Pool;
+
+import java.lang.reflect.Field;
+
+public class JedisHealthIndicatorFactory {
+
+  public static HealthIndicator build(Pool<Jedis> jedisPool) {
+    try {
+      final Pool<Jedis> src = jedisPool;
+      final Field poolAccess = Pool.class.getDeclaredField("internalPool");
+      poolAccess.setAccessible(true);
+      GenericObjectPool<Jedis> internal = (GenericObjectPool<Jedis>) poolAccess.get(jedisPool);
+      return () -> {
+        Jedis jedis = null;
+        Health.Builder health;
+        try {
+          jedis = src.getResource();
+          if ("PONG".equals(jedis.ping())) {
+            health = Health.up();
+          } else {
+            health = Health.down();
+          }
+        } catch (Exception ex) {
+          health = Health.down(ex);
+        } finally {
+          if (jedis != null) jedis.close();
+        }
+        health.withDetail("maxIdle", internal.getMaxIdle());
+        health.withDetail("minIdle", internal.getMinIdle());
+        health.withDetail("numActive", internal.getNumActive());
+        health.withDetail("numIdle", internal.getNumIdle());
+        health.withDetail("numWaiters", internal.getNumWaiters());
+
+        return health.build();
+      };
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new BeanCreationException("Error creating Redis health indicator", e);
+    }
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.kork.jedis.exception.ConflictingConfiguration;
+import com.netflix.spinnaker.kork.jedis.exception.MissingRequiredConfiguration;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Protocol;
+import redis.clients.util.Pool;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class JedisPoolFactory {
+
+  private GenericObjectPoolConfig poolConfig;
+  private RedisConfigurationProperties properties;
+  private Registry registry;
+
+  public JedisPoolFactory poolConfig(GenericObjectPoolConfig poolConfig) {
+    this.poolConfig = poolConfig;
+    return this;
+  }
+
+  public JedisPoolFactory properties(RedisConfigurationProperties properties) {
+    this.properties = properties;
+    return this;
+  }
+
+  public JedisPoolFactory registry(Registry registry) {
+    this.registry = registry;
+    return this;
+  }
+
+  public Pool<Jedis> build() {
+    if (registry == null) {
+      throw new MissingRequiredConfiguration("registry");
+    }
+    if (properties == null) {
+      properties = new RedisConfigurationProperties();
+    }
+    if (properties.connection == null || "".equals(properties.connection)) {
+      throw new MissingRequiredConfiguration("Jedis client must have a connection defined");
+    }
+    if (properties.sentinel.enabled && properties.cluster.enabled) {
+      throw new ConflictingConfiguration("Jedis client cannot have sentinel and cluster flags enabled at the same time");
+    }
+    if (properties.sentinel.enabled || properties.cluster.enabled) {
+      // rz - Added the configuration for Sentinel and Cluster as a carrot for someone to validate these topologies
+      // actually work. I figure having the configurations, then exploding before people can actually start services
+      // will be better than just not addressing it at all.
+      throw new UnsupportedConnectionStrategy("Support has not been verified for Sentinel or Cluster connections");
+    }
+
+    URI redisConnection = URI.create(properties.connection);
+
+    String host = redisConnection.getHost();
+    int port = redisConnection.getPort() == -1 ? Protocol.DEFAULT_PORT : redisConnection.getPort();
+    int database = parseDatabase(redisConnection.getPath());
+    String password = parsePassword(redisConnection.getUserInfo());
+    GenericObjectPoolConfig objectPoolConfig = Optional.ofNullable(poolConfig).orElse(new GenericObjectPoolConfig());
+
+    return new JedisPool(objectPoolConfig, host, port, properties.timeoutMs, password, database, properties.name);
+  }
+
+  private static int parseDatabase(String path) {
+    if (path == null) {
+      return 0;
+    }
+    return Integer.parseInt(("/" + Protocol.DEFAULT_DATABASE).split("/", 2)[1]);
+  }
+
+  private static String parsePassword(String userInfo) {
+    if (userInfo == null) {
+      return null;
+    }
+    return userInfo.split(":", 2)[1];
+  }
+
+  static class UnsupportedConnectionStrategy extends IllegalStateException {
+    UnsupportedConnectionStrategy(String s) {
+      super(s);
+    }
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisConfigurationProperties.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisConfigurationProperties.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+public class RedisConfigurationProperties {
+  public String name;
+  public String connection;
+  public int timeoutMs = 2000;
+
+  public SentinelProperties sentinel = new SentinelProperties();
+  public ClusterProperties cluster = new ClusterProperties();
+
+  public static class SentinelProperties {
+    public boolean enabled = false;
+  }
+
+  public static class ClusterProperties {
+    public boolean enabled = false;
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/ConflictingConfiguration.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/ConflictingConfiguration.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis.exception;
+
+public class ConflictingConfiguration extends IllegalStateException {
+  public ConflictingConfiguration(String s) {
+    super(s);
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/MissingRequiredConfiguration.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/MissingRequiredConfiguration.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis.exception;
+
+public class MissingRequiredConfiguration extends IllegalStateException {
+  public MissingRequiredConfiguration(String configuration) {
+    super("Missing required Jedis client configuration '" + configuration + "'");
+  }
+}


### PR DESCRIPTION
This is mostly just a lift of clouddriver's Redis & Dynomite configs. I'd like to add another layer on top that would be Spring-y that would offer something more like the following, but also have classes (seen in this PR) that can be used to drive our current configs.

```yaml
# clouddriver.yml
cache:
  primary:
    driver: dynomite
    applicationName: clouddriver
    clusterName: dyno_clouddriver_main
  previous:
    driver: redis
    connection: redis://localhost:6379
  

taskRepository:
  primary:
    driver: redis
    connection: redis://localhost:6379
```

Rather than defining a single location for redis configs, so we can better control what we're migrating at certain times or using vanilla Redis where we don't think Dynomite may be worth the overhead, etc.