### PR TITLE
feat(artifacts): Put "unknown" fields into the metadata map

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.kork.artifacts.model;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -37,4 +38,10 @@ public class Artifact {
   private String artifactAccount;
   private String provenance;
   private String uuid;
+
+  // Add extra, unknown data to the metadata map:
+  @JsonAnySetter
+  public void putMetadata(String key, Object value) {
+    metadata.put(key, value);
+  }
 }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -22,6 +22,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Data
@@ -42,6 +43,9 @@ public class Artifact {
   // Add extra, unknown data to the metadata map:
   @JsonAnySetter
   public void putMetadata(String key, Object value) {
+    if (metadata == null) {
+      metadata = new HashMap<>();
+    }
     metadata.put(key, value);
   }
 }


### PR DESCRIPTION
Artifacts from Igor contains fields that can't be directly mapped to the fields in Kork's `Artifact` class. This commit will put the data in these fields into the metadata map.