### PR TITLE
support rediss:// (redis+ssl) URIs

### DIFF
--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
@@ -51,10 +51,11 @@ public class JedisPoolFactory {
     int database = parseDatabase(redisConnection.getPath());
     String password = parsePassword(redisConnection.getUserInfo());
     GenericObjectPoolConfig objectPoolConfig = properties.poolConfig;
+    boolean isSSL = redisConnection.scheme.equals("rediss");
 
     return new InstrumentedJedisPool(
       registry,
-      new JedisPool(objectPoolConfig, host, port, properties.timeoutMs, password, database, name),
+      new JedisPool(objectPoolConfig, host, port, properties.timeoutMs, password, database, name, isSSL),
       name
     );
   }


### PR DESCRIPTION
AWS Elasticache only supports redis with AUTH when used in combination with "in-transit encryption" (a/k/a SSL).  Redis SSL URIs have the scheme `rediss://`.  Jedis already supports SSL, but we need to pass through the SSL-ness after parsing the URI.