### PR TITLE
feat(core): TransientConfigService

### DIFF
--- a/kork-core/kork-core.gradle
+++ b/kork-core/kork-core.gradle
@@ -10,6 +10,8 @@ dependencies {
     compile spinnaker.dependency('spectatorJvm')
     compile spinnaker.dependency('spectatorWebSpring')
 
-    testCompile spinnaker.dependency('junit')
+
+    testCompile spinnaker.dependency('groovy')
+    spinnaker.group('spockBase')
     testRuntime spinnaker.dependency('slf4jSimple')
 }

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/PlatformComponents.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/PlatformComponents.java
@@ -19,12 +19,18 @@ package com.netflix.spinnaker.kork;
 import com.netflix.spinnaker.kork.archaius.ArchaiusConfiguration;
 import com.netflix.spinnaker.kork.aws.AwsComponents;
 import com.netflix.spinnaker.kork.eureka.EurekaComponents;
+import com.netflix.spinnaker.kork.transientconfig.TransientConfigConfiguration;
 import com.netflix.spinnaker.kork.metrics.SpectatorConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import({ArchaiusConfiguration.class, EurekaComponents.class, SpectatorConfiguration.class, AwsComponents.class})
+@Import({
+  ArchaiusConfiguration.class,
+  TransientConfigConfiguration.class,
+  EurekaComponents.class,
+  SpectatorConfiguration.class,
+  AwsComponents.class
+})
 public class PlatformComponents {
 }

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/transientconfig/ScopedCriteria.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/transientconfig/ScopedCriteria.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.transientconfig;
+
+public class ScopedCriteria {
+  public final String region;
+  public final String account;
+  public final String cloudProvider;
+  public final String application;
+
+  ScopedCriteria(String region, String account, String cloudProvider, String application) {
+    this.region = region;
+    this.account = account;
+    this.cloudProvider = cloudProvider;
+    this.application = application;
+  }
+
+  public static class Builder {
+    String region;
+    String account;
+    String cloudProvider;
+    String application;
+
+    public Builder withRegion(String region) {
+      this.region = region;
+      return this;
+    }
+
+    public Builder withAccount(String account) {
+      this.account = account;
+      return this;
+    }
+
+    public Builder withCloudProvider(String cloudProvider) {
+      this.cloudProvider = cloudProvider;
+      return this;
+    }
+
+    public Builder withApplication(String application) {
+      this.application = application;
+      return this;
+    }
+
+    public ScopedCriteria build() {
+      return new ScopedCriteria(region, account, cloudProvider, application);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "ScopedCriteria{" +
+      "region='" + region + '\'' +
+      ", account='" + account + '\'' +
+      ", cloudProvider='" + cloudProvider + '\'' +
+      ", application='" + application + '\'' +
+      '}';
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/transientconfig/SpringTransientConfigService.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/transientconfig/SpringTransientConfigService.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.transientconfig;
+
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+
+/**
+ * The SpringTransientConfigService directly interacts with the Spring Environment.
+ */
+public class SpringTransientConfigService implements TransientConfigService, EnvironmentAware {
+
+  private Environment environment;
+
+  @Override
+  public <T> T getTransientConfig(@Nonnull Class<T> configType, @Nonnull String configName, @Nonnull T defaultValue) {
+    if (environment == null) {
+      return defaultValue;
+    }
+    return environment.getProperty(configName, configType, defaultValue);
+  }
+
+  @Override
+  public boolean isEnabled(@Nonnull String flagName, boolean defaultValue) {
+    if (environment == null) {
+      return defaultValue;
+    }
+    return environment.getProperty(flagName, Boolean.class, defaultValue);
+  }
+
+  @Override
+  public boolean isEnabled(@Nonnull String flagName, boolean defaultValue, @Nonnull ScopedCriteria criteria) {
+    if (environment == null) {
+      return defaultValue;
+    }
+    Boolean value = chainedFlagSupplier(new LinkedList<>(Arrays.asList(
+      booleanSupplier(flagName, "region", criteria.region),
+      booleanSupplier(flagName, "account", criteria.account),
+      booleanSupplier(flagName, "cloudProvider", criteria.cloudProvider),
+      booleanSupplier(flagName, "application", criteria.application),
+      () -> environment.getProperty(format("%s.enabled", flagName), Boolean.class)
+    )));
+    return (value == null) ? defaultValue : value;
+  }
+
+  private Boolean chainedFlagSupplier(LinkedList<Supplier<Boolean>> chain) {
+    if (chain.isEmpty()) {
+      return null;
+    }
+    Boolean value = chain.removeFirst().get();
+    return (value != null) ? value : chainedFlagSupplier(chain);
+  }
+
+  private Supplier<Boolean> booleanSupplier(String configName, String criteriaName, String criteria) {
+    return () -> (configName == null) ? null : environment.getProperty(format("%s.%s.%s", configName, criteriaName, criteria), Boolean.class);
+  }
+
+  @Override
+  public void setEnvironment(Environment environment) {
+    this.environment = environment;
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/transientconfig/TransientConfigConfiguration.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/transientconfig/TransientConfigConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.transientconfig;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TransientConfigConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(TransientConfigService.class)
+  TransientConfigService springTransientConfigService() {
+    return new SpringTransientConfigService();
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/transientconfig/TransientConfigService.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/transientconfig/TransientConfigService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.transientconfig;
+
+import javax.annotation.Nonnull;
+import java.util.function.Supplier;
+
+/**
+ * A simple interface for interacting with dynamic Spring properties in the scope of feature flags.
+ */
+public interface TransientConfigService {
+
+  <T> T getTransientConfig(@Nonnull Class<T> configType, @Nonnull String configName, @Nonnull T defaultValue);
+
+  default <T> T getTransientConfig(@Nonnull Class<T> configType, @Nonnull String configName, @Nonnull T defaultValue, @Nonnull Supplier<Boolean> predicate) {
+    if (predicate.get()) {
+      return getTransientConfig(configType, configName, defaultValue);
+    }
+    return defaultValue;
+  }
+
+  boolean isEnabled(@Nonnull String flagName, boolean defaultValue);
+
+  default boolean isEnabled(@Nonnull String flagName, boolean defaultValue, @Nonnull Supplier<Boolean> predicate) {
+    if (predicate.get()) {
+      return isEnabled(flagName, defaultValue);
+    }
+    return defaultValue;
+  }
+
+  boolean isEnabled(@Nonnull String flagName, boolean defaultValue, @Nonnull ScopedCriteria criteria);
+}

--- a/kork-core/src/test/groovy/com/netflix/spinnaker/kork/transientconfig/SpringTransientConfigServiceSpec.groovy
+++ b/kork-core/src/test/groovy/com/netflix/spinnaker/kork/transientconfig/SpringTransientConfigServiceSpec.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.transientconfig
+
+import org.springframework.core.env.Environment
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import static com.netflix.spinnaker.kork.transientconfig.ScopedCriteria.*
+
+class SpringTransientConfigServiceSpec extends Specification {
+
+  Environment environment = Mock()
+
+  @Subject
+  SpringTransientConfigService subject = new SpringTransientConfigService()
+
+  @Unroll
+  def "should return correctly chained feature flag"() {
+    given:
+    environment.getProperty("myfeature.enabled", Boolean) >> { true }
+    environment.getProperty("myfeature.region.us-west-2", Boolean) >> { false }
+    environment.getProperty("myfeature.application.orca", Boolean) >> { false }
+    subject.setEnvironment(environment)
+
+    expect:
+    subject.isEnabled(feature, false, criteria.build()) == expected
+
+    where:
+    feature     | criteria                                      || expected
+    "noexist"   | new Builder()                                 || false
+    "myfeature" | new Builder()                                 || true
+    "myfeature" | new Builder().withApplication("clouddriver")  || true
+    "myfeature" | new Builder().withApplication("orca")         || false
+    "myfeature" | new Builder().withRegion("us-west-2")         || false
+    "myfeature" | new Builder().withRegion("us-east-1")         || true
+  }
+
+}


### PR DESCRIPTION
Offers a pluggable dynamic / transient config service interface, and a default Spring-backed implementation. Two primary APIs are offered: A generic `getTransientConfig` and a `isEnabled` feature flag. Both of which support passing a `Supplier<Boolean>` predicate that must satisfy to `true` before returning the actual value. If `false`, the `defaultValue` is returned.

An additional layer of logic was added to feature flags that allows us to pass in canned `ScopedCriteria` according to our usual domain filters: `application`, `region`, `cloudProvider` and `account`. Precedence (highest to lowest) is currently: `region -> account -> cloudProvider -> application -> global`.

Given a feature flag `myFeature`, the configs for the Spring-backed implementation would be:

* `myFeature.enabled` (global)
* `myFeature.{scope}.{value}` (e.g. `myFeature.application.orca`)

Example usage:

```kotlin
// No extra logic usage
transientConfigService.isEnabled("myFeature", false)

// Scoped criteria usage
val criteria = ScopedCriteria.Builder().withApplication("orca").build()
transientConfigService.isEnabled("myFeature", false, criteria)

// Predicate usage
transientConfigService.isEnabled("myFeature", false, { myPredicationLogic() })

// Config usage
transientConfigService.getTransientConfig<String>("myConfig", "Hello!")
```