### PR TITLE
feat(core): Add no discovery poller

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/eureka/DiscoveryPollingConfiguration.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/eureka/DiscoveryPollingConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.eureka;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.DiscoveryClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+import java.lang.management.ManagementFactory;
+
+@Configuration
+public class DiscoveryPollingConfiguration {
+
+  @Configuration
+  @ConditionalOnMissingBean(DiscoveryClient.class)
+  public static class NoDiscoveryConfiguration {
+
+    private final ApplicationEventPublisher publisher;
+
+    @Autowired
+    public NoDiscoveryConfiguration(ApplicationEventPublisher publisher) {
+      this.publisher = publisher;
+    }
+
+    @Bean
+    public ApplicationListener<ContextRefreshedEvent> discoveryStatusPoller() {
+      return new NoDiscoveryApplicationStatusPublisher(publisher);
+    }
+
+    @Bean
+    public String currentInstanceId() {
+      return ManagementFactory.getRuntimeMXBean().getName();
+    }
+  }
+
+  @Configuration
+  @ConditionalOnBean(DiscoveryClient.class)
+  public static class DiscoveryConfiguration {
+
+    @Bean
+    public String currentInstanceId(InstanceInfo instanceInfo) {
+      return instanceInfo.getInstanceId();
+    }
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/eureka/NoDiscoveryApplicationStatusPublisher.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/eureka/NoDiscoveryApplicationStatusPublisher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.eureka;
+
+import com.netflix.appinfo.InstanceInfo.InstanceStatus;
+import com.netflix.discovery.StatusChangeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+import static com.netflix.appinfo.InstanceInfo.InstanceStatus.UNKNOWN;
+import static com.netflix.appinfo.InstanceInfo.InstanceStatus.UP;
+
+public class NoDiscoveryApplicationStatusPublisher implements ApplicationListener<ContextRefreshedEvent> {
+
+  private final Logger log = LoggerFactory.getLogger(NoDiscoveryApplicationStatusPublisher.class);
+  private final ApplicationEventPublisher publisher;
+
+  private InstanceStatus instanceStatus = UNKNOWN;
+
+  public NoDiscoveryApplicationStatusPublisher(ApplicationEventPublisher publisher) {
+    this.publisher = publisher;
+  }
+
+  @Override
+  public void onApplicationEvent(ContextRefreshedEvent event) {
+    log.warn("No discovery client is available, assuming application is UP");
+    setInstanceStatus(UP);
+  }
+
+  private void setInstanceStatus(InstanceStatus current) {
+    InstanceStatus previous = instanceStatus;
+    instanceStatus = current;
+    publisher.publishEvent(new RemoteStatusChangedEvent(new StatusChangeEvent(previous, current)));
+  }
+}


### PR DESCRIPTION
There's not a lot here, but it does get copied around service to service that needs to stop processing background work when it comes out of discovery. Thoughts?