### PR TITLE
feat(redis): Add scan command facade

### DIFF
--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientDelegate.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientDelegate.java
@@ -22,6 +22,8 @@ import java.util.function.Function;
 
 /**
  * Offers a functional interface over either a vanilla Jedis or Dynomite client.
+ *
+ * TODO rz - remove withKeyScan once Dyno implements the Jedis interfaces
  */
 public interface RedisClientDelegate {
 
@@ -60,4 +62,6 @@ public interface RedisClientDelegate {
   void withScriptingClient(Consumer<ScriptingCommands> f);
 
   <R> R withScriptingClient(Function<ScriptingCommands, R> f);
+
+  void withKeyScan(String pattern, int count, Consumer<RedisScanResult> f);
 }

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisScanResult.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisScanResult.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import java.util.List;
+
+public interface RedisScanResult {
+
+  List<String> getResults();
+}


### PR DESCRIPTION
Dynomite's scan methods don't implement the Jedis interfaces. This method puts a small facade around barebones functionality of scan. 

```java
client.withScan("mypattern*", 100, (scan) -> {
  log.info(
    "This is called for every scan iteration and has {} items", 
    scan.getResults().size()
  );
});
```

Something like that.