### PR TITLE
feat(redis): Generic Locking support

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/lock/LockManager.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/lock/LockManager.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.lock;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.http.util.Asserts;
+
+import javax.annotation.Nonnull;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.Callable;
+
+public interface LockManager {
+  <R> AcquireLockResponse<R> acquireLock(@Nonnull final LockOptions lockOptions,
+                                         @Nonnull final Callable<R> onLockAcquiredCallback);
+
+  AcquireLockResponse<Void> acquireLock(@Nonnull final LockOptions lockOptions,
+                                        @Nonnull final Runnable onLockAcquiredCallback);
+
+  <R> AcquireLockResponse<R> acquireLock(@Nonnull final String lockName,
+                                         final long maximumLockDurationMillis,
+                                         @Nonnull final Callable<R> onLockAcquiredCallback);
+
+  AcquireLockResponse<Void> acquireLock(@Nonnull final String lockName,
+                                        final long maximumLockDurationMillis,
+                                        @Nonnull final Runnable onLockAcquiredCallback);
+
+  boolean releaseLock(@Nonnull final Lock lock);
+
+  String NAME_FALLBACK = UUID.randomUUID().toString();
+
+  /**
+   * Used only if an ownerName is not provided in the constructor.
+   */
+  default String getOwnerName() {
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      return NAME_FALLBACK;
+    }
+  }
+
+  default String lockKey(String name) {
+    return String.format("{korkLock:%s}", name.toLowerCase());
+  }
+
+  class AcquireLockResponse<R> {
+    private final Lock lock;
+    private final R onLockAcquiredCallbackResult;
+    private final LockStatus lockStatus;
+    private final Exception exception;
+    private boolean released;
+
+    public AcquireLockResponse(final Lock lock,
+                               final R onLockAcquiredCallbackResult,
+                               final LockStatus lockStatus,
+                               final Exception exception,
+                               final boolean released) {
+      this.lock = lock;
+      this.onLockAcquiredCallbackResult = onLockAcquiredCallbackResult;
+      this.lockStatus = lockStatus;
+      this.exception = exception;
+      this.released = released;
+    }
+
+    public Lock getLock() {
+      return lock;
+    }
+
+    public R getOnLockAcquiredCallbackResult() {
+      return onLockAcquiredCallbackResult;
+    }
+
+    public LockStatus getLockStatus() {
+      return lockStatus;
+    }
+
+    public Exception getException() {
+      return exception;
+    }
+
+    public boolean isReleased() {
+      return released;
+    }
+  }
+
+  enum LockStatus {
+    ACQUIRED,
+    TAKEN,
+    ERROR,
+    EXPIRED
+  }
+
+  interface LockReleaseStatus {
+    String SUCCESS = "SUCCESS";
+    String SUCCESS_GONE = "SUCCESS_GONE"; //lock no longer exists
+    String FAILED_NOT_OWNER = "FAILED_NOT_OWNER"; //found lock but belongs to someone else
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  class Lock implements Named {
+    private final String name;
+    private final String ownerName;
+    private final long leaseDurationMillis;
+    private final long version;
+    private final long ownerSystemTimestamp;
+    private final String attributes; //arbitrary string to store data along side the lock
+
+    @JsonCreator
+    public Lock(@JsonProperty("name") String name,
+                @JsonProperty("ownerName") String ownerName,
+                @JsonProperty("version") long version,
+                @JsonProperty("leaseDurationMillis") long leaseDurationMillis,
+                @JsonProperty("ownerSystemTimestamp") long ownerSystemTimestamp,
+                @JsonProperty("attributes") String attributes) {
+      this.name = name;
+      this.ownerName = ownerName;
+      this.leaseDurationMillis = leaseDurationMillis;
+      this.ownerSystemTimestamp = ownerSystemTimestamp;
+      this.version = version;
+      this.attributes = attributes;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    public String getOwnerName() {
+      return ownerName;
+    }
+
+    public long getLeaseDurationMillis() {
+      return leaseDurationMillis;
+    }
+
+    public long getVersion() {
+      return version;
+    }
+
+    public long nextVersion() {
+      return version + 1;
+    }
+
+    public long getOwnerSystemTimestamp() {
+      return ownerSystemTimestamp;
+    }
+
+    public String getAttributes() {
+      return attributes;
+    }
+
+    @Override
+    public String toString() {
+      return "Lock{" +
+        "name='" + name + '\'' +
+        ", ownerName='" + ownerName + '\'' +
+        ", leaseDurationMillis=" + leaseDurationMillis +
+        ", version='" + version + '\'' +
+        ", ownerSystemTimestamp=" + ownerSystemTimestamp +
+        ", attributes=" + attributes +
+        '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      // Two locks are identical if the lock name, owner and version match.
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Lock lock = (Lock) o;
+      return Objects.equals(name, lock.name) &&
+        Objects.equals(ownerName, lock.ownerName) &&
+        Objects.equals(version, lock.version);
+    }
+
+    @Override
+    public int hashCode() {
+      // Two locks are equal if lockName, ownerName and version match.
+      return Objects.hash(name, ownerName, version);
+    }
+  }
+
+  interface Named {
+    String getName();
+  }
+
+  class LockOptions {
+    private String lockName;
+    private Duration maximumLockDuration;
+    private long version;
+    private List<String> attributes = new ArrayList<>(); // the list will be joined with a ';' delimiter for brevity
+
+    public LockOptions withLockName(String name) {
+      this.lockName = name;
+      return this;
+    }
+
+    public LockOptions withMaximumLockDuration(Duration duration) {
+      this.maximumLockDuration = duration;
+      return this;
+    }
+
+    public LockOptions withAttributes(List<String> attributes) {
+      this.attributes = attributes;
+      return this;
+    }
+
+    public LockOptions withVersion(long version) {
+      this.version = version;
+      return this;
+    }
+
+    public String getLockName() {
+      return lockName;
+    }
+
+    public Duration getMaximumLockDuration() {
+      return maximumLockDuration;
+    }
+
+    public List<String> getAttributes() {
+      return attributes;
+    }
+
+    public long getVersion() {
+      return version;
+    }
+
+    public void validateInputs() {
+      Asserts.check(this.lockName.matches("^[a-zA-Z0-9.-]+$"),
+        "Lock name must be alphanumeric, may contain dots");
+
+      Objects.requireNonNull(this.lockName, "Lock name must be provided");
+      Objects.requireNonNull(this.maximumLockDuration, "Lock max duration must be provided");
+    }
+
+    public void setVersion(long version) {
+      this.version = version;
+    }
+
+    @Override
+    public String toString() {
+      return "LockOptions{" +
+        "lockName='" + lockName + '\'' +
+        ", maximumLockDuration=" + maximumLockDuration +
+        ", version=" + version +
+        ", attributes=" + attributes +
+        '}';
+    }
+  }
+
+  class LockException extends RuntimeException {
+    public LockException() {
+      super();
+    }
+
+    public LockException(String message) {
+      super(message);
+    }
+
+    public LockException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+    public LockException(Throwable cause) {
+      super(cause);
+    }
+  }
+
+  class LockCallbackException extends LockException {
+    public LockCallbackException(String message) {
+      super(message);
+    }
+
+    public LockCallbackException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+    public LockCallbackException(Throwable cause) {
+      super(cause);
+    }
+  }
+
+  class LockNotAcquiredException extends LockException {
+    public LockNotAcquiredException(String message) {
+      super(message);
+    }
+
+    public LockNotAcquiredException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+    public LockNotAcquiredException(Throwable cause) {
+      super(cause);
+    }
+  }
+
+  class LockExpiredException extends LockException {
+    public LockExpiredException(String message) {
+      super(message);
+    }
+
+    public LockExpiredException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+    public LockExpiredException(Throwable cause) {
+      super(cause);
+    }
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/lock/RefreshableLockManager.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/lock/RefreshableLockManager.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.lock;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Lock Manager with heartbeat support.
+ */
+public interface RefreshableLockManager extends LockManager {
+  HeartbeatResponse heartbeat(final HeartbeatLockRequest heartbeatLockRequest);
+  void queueHeartbeat(final HeartbeatLockRequest heartbeatLockRequest);
+
+  class HeartbeatLockRequest {
+    private AtomicReference<Lock> lock;
+    private final Duration heartbeatDuration;
+    private final Instant startedAt;
+    private final Clock clock;
+
+    public HeartbeatLockRequest(Lock lock, Clock clock, Duration heartbeatDuration) {
+      this.lock = new AtomicReference<>(lock);
+      this.clock = clock;
+      this.startedAt = clock.instant();
+      this.heartbeatDuration = heartbeatDuration;
+    }
+
+    public Lock getLock() {
+      return lock.get();
+    }
+
+    public void setLock(final Lock lock) {
+      this.lock.set(lock);
+    }
+
+    public Duration getHeartbeatDuration() {
+      return heartbeatDuration;
+    }
+
+    public Instant getStartedAt() {
+      return startedAt;
+    }
+
+    public boolean timesUp() {
+      return Duration.between(startedAt, clock.instant()).compareTo(heartbeatDuration) >= 0;
+    }
+
+    public Duration getRemainingLockDuration() {
+      return Duration.between(startedAt, clock.instant()).minus(heartbeatDuration).abs();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      HeartbeatLockRequest that = (HeartbeatLockRequest) o;
+      return Objects.equals(lock, that.lock) &&
+        Objects.equals(heartbeatDuration, that.heartbeatDuration) &&
+        Objects.equals(startedAt, that.startedAt) &&
+        Objects.equals(clock, that.clock);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(lock, heartbeatDuration, startedAt, clock);
+    }
+  }
+
+  class HeartbeatResponse {
+    private final Lock lock;
+    private final LockStatus lockStatus;
+
+    public HeartbeatResponse(Lock lock, LockStatus lockStatus) {
+      this.lock = lock;
+      this.lockStatus = lockStatus;
+    }
+
+    public Lock getLock() {
+      return lock;
+    }
+
+    public LockStatus getLockStatus() {
+      return lockStatus;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      HeartbeatResponse that = (HeartbeatResponse) o;
+      return Objects.equals(lock, that.lock) &&
+        lockStatus == that.lockStatus;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(lock, lockStatus);
+    }
+  }
+
+  class LockFailedHeartbeatException extends LockException {
+    public LockFailedHeartbeatException(String message) {
+      super(message);
+    }
+
+    public LockFailedHeartbeatException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+    public LockFailedHeartbeatException(Throwable cause) {
+      super(cause);
+    }
+  }
+}

--- a/kork-jedis/kork-jedis.gradle
+++ b/kork-jedis/kork-jedis.gradle
@@ -1,8 +1,10 @@
 dependencies {
-  compile spinnaker.dependency('bootActuator')
+  compile project(":kork-core")
   compile spinnaker.dependency('spectatorApi')
+  compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('jedis')
 
   testCompile spinnaker.dependency('groovy')
+  testCompile project(":kork-jedis-test")
   spinnaker.group('spockBase')
 }

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/lock/RedisLockManager.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/lock/RedisLockManager.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.jedis.lock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.LongTaskTimer;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import com.netflix.spinnaker.kork.lock.RefreshableLockManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.PreDestroy;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static com.netflix.spinnaker.kork.jedis.lock.RedisLockManager.LockScripts.*;
+import static com.netflix.spinnaker.kork.lock.LockManager.LockReleaseStatus.*;
+
+public class RedisLockManager implements RefreshableLockManager {
+  private static final Logger log = LoggerFactory.getLogger(RedisLockManager.class);
+  private static final long DEFAULT_HEARTBEAT_RATE_MILLIS = 5000L;
+  private static final long DEFAULT_TTL_MILLIS = 10000L;
+
+  private final String ownerName;
+  private final Clock clock;
+  private final Registry registry;
+  private final ObjectMapper objectMapper;
+  private final RedisClientDelegate redisClientDelegate;
+  private final ScheduledExecutorService scheduledExecutorService;
+
+  private final Id acquireId;
+  private final Id releaseId;
+  private final Id heartbeatId;
+
+  private long heartbeatRateMillis;
+  private long leaseDurationMillis;
+  private BlockingDeque<HeartbeatLockRequest> heartbeatQueue;
+
+  public RedisLockManager(String ownerName,
+                          Clock clock,
+                          Registry registry,
+                          ObjectMapper objectMapper,
+                          RedisClientDelegate redisClientDelegate,
+                          Optional<Long> heartbeatRateMillis,
+                          Optional<Long> leaseDurationMillis
+  ) {
+    this.ownerName = Optional.ofNullable(ownerName).orElse(getOwnerName());
+    this.clock = clock;
+    this.registry = registry;
+    this.objectMapper = objectMapper;
+    this.redisClientDelegate = redisClientDelegate;
+    this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    this.heartbeatQueue = new LinkedBlockingDeque<>();
+    this.heartbeatRateMillis = heartbeatRateMillis.orElse(DEFAULT_HEARTBEAT_RATE_MILLIS);
+    this.leaseDurationMillis = leaseDurationMillis.orElse(DEFAULT_TTL_MILLIS);
+
+    acquireId = registry.createId("redis.lock.acquire");
+    releaseId = registry.createId("redis.lock.release");
+    heartbeatId = registry.createId("redis.lock.heartbeat");
+    scheduleHeartbeats();
+  }
+
+  public RedisLockManager(String ownerName,
+                          Clock clock,
+                          Registry registry,
+                          ObjectMapper objectMapper,
+                          RedisClientDelegate redisClientDelegate
+  ) {
+    this(
+      ownerName,
+      clock,
+      registry,
+      objectMapper,
+      redisClientDelegate,
+      Optional.of(DEFAULT_HEARTBEAT_RATE_MILLIS),
+      Optional.of(DEFAULT_TTL_MILLIS)
+    );
+  }
+
+  @Override
+  public <R> AcquireLockResponse<R> acquireLock(@Nonnull final LockOptions lockOptions,
+                                                @Nonnull final Callable<R> onLockAcquiredCallback) {
+    return acquire(lockOptions, onLockAcquiredCallback);
+  }
+
+  @Override
+  public <R> AcquireLockResponse<R> acquireLock(@Nonnull final String lockName,
+                                                final long maximumLockDurationMillis,
+                                                @Nonnull final Callable<R> onLockAcquiredCallback) {
+    LockOptions lockOptions = new LockOptions()
+      .withLockName(lockName)
+      .withMaximumLockDuration(Duration.ofMillis(maximumLockDurationMillis));
+    return acquire(lockOptions, onLockAcquiredCallback);
+  }
+
+  @Override
+  public AcquireLockResponse<Void> acquireLock(@Nonnull final String lockName,
+                                               final long maximumLockDurationMillis,
+                                               @Nonnull final Runnable onLockAcquiredCallback) {
+    LockOptions lockOptions = new LockOptions()
+      .withLockName(lockName)
+      .withMaximumLockDuration(Duration.ofMillis(maximumLockDurationMillis));
+    return acquire(lockOptions, onLockAcquiredCallback);
+  }
+
+  @Override
+  public AcquireLockResponse<Void> acquireLock(@Nonnull LockOptions lockOptions,
+                                               @Nonnull Runnable onLockAcquiredCallback) {
+    return acquire(lockOptions, onLockAcquiredCallback);
+  }
+
+  @Override
+  public boolean releaseLock(@Nonnull final Lock lock) {
+    try {
+      // we are aware that the cardinality can get high. To revisit if concerns arise.
+      Id lockRelease = releaseId.withTag("lockName", lock.getName());
+      String status = tryReleaseLock(lock);
+      registry.counter(lockRelease.withTag("status", status)).increment();
+
+      switch (status) {
+        case SUCCESS:
+        case SUCCESS_GONE:
+          log.info("Released lock {}", lock);
+          return true;
+
+        case FAILED_NOT_OWNER:
+          log.warn("Failed releasing lock {}: Not owner", lock);
+          return false;
+
+        default:
+          log.error("Unknown release response code {} for lock {}", status, lock);
+          return false;
+      }
+    } finally {
+      heartbeatQueue.removeIf(r -> r.getLock().equals(lock));
+    }
+  }
+
+  @Override
+  public HeartbeatResponse heartbeat(HeartbeatLockRequest heartbeatLockRequest) {
+    return heartbeat(heartbeatLockRequest.getLock());
+  }
+
+  @Override
+  public void queueHeartbeat(HeartbeatLockRequest heartbeatLockRequest) {
+    if (!heartbeatQueue.contains(heartbeatLockRequest)) {
+      log.info("Lock {} will heartbeats for {}ms", heartbeatLockRequest.getLock(), heartbeatLockRequest.getHeartbeatDuration().toMillis());
+      heartbeatQueue.add(heartbeatLockRequest);
+    }
+  }
+
+  private <R> AcquireLockResponse<R> doAcquire(@Nonnull final LockOptions lockOptions,
+                                               final Optional<Callable<R>> onLockAcquiredCallbackCallable,
+                                               final Optional<Runnable> onLockAcquiredCallbackRunnable) {
+    lockOptions.validateInputs();
+    Lock lock = null;
+    R workResult = null;
+    LockStatus status = LockStatus.TAKEN;
+    HeartbeatLockRequest heartbeatLockRequest = null;
+    lockOptions.setVersion(clock.millis());
+    try {
+      lock = tryCreateLock(lockOptions);
+      if (!matchesLock(lockOptions, lock)) {
+        log.info("Could not acquire already taken lock {}", lock);
+        return new AcquireLockResponse<>(lock,
+          null,
+          status,
+          null,
+          tryLockReleaseQuietly(lock)
+        );
+      }
+
+      LongTaskTimer acquireDurationTimer = registry.longTaskTimer(
+        String.format("redis.lock.acquireDuration.%s", lock.getName())
+      );
+
+      status = LockStatus.ACQUIRED;
+      log.info("Acquired Lock {}.", lock);
+      long timer = acquireDurationTimer.start();
+
+      // Queues the acquired lock to receive heartbeats for the defined max lock duration.
+      heartbeatLockRequest = new HeartbeatLockRequest(lock, clock, lockOptions.getMaximumLockDuration());
+      queueHeartbeat(heartbeatLockRequest);
+
+      synchronized (heartbeatLockRequest.getLock()) {
+        try {
+          if (onLockAcquiredCallbackCallable.isPresent()) {
+            workResult = onLockAcquiredCallbackCallable.get().call();
+          } else {
+            onLockAcquiredCallbackRunnable.ifPresent(Runnable::run);
+          }
+        } catch (Exception e) {
+          log.error("Callback failed using lock {}", lock, e);
+          throw new LockCallbackException(e);
+        } finally {
+          acquireDurationTimer.stop(timer);
+          // Use refreshed lock if it received heartbeats
+          lock = heartbeatLockRequest.getLock();
+        }
+      }
+
+      return new AcquireLockResponse<>(lock, workResult, status, null, tryLockReleaseQuietly(lock));
+    } catch (Exception e) {
+      if (e instanceof LockCallbackException) {
+        throw e;
+      }
+
+      log.error("Failed to acquire lock with options {}", lockOptions, e);
+      status = LockStatus.ERROR;
+      return new AcquireLockResponse<>(lock, workResult, status, e, tryLockReleaseQuietly(lock));
+    } finally {
+      Optional.ofNullable(heartbeatLockRequest).ifPresent(r -> heartbeatQueue.remove(r));
+      registry.counter(
+        acquireId
+          .withTag("lockName", lockOptions.getLockName())
+          .withTag("status", status.toString())
+      ).increment();
+    }
+  }
+
+  private AcquireLockResponse<Void> acquire(@Nonnull final LockOptions lockOptions,
+                                            @Nonnull final Runnable onLockAcquiredCallback) {
+    return doAcquire(lockOptions, Optional.empty(), Optional.of(onLockAcquiredCallback));
+  }
+
+  private <R> AcquireLockResponse<R> acquire(@Nonnull final LockOptions lockOptions,
+                                             @Nonnull final Callable<R> onLockAcquiredCallback) {
+    return doAcquire(lockOptions, Optional.of(onLockAcquiredCallback), Optional.empty());
+  }
+
+  @PreDestroy
+  private void shutdownHeartbeatScheduler() {
+    scheduledExecutorService.shutdown();
+  }
+
+  private void scheduleHeartbeats() {
+    scheduledExecutorService
+      .scheduleAtFixedRate(this::sendHeartbeats, 0, heartbeatRateMillis, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Send heartbeats to queued locks. Monitors maximum heartbeat count when provided.
+   * If a max heartbeat is provided, the underlying lock will receive at most the provided maximum heartbeats.
+   */
+  private void sendHeartbeats() {
+    if (heartbeatQueue.isEmpty()) {
+      return;
+    }
+
+    HeartbeatLockRequest heartbeatLockRequest = heartbeatQueue.getFirst();
+    if (heartbeatLockRequest.timesUp()) {
+      // Informational warning. Lock may expire as it no longer receive heartbeats.
+      log.warn("***MAX HEARTBEAT REACHED***. No longer sending heartbeats to {}", heartbeatLockRequest.getLock());
+      heartbeatQueue.remove(heartbeatLockRequest);
+    } else {
+      try {
+        HeartbeatResponse heartbeatResponse = heartbeat(heartbeatLockRequest.getLock());
+        switch (heartbeatResponse.getLockStatus()) {
+          case EXPIRED:
+          case ERROR:
+            log.warn("Lock status {} for {}", heartbeatResponse.getLockStatus(), heartbeatResponse.getLock());
+            heartbeatQueue.remove(heartbeatLockRequest);
+            break;
+          default:
+            log.debug("Remaining lock duration {}ms. Refreshed lock {}",
+              heartbeatLockRequest.getRemainingLockDuration().toMillis(), heartbeatResponse.getLock());
+            heartbeatLockRequest.setLock(heartbeatResponse.getLock());
+        }
+      } catch (Exception e) {
+        log.error("Heartbeat {} for {} failed", heartbeatLockRequest, heartbeatLockRequest.getLock(), e);
+        heartbeatQueue.remove(heartbeatLockRequest);
+      }
+    }
+  }
+
+  /**
+   * A heartbeat will only be accepted if the provided version matches the
+   * version stored in Redis. If a heartbeat is accepted, a new version value will
+   * be stored with the lock along side a renewed lease and the system timestamp.
+   */
+  private HeartbeatResponse heartbeat(final Lock lock) {
+    // we are aware that the cardinality can get high. To revisit if concerns arise.
+    Id lockHeartbeat = heartbeatId.withTag("lockName", lock.getName());
+    Lock extendedLock = lock;
+    try {
+      extendedLock = tryUpdateLock(lock, lock.nextVersion());
+      registry.counter(lockHeartbeat.withTag("status", LockStatus.ACQUIRED.toString())).increment();
+      return new HeartbeatResponse(extendedLock, LockStatus.ACQUIRED);
+    } catch (Exception e) {
+      if (e instanceof LockExpiredException) {
+        registry.counter(lockHeartbeat.withTag("status", LockStatus.EXPIRED.toString())).increment();
+        return new HeartbeatResponse(extendedLock, LockStatus.EXPIRED);
+      }
+
+      log.error("Heartbeat failed for lock {}", extendedLock, e);
+      registry.counter(lockHeartbeat.withTag("status", LockStatus.ERROR.toString())).increment();
+      return new HeartbeatResponse(extendedLock, LockStatus.ERROR);
+    }
+  }
+
+  private boolean tryLockReleaseQuietly(final Lock lock) {
+    if (lock != null) {
+      try {
+        return releaseLock(lock);
+      } catch (Exception e) {
+        log.warn("Attempt to release lock {} failed", lock, e);
+      }
+    }
+
+    return false;
+  }
+
+  private boolean matchesLock(LockOptions lockOptions, Lock lock) {
+    return ownerName.equals(lock.getOwnerName()) &&
+      lockOptions.getVersion() == lock.getVersion();
+  }
+
+  private Lock tryCreateLock(final LockOptions lockOptions) {
+    try {
+      List<String> attributes = Optional.ofNullable(lockOptions.getAttributes()).orElse(Collections.emptyList());
+      Object payload = redisClientDelegate.withScriptingClient(c -> {
+        return c.eval(
+          ACQUIRE_SCRIPT,
+          Collections.singletonList(lockKey(lockOptions.getLockName())),
+          Arrays.asList(
+            Long.toString(Duration.ofMillis(leaseDurationMillis).toMillis()),
+            ownerName,
+            Long.toString(clock.millis()),
+            String.valueOf(lockOptions.getVersion()),
+            lockOptions.getLockName(),
+            String.join(";", attributes)
+          ));
+      });
+
+      if (payload == null) {
+        throw new LockNotAcquiredException(String.format("Lock not acquired %s", lockOptions));
+      }
+
+      return objectMapper.readValue(payload.toString(), Lock.class);
+    } catch (IOException e) {
+      throw new LockNotAcquiredException(String.format("Lock not acquired %s", lockOptions), e);
+    }
+  }
+
+  private String tryReleaseLock(final Lock lock) {
+    Object payload =  redisClientDelegate.withScriptingClient(c -> {
+      return c.eval(
+        RELEASE_SCRIPT,
+        Collections.singletonList(lockKey(lock.getName())),
+        Arrays.asList(
+          ownerName,
+          String.valueOf(lock.getVersion())
+        )
+      );
+    });
+
+    return payload.toString();
+  }
+
+  private Lock tryUpdateLock(final Lock lock, final long nextVersion) {
+    Object payload = redisClientDelegate.withScriptingClient(c -> {
+      return c.eval(
+        HEARTBEAT_SCRIPT,
+        Collections.singletonList(lockKey(lock.getName())),
+        Arrays.asList(
+          ownerName,
+          String.valueOf(lock.getVersion()),
+          String.valueOf(nextVersion),
+          Long.toString(lock.getLeaseDurationMillis()),
+          Long.toString(clock.millis())
+        )
+      );
+    });
+
+    if (payload == null) {
+      throw new LockExpiredException(String.format("Lock expired %s", lock));
+    }
+
+    try {
+      return objectMapper.readValue(payload.toString(), Lock.class);
+    } catch (IOException e) {
+      throw new LockFailedHeartbeatException(String.format("Lock not acquired %s", lock), e);
+    }
+  }
+
+  interface LockScripts {
+    /**
+     * Returns 1 if the release is successful, 0 if the release could not be
+     * completed (no longer the owner, different version), 2 if the lock no
+     * longer exists.
+     * <p>
+     * ARGS
+     * 1: owner
+     * 2: previousRecordVersion
+     * 3: newRecordVersion
+     */
+    String RELEASE_SCRIPT = "" +
+      "local payload = redis.call('GET', KEYS[1]) " +
+      "if payload then" +
+      " local lock = cjson.decode(payload)" +
+      "  if lock['ownerName'] == ARGV[1] and lock['version'] == ARGV[2] then" +
+      "    redis.call('DEL', KEYS[1])" +
+      "    return 'SUCCESS'" +
+      "  end" +
+      "  return 'FAILED_NOT_OWNER' " +
+      "end " +
+      "return 'SUCCESS_GONE'";
+
+    /**
+     * Returns the active lock, whether or not the desired lock was acquired.
+     * <p>
+     * ARGS
+     * 1: leaseDurationMillis
+     * 2: owner
+     * 3: ownerSystemTimestamp
+     * 4: version
+     */
+    String ACQUIRE_SCRIPT = "" +
+      "local payload = cjson.encode({" +
+      "  ['leaseDurationMillis']=ARGV[1]," +
+      "  ['ownerName']=ARGV[2]," +
+      "  ['ownerSystemTimestamp']=ARGV[3]," +
+      "  ['version']=ARGV[4]," +
+      "  ['name']=ARGV[5]," +
+      "  ['attributes']=ARGV[6]" +
+      "}) " +
+      "if redis.call('SET', KEYS[1], payload, 'NX', 'EX', ARGV[1]) == 'OK' then" +
+      "  return payload " +
+      "end " +
+      "return redis.call('GET', KEYS[1])";
+
+    /**
+     * Returns 1 if heartbeat was successful, -1 if the lock no longer exists,
+     * 0 if the lock is now owned by someone else or is a different version.
+     * <p>
+     * If the heartbeat is successful, update the lock with the NRV and updated
+     * owner system timestamp.
+     * <p>
+     * ARGS
+     * 1: ownerName
+     * 2: previousRecordVersion
+     * 3: newRecordVersion
+     * 4: newleaseDurationMillis
+     * 5: updatedOwnerSystemTimestamp
+     */
+    String HEARTBEAT_SCRIPT = "" +
+      "local payload = redis.call('GET', KEYS[1]) " +
+      "if payload then" +
+      "  local lock = cjson.decode(payload)" +
+      "  if lock['ownerName'] == ARGV[1] and lock['version'] == ARGV[2] then" +
+      "    lock['version']=ARGV[3]" +
+      "    lock['leaseDurationMillis']=ARGV[4]" +
+      "    lock['ownerSystemTimestamp']=ARGV[5]" +
+      "    redis.call('PSETEX', KEYS[1], ARGV[4], cjson.encode(lock))" +
+      "    return redis.call('GET', KEYS[1])" +
+      "  end " +
+      "end";
+  }
+}

--- a/kork-jedis/src/test/groovy/com/netflix/spinnaker/kork/jedis/locking/RedisLockManagerSpec.groovy
+++ b/kork-jedis/src/test/groovy/com/netflix/spinnaker/kork/jedis/locking/RedisLockManagerSpec.groovy
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.jedis.locking
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.NoopRegistry
+
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.lock.RedisLockManager
+import com.netflix.spinnaker.kork.lock.LockManager
+import redis.clients.jedis.JedisPool
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.Clock
+import java.time.Duration
+import java.util.concurrent.Callable
+
+import static com.netflix.spinnaker.kork.lock.LockManager.LockStatus.*
+import static com.netflix.spinnaker.kork.lock.RefreshableLockManager.*
+
+class RedisLockManagerSpec extends Specification {
+  @Shared def embeddedRedis = EmbeddedRedis.embed()
+  def jedisPool = embeddedRedis.getPool() as JedisPool
+  def objectMapper = new ObjectMapper()
+  def clock = Clock.systemDefaultZone()
+  def registry = new NoopRegistry()
+  def redisClientDelegate = new JedisClientDelegate(jedisPool)
+  def heartbeatRateMillis = 30L
+  def testLockMaxDurationMillis = 30L
+  def redisLockManager = new RedisLockManager(
+    "testOwner",
+    clock,
+    registry,
+    objectMapper,
+    redisClientDelegate,
+    Optional.of(heartbeatRateMillis),
+    Optional.of(testLockMaxDurationMillis)
+  )
+
+  def setup() {
+    jedisPool.resource.flushDB()
+  }
+
+  def cleanupSpec() {
+    embeddedRedis.destroy()
+  }
+
+  def "should acquire a simple lock and auto release"() {
+    when:
+    def result = redisLockManager.acquireLock("veryImportantLock", testLockMaxDurationMillis, {
+      return "Run after lock is safely acquired."
+    } as Callable<String>)
+
+    then:
+    result.lockStatus == ACQUIRED
+    result.released == true
+    result.onLockAcquiredCallbackResult == "Run after lock is safely acquired."
+  }
+
+  def "should store arbitrary data as attributes alongside the lock"() {
+    given:
+    def lockOptions = new LockManager.LockOptions()
+      .withMaximumLockDuration(Duration.ofMillis(testLockMaxDurationMillis))
+      .withLockName("veryImportantLock")
+      .withAttributes(["key:value","key2:value2"])
+
+    when:
+    def result = redisLockManager.acquireLock(lockOptions, {
+      return "Lock with data in attributes"
+    } as Callable<String>)
+
+    then:
+    result.lock.attributes == "key:value;key2:value2"
+  }
+
+  def "should fail to acquire an already taken lock"() {
+    given:
+    def lockOptions = new LockManager.LockOptions()
+      .withMaximumLockDuration(Duration.ofMillis(testLockMaxDurationMillis))
+      .withLockName("veryImportantLock")
+
+    and:
+    redisLockManager.tryCreateLock(lockOptions)
+
+    when:
+    def result = redisLockManager.acquireLock(lockOptions, {
+      return "attempting to acquire lock"
+    } as Callable<String>)
+
+    then:
+    result.lockStatus == TAKEN
+    result.onLockAcquiredCallbackResult == null
+  }
+
+  def "should acquire with heartbeat"() {
+    given:
+    def lockOptions = new LockManager.LockOptions()
+      .withMaximumLockDuration(Duration.ofMillis(testLockMaxDurationMillis))
+      .withLockName("veryImportantLock")
+
+    when:
+    def result = redisLockManager.acquireLock(lockOptions, {
+      // simulates long running task
+      Thread.sleep(100)
+      "Done"
+    } as Callable<String>)
+
+    then:
+    result.released == true
+    result.lockStatus == ACQUIRED
+    result.onLockAcquiredCallbackResult == "Done"
+
+    when:
+    result = redisLockManager.acquireLock(lockOptions.withLockName("withRunnable"), {
+      // simulates long running task
+      Thread.sleep(100)
+    } as Runnable)
+
+    then:
+    result.onLockAcquiredCallbackResult == null
+    result.lockStatus == ACQUIRED
+  }
+
+  def "should propagate exception on callback failure"() {
+    given:
+    def lockName = "veryImportantLock"
+    def onLockAcquiredCallback = {
+      throw new IllegalStateException("Failure")
+    }
+
+    when:
+    redisLockManager.acquireLock(lockName, testLockMaxDurationMillis, onLockAcquiredCallback)
+
+    then:
+    thrown(LockManager.LockCallbackException)
+  }
+
+  def "should release a lock"() {
+    given:
+    def lockOptions = new LockManager.LockOptions()
+      .withMaximumLockDuration(Duration.ofMillis(testLockMaxDurationMillis))
+      .withLockName("veryImportantLock")
+
+    and:
+    def lock = redisLockManager.tryCreateLock(lockOptions)
+
+    when:
+    def response = redisLockManager.tryReleaseLock(lock)
+
+    then:
+    response == LockManager.LockReleaseStatus.SUCCESS.toString()
+  }
+
+  def "should heartbeat by updating lock ttl"() {
+    given:
+    def lockOptions = new LockManager.LockOptions()
+      .withMaximumLockDuration(Duration.ofMillis(testLockMaxDurationMillis))
+      .withLockName("veryImportantLock")
+
+    and:
+    def lock = redisLockManager.tryCreateLock(lockOptions)
+    def request = new HeartbeatLockRequest(lock, clock, Duration.ofMillis(200))
+    Thread.sleep(10)
+
+    when:
+    def response = redisLockManager.heartbeat(request)
+    Thread.sleep(10)
+
+    then:
+    response.lockStatus == ACQUIRED
+
+    when: "Late heartbeat resulting in expired lock "
+    request = new HeartbeatLockRequest(lock, clock, Duration.ofMillis(200))
+    redisLockManager.heartbeat(request)
+    Thread.sleep(30)
+    response = redisLockManager.heartbeat(request)
+
+    then:
+    response.lockStatus == EXPIRED
+  }
+}


### PR DESCRIPTION
- `LockManager` defines a basic locking interface. 
- `RefreshableLock` as an extension of `LockManager`. Defines lock heartbeat functionality.
- Simple usage:
``` 
val acquireLockResponse = lockManager.acquireLock(locksName, maxLockDuration), {
    // Callback to run when lock is acquired
    // Lock will be kept alive with periodic heartbeats for `maxLockDuration`.
})

log.info("Status", acquireLockResponse.lockStatus)
- Heartbeats are handled by an internal single-threaded scheduler executor. The run frequency of the scheduler is configurable as well as the default lease duration.