### PR TITLE
feat(redis): Adding jedis/dynomite client factories

### DIFF
--- a/kork-dynomite/kork-dynomite.gradle
+++ b/kork-dynomite/kork-dynomite.gradle
@@ -1,4 +1,10 @@
 dependencies {
   compile project(":kork-jedis")
-  compile spinnaker.dependency("dynomite")
+  compile("com.netflix.dyno:dyno-jedis:1.6.0") {
+    exclude group: 'joda-time'
+    exclude group: 'org.apache.httpcomponents'
+    exclude group: 'org.slf4j'
+  }
+
+  testCompile spinnaker.dependency('junit')
 }

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientConfiguration.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.spinnaker.kork.jedis.RedisClientConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+@Configuration
+@Import(RedisClientConfiguration.class)
+public class DynomiteClientConfiguration {
+
+  @Bean
+  DynomiteClientDelegateFactory dynomiteClientDelegateFactory(ObjectMapper objectMapper,
+                                                              Optional<DiscoveryClient> discoveryClient) {
+    return new DynomiteClientDelegateFactory(objectMapper, discoveryClient.get());
+  }
+}

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientDelegate.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientDelegate.java
@@ -27,10 +27,21 @@ import java.util.function.Function;
 
 public class DynomiteClientDelegate implements RedisClientDelegate {
 
+  private final String name;
   private final DynoJedisClient client;
 
   public DynomiteClientDelegate(DynoJedisClient client) {
+    this("default", client);
+  }
+
+  public DynomiteClientDelegate(String name, DynoJedisClient client) {
+    this.name = name;
     this.client = client;
+  }
+
+  @Override
+  public String name() {
+    return name;
   }
 
   @Override

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientDelegateFactory.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientDelegateFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegateFactory;
+import com.netflix.spinnaker.kork.jedis.RedisClientConfiguration.Driver;
+
+import java.util.Map;
+
+import static com.netflix.spinnaker.kork.jedis.RedisClientConfiguration.Driver.DYNOMITE;
+
+public class DynomiteClientDelegateFactory implements RedisClientDelegateFactory<DynomiteClientDelegate> {
+
+  private ObjectMapper objectMapper;
+  private DiscoveryClient discoveryClient;
+
+  public DynomiteClientDelegateFactory(ObjectMapper objectMapper, DiscoveryClient discoveryClient) {
+    this.objectMapper = objectMapper;
+    this.discoveryClient = discoveryClient;
+  }
+
+  @Override
+  public boolean supports(Driver driver) {
+    return driver == DYNOMITE;
+  }
+
+  @Override
+  public DynomiteClientDelegate build(String name, Map<String, Object> properties) {
+    DynomiteDriverProperties props = objectMapper.convertValue(properties, DynomiteDriverProperties.class);
+    return new DynomiteClientDelegate(
+      name,
+      new DynomiteClientFactory().discoveryClient(discoveryClient).build(props)
+    );
+  }
+}

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientFactory.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.dyno.jedis.DynoJedisClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class DynomiteClientFactory {
+
+  private final Logger log = LoggerFactory.getLogger(DynomiteClientFactory.class);
+
+  private DynomiteDriverProperties properties;
+  private DiscoveryClient discoveryClient;
+
+  public DynomiteClientFactory properties(DynomiteDriverProperties properties) {
+    this.properties = properties;
+    return this;
+  }
+
+  public DynomiteClientFactory discoveryClient(DiscoveryClient discoveryClient) {
+    this.discoveryClient = discoveryClient;
+    return this;
+  }
+
+  public DynoJedisClient build(DynomiteDriverProperties properties) {
+    DynoJedisClient.Builder builder = new DynoJedisClient.Builder()
+      .withApplicationName(properties.applicationName)
+      .withDynomiteClusterName(properties.clusterName);
+
+    if (!"{}".equals(properties.connectionPool.getHashtag())) {
+      // I don't really want to make the assumption all of our services will use hashtags, but they probably will...
+      log.warn("Hashtag value has not been set. This will likely lead to inconsistent operations.");
+    }
+
+    Optional<DiscoveryClient> discovery = getDiscoveryClient();
+    if (discovery.isPresent()) {
+      builder.withDiscoveryClient(discovery.get());
+    } else {
+      properties.connectionPool
+        .withTokenSupplier(new StaticTokenMapSupplier(properties.getDynoHostTokens()))
+        .setLocalDataCenter(properties.localDatacenter)
+        .setLocalRack(properties.localRack);
+
+      builder
+        .withHostSupplier(new StaticHostSupplier(properties.getDynoHosts()));
+    }
+
+    builder.withCPConfig(properties.connectionPool);
+
+    return builder.build();
+  }
+
+  private Optional<DiscoveryClient> getDiscoveryClient() {
+    if (properties.forceUseStaticHosts) {
+      return Optional.empty();
+    }
+    return Optional.of(discoveryClient);
+  }
+}

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteDriverProperties.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteDriverProperties.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.impl.ConnectionPoolConfigurationImpl;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.netflix.dyno.connectionpool.Host.DEFAULT_PORT;
+import static com.netflix.dyno.connectionpool.Host.Status;
+
+public class DynomiteDriverProperties {
+
+  private final static String LOCAL_RACK = "localrack";
+  private final static String LOCAL_DATACENTER = "localrac";
+
+  public String applicationName;
+  public String clusterName;
+
+  public String localRack = LOCAL_RACK;
+  public String localDatacenter = LOCAL_DATACENTER;
+
+  public boolean forceUseStaticHosts = false;
+  public List<DynoHost> hosts = new ArrayList<>();
+
+  public ConnectionPoolConfigurationImpl connectionPool;
+
+  public List<Host> getDynoHosts() {
+    return hosts.stream()
+      .map(it -> new Host(it.hostname, it.ipAddress, it.port, it.rack, it.datacenter, it.status, it.hashtag))
+      .collect(Collectors.toList());
+  }
+
+  public List<HostToken> getDynoHostTokens() {
+    List<HostToken> tokens = new ArrayList<>();
+    List<Host> dynoHosts = getDynoHosts();
+    for (int i = 0; i < dynoHosts.size(); i++) {
+      tokens.add(new HostToken(hosts.get(i).token, dynoHosts.get(i)));
+    }
+    return tokens;
+  }
+
+  static class DynoHost {
+    public String hostname;
+    public String ipAddress;
+    public int port = DEFAULT_PORT;
+    public Status status = Status.Up;
+    public String rack = LOCAL_RACK;
+    public String datacenter = LOCAL_DATACENTER;
+    public Long token = 1000000L;
+    public String hashtag = "{}";
+  }
+}

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/StaticHostSupplier.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/StaticHostSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.HostSupplier;
+
+import java.util.Collection;
+import java.util.List;
+
+public class StaticHostSupplier implements HostSupplier {
+
+  private final List<Host> hosts;
+
+  public StaticHostSupplier(List<Host> hosts) {
+    this.hosts = hosts;
+  }
+
+  @Override
+  public Collection<Host> getHosts() {
+    return hosts;
+  }
+}

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/StaticTokenMapSupplier.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/StaticTokenMapSupplier.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.dynomite;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.TokenMapSupplier;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+
+import java.util.List;
+import java.util.Set;
+
+public class StaticTokenMapSupplier implements TokenMapSupplier {
+
+  private final List<HostToken> hostTokens;
+
+  public StaticTokenMapSupplier(List<HostToken> hostTokens) {
+    this.hostTokens = hostTokens;
+  }
+
+  @Override
+  public List<HostToken> getTokens(Set<Host> activeHosts) {
+    return hostTokens;
+  }
+
+  @Override
+  public HostToken getTokenForHost(final Host host, final Set<Host> activeHosts) {
+    for (HostToken hostToken : hostTokens) {
+      if (hostToken.getHost().compareTo(host) == 0) {
+        return hostToken;
+      }
+    }
+    return null;
+  }
+}

--- a/kork-jedis/kork-jedis.gradle
+++ b/kork-jedis/kork-jedis.gradle
@@ -1,3 +1,8 @@
 dependencies {
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('spectatorApi')
   compile spinnaker.dependency('jedis')
+
+  testCompile spinnaker.dependency('groovy')
+  spinnaker.group('spockBase')
 }

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisClientConfiguration.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisClientConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Configuration
+@Import(RedisClientConfiguration.class)
+public class JedisClientConfiguration {
+
+  @Bean
+  JedisClientDelegateFactory jedisClientDelegateFactory(ObjectMapper objectMapper) {
+    return new JedisClientDelegateFactory(objectMapper);
+  }
+
+  @Bean
+  public List<HealthIndicator> jedisClientHealthIndicators(List<RedisClientDelegate> redisClientDelegates) {
+    return redisClientDelegates.stream()
+      .filter(it -> it instanceof JedisClientDelegate)
+      .map(it -> JedisHealthIndicatorFactory.build((JedisClientDelegate) it))
+      .collect(Collectors.toList());
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisClientDelegate.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisClientDelegate.java
@@ -23,10 +23,21 @@ import java.util.function.Function;
 
 public class JedisClientDelegate implements RedisClientDelegate {
 
+  private final String name;
   private final Pool<Jedis> jedisPool;
 
   public JedisClientDelegate(Pool<Jedis> jedisPool) {
+    this("default", jedisPool);
+  }
+
+  public JedisClientDelegate(String name, Pool<Jedis> jedisPool) {
+    this.name = name;
     this.jedisPool = jedisPool;
+  }
+
+  @Override
+  public String name() {
+    return name;
   }
 
   @Override

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisClientDelegateFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisClientDelegateFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.jedis.RedisClientConfiguration.Driver;
+
+import java.util.Map;
+
+import static com.netflix.spinnaker.kork.jedis.RedisClientConfiguration.Driver.REDIS;
+
+public class JedisClientDelegateFactory implements RedisClientDelegateFactory<JedisClientDelegate> {
+
+  private ObjectMapper objectMapper;
+
+  public JedisClientDelegateFactory(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean supports(Driver driver) {
+    return driver == REDIS;
+  }
+
+  @Override
+  public JedisClientDelegate build(String name, Map<String, Object> properties) {
+    JedisDriverProperties props = objectMapper.convertValue(properties, JedisDriverProperties.class);
+    return new JedisClientDelegate(
+      name,
+      new JedisPoolFactory().build(name, props)
+    );
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisDriverProperties.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisDriverProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+public class JedisDriverProperties {
+
+  /**
+   * The redis connection uri: (e.g. redis://localhost:6379)
+   */
+  public String connection;
+
+  /**
+   * Client connection timeout. (Not to be confused with command timeout).
+   */
+  public int timeoutMs = 2000;
+
+  /**
+   * Redis object pool configuration.
+   */
+  public GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisHealthIndicatorFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisHealthIndicatorFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import redis.clients.jedis.Jedis;
+import redis.clients.util.Pool;
+
+import java.lang.reflect.Field;
+
+@SuppressWarnings("unchecked")
+public class JedisHealthIndicatorFactory {
+
+  public static HealthIndicator build(JedisClientDelegate client) {
+    try {
+      final JedisClientDelegate src = client;
+      final Field clientAccess = JedisClientDelegate.class.getDeclaredField("jedisPool");
+      clientAccess.setAccessible(true);
+
+      return build((Pool<Jedis>) clientAccess.get(src));
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new BeanCreationException("Error creating Redis health indicator", e);
+    }
+  }
+
+  public static HealthIndicator build(Pool<Jedis> jedisPool) {
+    try {
+      final Pool<Jedis> src = jedisPool;
+      final Field poolAccess = Pool.class.getDeclaredField("internalPool");
+      poolAccess.setAccessible(true);
+      GenericObjectPool<Jedis> internal = (GenericObjectPool<Jedis>) poolAccess.get(jedisPool);
+      return () -> {
+        Jedis jedis = null;
+        Health.Builder health;
+        try {
+          jedis = src.getResource();
+          if ("PONG".equals(jedis.ping())) {
+            health = Health.up();
+          } else {
+            health = Health.down();
+          }
+        } catch (Exception ex) {
+          health = Health.down(ex);
+        } finally {
+          if (jedis != null) jedis.close();
+        }
+        health.withDetail("maxIdle", internal.getMaxIdle());
+        health.withDetail("minIdle", internal.getMinIdle());
+        health.withDetail("numActive", internal.getNumActive());
+        health.withDetail("numIdle", internal.getNumIdle());
+        health.withDetail("numWaiters", internal.getNumWaiters());
+
+        return health.build();
+      };
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new BeanCreationException("Error creating Redis health indicator", e);
+    }
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import com.netflix.spinnaker.kork.jedis.exception.MissingRequiredConfiguration;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Protocol;
+import redis.clients.util.Pool;
+
+import java.net.URI;
+
+public class JedisPoolFactory {
+
+  public Pool<Jedis> build(String name, JedisDriverProperties properties) {
+    if (properties.connection == null || "".equals(properties.connection)) {
+      throw new MissingRequiredConfiguration("Jedis client must have a connection defined");
+    }
+
+    URI redisConnection = URI.create(properties.connection);
+
+    String host = redisConnection.getHost();
+    int port = redisConnection.getPort() == -1 ? Protocol.DEFAULT_PORT : redisConnection.getPort();
+    int database = parseDatabase(redisConnection.getPath());
+    String password = parsePassword(redisConnection.getUserInfo());
+    GenericObjectPoolConfig objectPoolConfig = properties.poolConfig;
+
+    return new JedisPool(objectPoolConfig, host, port, properties.timeoutMs, password, database, name);
+  }
+
+  private static int parseDatabase(String path) {
+    if (path == null) {
+      return 0;
+    }
+    return Integer.parseInt(("/" + Protocol.DEFAULT_DATABASE).split("/", 2)[1]);
+  }
+
+  private static String parsePassword(String userInfo) {
+    if (userInfo == null) {
+      return null;
+    }
+    return userInfo.split(":", 2)[1];
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientConfiguration.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientConfiguration.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import com.netflix.spinnaker.kork.jedis.exception.RedisClientFactoryNotFound;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.*;
+
+import static com.netflix.spinnaker.kork.jedis.RedisClientConfiguration.Driver.REDIS;
+
+/**
+ * Offers a standardized Spring configuration for a named redis clients, as well as primary and previous connections.
+ * This class should not be imported, but instead use JedisClientConfiguration or DynomiteClientConfiguration.
+ *
+ * While using this configuration, all clients are exposed through RedisClientSelector.
+ *
+ * This configuration also supports old-style Redis Spring configuration, as long as they wrap their Redis connection
+ * pools with a RedisClientDelegate. Typically speaking, these older configuration formats should give their client
+ * delegate the name "default".
+ */
+@Configuration
+@EnableConfigurationProperties({
+  RedisClientConfiguration.ClientConfigurationWrapper.class,
+  RedisClientConfiguration.RedisDriverConfiguration.class,
+  RedisClientConfiguration.DualClientConfiguration.class
+})
+public class RedisClientConfiguration {
+
+  @Autowired
+  List<RedisClientDelegateFactory> clientDelegateFactories;
+
+  @Bean("namedRedisClients")
+  public List<RedisClientDelegate> redisClientDelegates(ClientConfigurationWrapper redisClientConfigurations,
+                                                        Optional<List<RedisClientDelegate>> otherRedisClientDelegates) {
+    List<RedisClientDelegate> clients = new ArrayList<>();
+    redisClientConfigurations.clients.forEach((name, config) -> {
+      if (config.primary != null) {
+        clients.add(createClient(
+          RedisClientSelector.getName(true, name),
+          config.primary.driver,
+          config.primary.config
+        ));
+      }
+      if (config.previous != null) {
+        clients.add(createClient(
+          RedisClientSelector.getName(false, name),
+          config.previous.driver,
+          config.previous.config
+        ));
+      }
+    });
+    if (otherRedisClientDelegates.isPresent()) {
+      clients.addAll(otherRedisClientDelegates.get());
+    }
+    return clients;
+  }
+
+  private RedisClientDelegate createClient(String name, Driver driver, Map<String, Object> properties) {
+    return getClientFactoryForDriver(driver).build(name, properties);
+  }
+
+  @Bean
+  public RedisClientSelector redisClientSelector(@Qualifier("namedRedisClients") List<RedisClientDelegate> redisClientDelegates) {
+    return new RedisClientSelector(redisClientDelegates);
+  }
+
+  private RedisClientDelegateFactory<?> getClientFactoryForDriver(Driver driver) {
+    return clientDelegateFactories.stream()
+      .filter(it -> it.supports(driver))
+      .findFirst()
+      .orElseThrow(() -> new RedisClientFactoryNotFound("Could not find factory for driver: " + driver.name()));
+  }
+
+  public enum Driver {
+    REDIS("redis"),
+    DYNOMITE("dynomite");
+
+    private final String value;
+
+    Driver(String value) {
+      this.value = value;
+    }
+  }
+
+  @ConfigurationProperties(prefix = "redis")
+  public static class ClientConfigurationWrapper {
+    Map<String, DualClientConfiguration> clients;
+
+    public Map<String, DualClientConfiguration> getClients() {
+      return clients;
+    }
+
+    public void setClients(Map<String, DualClientConfiguration> clients) {
+      this.clients = clients;
+    }
+  }
+
+  @ConfigurationProperties
+  public static class RedisDriverConfiguration {
+    public Driver driver = REDIS;
+    public Map<String, Object> config = new HashMap<>();
+
+    public Driver getDriver() {
+      return driver;
+    }
+
+    public void setDriver(Driver driver) {
+      this.driver = driver;
+    }
+
+    public Map<String, Object> getConfig() {
+      return config;
+    }
+
+    public void setConfig(Map<String, Object> config) {
+      this.config = config;
+    }
+  }
+
+  @ConfigurationProperties
+  public static class DualClientConfiguration {
+    public RedisDriverConfiguration primary;
+    public RedisDriverConfiguration previous;
+
+    public RedisDriverConfiguration getPrimary() {
+      return primary;
+    }
+
+    public void setPrimary(RedisDriverConfiguration primary) {
+      this.primary = primary;
+    }
+
+    public RedisDriverConfiguration getPrevious() {
+      return previous;
+    }
+
+    public void setPrevious(RedisDriverConfiguration previous) {
+      this.previous = previous;
+    }
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientDelegate.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientDelegate.java
@@ -25,6 +25,8 @@ import java.util.function.Function;
  */
 public interface RedisClientDelegate {
 
+  String name();
+
   <R> R withCommandsClient(Function<JedisCommands, R> f);
 
   void withCommandsClient(Consumer<JedisCommands> f);

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientDelegateFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientDelegateFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import com.netflix.spinnaker.kork.jedis.RedisClientConfiguration.Driver;
+
+import java.util.Map;
+
+public interface RedisClientDelegateFactory<C extends RedisClientDelegate> {
+
+  boolean supports(Driver driver);
+
+  C build(String name, Map<String, Object> properties);
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientSelector.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientSelector.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import com.netflix.spinnaker.kork.jedis.exception.RedisClientNotFound;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+public class RedisClientSelector {
+
+  private final static String DEFAULT = "default";
+  private final static String PRIMARY = "primary";
+  private final static String PREVIOUS = "previous";
+
+  private final Logger log = LoggerFactory.getLogger(RedisClientSelector.class);
+
+  private final List<RedisClientDelegate> clients;
+
+  public RedisClientSelector(List<RedisClientDelegate> clients) {
+    this.clients = clients;
+    clients.forEach(client -> {
+      log.info("Configured {} using {}", client.name(), client.getClass().getSimpleName());
+    });
+  }
+
+  public RedisClientDelegate primary(String name) {
+    return primary(name, true);
+  }
+
+  public Optional<RedisClientDelegate> previous(String name) {
+    return previous(name, true);
+  }
+
+  public RedisClientDelegate primary(String name, boolean fallbackToDefault) {
+    return select(name, true, fallbackToDefault)
+      .orElseThrow(() ->
+        new RedisClientNotFound("Could not find primary Redis client by name '" + name + "' and no default configured")
+      );
+  }
+
+  public Optional<RedisClientDelegate> previous(String name, boolean fallbackToDefault) {
+    return select(name, false, fallbackToDefault);
+  }
+
+  private Optional<RedisClientDelegate> select(String name, boolean primary, boolean fallbackToDefault) {
+    String stdName = getName(primary, name);
+
+    Optional<RedisClientDelegate> client = clients.stream().filter(it -> stdName.equals(it.name())).findFirst();
+
+    if (!client.isPresent() && fallbackToDefault) {
+      String defaultName = getName(primary, DEFAULT);
+      client = clients.stream()
+        .filter(it -> defaultName.equals(it.name()))
+        .findFirst();
+    }
+
+    return client;
+  }
+
+  public static String getName(boolean primary, String name) {
+    return (primary ? PRIMARY : PREVIOUS) + name.substring(0, 1).toUpperCase() + name.substring(1);
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/ConflictingConfiguration.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/ConflictingConfiguration.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis.exception;
+
+public class ConflictingConfiguration extends IllegalStateException {
+  public ConflictingConfiguration(String s) {
+    super(s);
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/MissingRequiredConfiguration.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/MissingRequiredConfiguration.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis.exception;
+
+public class MissingRequiredConfiguration extends IllegalStateException {
+  public MissingRequiredConfiguration(String configuration) {
+    super("Missing required Jedis client configuration '" + configuration + "'");
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/RedisClientFactoryNotFound.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/RedisClientFactoryNotFound.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis.exception;
+
+public class RedisClientFactoryNotFound extends IllegalStateException {
+
+  public RedisClientFactoryNotFound(String s) {
+    super(s);
+  }
+}

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/RedisClientNotFound.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/exception/RedisClientNotFound.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis.exception;
+
+public class RedisClientNotFound extends RuntimeException {
+
+  public RedisClientNotFound(String message) {
+    super(message);
+  }
+}

--- a/kork-jedis/src/test/groovy/com/netflix/spinnaker/kork/jedis/RedisClientSelectorSpec.groovy
+++ b/kork-jedis/src/test/groovy/com/netflix/spinnaker/kork/jedis/RedisClientSelectorSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis
+
+import com.netflix.spinnaker.kork.jedis.exception.RedisClientNotFound
+import spock.lang.Specification
+
+class RedisClientSelectorSpec extends Specification {
+
+  def "should return client by name"() {
+    given:
+    def primaryClient = Mock(RedisClientDelegate) {
+      name() >> "primaryFoo"
+    }
+    def previousClient = Mock(RedisClientDelegate) {
+      name() >> "previousFoo"
+    }
+
+    def subject = new RedisClientSelector([primaryClient, previousClient])
+
+    expect:
+    subject.primary("foo") == primaryClient
+    subject.previous("foo").get() == previousClient
+  }
+
+  def "should throw exception if primary client cannot be found"() {
+    given:
+    def primaryClient = Mock(RedisClientDelegate) {
+      name() >> "primaryFoo"
+    }
+    def previousClient = Mock(RedisClientDelegate) {
+      name() >> "previousFoo"
+    }
+
+    def subject = new RedisClientSelector([primaryClient, previousClient])
+
+    when:
+    subject.primary("bar")
+
+    then:
+    thrown(RedisClientNotFound)
+  }
+
+  def "should fallback to default if available"() {
+    given:
+    def defaultPrimaryClient = Mock(RedisClientDelegate) {
+      name() >> "primaryDefault"
+    }
+    def defaultPreviousClient = Mock(RedisClientDelegate) {
+      name() >> "previousDefault"
+    }
+
+    def subject = new RedisClientSelector([defaultPrimaryClient, defaultPreviousClient])
+
+    expect:
+    subject.primary("foo") == defaultPrimaryClient
+    subject.previous("foo").get() == defaultPreviousClient
+  }
+}


### PR DESCRIPTION
There's a lot here, but most of it is just pulling out configuration stuff from orca, clouddriver, et al.

Standardizes redis (or dynomite) configuration for services, and adds support for named clients. Each named client supports both a `primary` and `previous` client. `RedisClientDelegate` exists, but is now provided by `RedisClientSelector`, which provides a little interface for getting a named client (if it exists) or optionally falling back to a default client connection. Supports our existing redis connection/connectionPrevious scheme as well, so long as a `JedisClientDelegate` is also created alongside the `Pool<Jedis>` stuff.

Here's what a configuration looks like:

```yaml
# orca.yml
redis:
  connection: redis://localhost:6379
  clients:
    executionRepository:
      primary:
        driver: dynomite
        config:
          applicationName: orca
          clusterName: dyno_orca_test
      previous:
        driver: redis
        config:
          connection: redis://localhost:6380
          secure: false
          connectionPool:
            maxTotal: 5
            maxIdle: 3
            minIdle: 3
```

In this example:

The default connection uses the old configuration format of `redis.connection`, but I've also configured a named client for `executionRepository`, which is pointed a dynomite cluster and a separate local redis connection.

The named clients will be handy for migrating individual parts of a service to dynomite, as well as have better control over capacity / blast radius.

Using this:

```java
# RedisConfiguration.java in Orca

@Configuration
@Import(JedisClientConfiguration.class)
public class RedisConfiguration {
}
```