### PR TITLE
fix(core): Simplify name of config service, fix isEnabled Spring implementation

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/PlatformComponents.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/PlatformComponents.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.kork;
 import com.netflix.spinnaker.kork.archaius.ArchaiusConfiguration;
 import com.netflix.spinnaker.kork.aws.AwsComponents;
 import com.netflix.spinnaker.kork.eureka.EurekaComponents;
-import com.netflix.spinnaker.kork.transientconfig.TransientConfigConfiguration;
+import com.netflix.spinnaker.kork.dynamicconfig.TransientConfigConfiguration;
 import com.netflix.spinnaker.kork.metrics.SpectatorConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/dynamicconfig/DynamicConfigSerivce.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/dynamicconfig/DynamicConfigSerivce.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.kork.transientconfig;
+package com.netflix.spinnaker.kork.dynamicconfig;
 
 import javax.annotation.Nonnull;
 import java.util.function.Supplier;
@@ -21,13 +21,13 @@ import java.util.function.Supplier;
 /**
  * A simple interface for interacting with dynamic Spring properties in the scope of feature flags.
  */
-public interface TransientConfigService {
+public interface DynamicConfigSerivce {
 
-  <T> T getTransientConfig(@Nonnull Class<T> configType, @Nonnull String configName, @Nonnull T defaultValue);
+  <T> T getConfig(@Nonnull Class<T> configType, @Nonnull String configName, @Nonnull T defaultValue);
 
-  default <T> T getTransientConfig(@Nonnull Class<T> configType, @Nonnull String configName, @Nonnull T defaultValue, @Nonnull Supplier<Boolean> predicate) {
+  default <T> T getConfig(@Nonnull Class<T> configType, @Nonnull String configName, @Nonnull T defaultValue, @Nonnull Supplier<Boolean> predicate) {
     if (predicate.get()) {
-      return getTransientConfig(configType, configName, defaultValue);
+      return getConfig(configType, configName, defaultValue);
     }
     return defaultValue;
   }

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/dynamicconfig/ScopedCriteria.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/dynamicconfig/ScopedCriteria.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.kork.transientconfig;
+package com.netflix.spinnaker.kork.dynamicconfig;
 
 public class ScopedCriteria {
   public final String region;

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/dynamicconfig/SpringDynamicConfigService.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/dynamicconfig/SpringDynamicConfigService.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.kork.transientconfig;
+package com.netflix.spinnaker.kork.dynamicconfig;
 
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
@@ -26,14 +26,14 @@ import java.util.function.Supplier;
 import static java.lang.String.format;
 
 /**
- * The SpringTransientConfigService directly interacts with the Spring Environment.
+ * The SpringDynamicConfigService directly interacts with the Spring Environment.
  */
-public class SpringTransientConfigService implements TransientConfigService, EnvironmentAware {
+public class SpringDynamicConfigService implements DynamicConfigSerivce, EnvironmentAware {
 
   private Environment environment;
 
   @Override
-  public <T> T getTransientConfig(@Nonnull Class<T> configType, @Nonnull String configName, @Nonnull T defaultValue) {
+  public <T> T getConfig(@Nonnull Class<T> configType, @Nonnull String configName, @Nonnull T defaultValue) {
     if (environment == null) {
       return defaultValue;
     }
@@ -45,7 +45,7 @@ public class SpringTransientConfigService implements TransientConfigService, Env
     if (environment == null) {
       return defaultValue;
     }
-    return environment.getProperty(flagName, Boolean.class, defaultValue);
+    return environment.getProperty(flagPropertyName(flagName), Boolean.class, defaultValue);
   }
 
   @Override
@@ -58,7 +58,7 @@ public class SpringTransientConfigService implements TransientConfigService, Env
       booleanSupplier(flagName, "account", criteria.account),
       booleanSupplier(flagName, "cloudProvider", criteria.cloudProvider),
       booleanSupplier(flagName, "application", criteria.application),
-      () -> environment.getProperty(format("%s.enabled", flagName), Boolean.class)
+      () -> environment.getProperty(flagPropertyName(flagName), Boolean.class)
     )));
     return (value == null) ? defaultValue : value;
   }
@@ -78,5 +78,9 @@ public class SpringTransientConfigService implements TransientConfigService, Env
   @Override
   public void setEnvironment(Environment environment) {
     this.environment = environment;
+  }
+
+  private static String flagPropertyName(String flagName) {
+    return format("%s.enabled", flagName);
   }
 }

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/dynamicconfig/TransientConfigConfiguration.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/dynamicconfig/TransientConfigConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.kork.transientconfig;
+package com.netflix.spinnaker.kork.dynamicconfig;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -23,8 +23,8 @@ import org.springframework.context.annotation.Configuration;
 public class TransientConfigConfiguration {
 
   @Bean
-  @ConditionalOnMissingBean(TransientConfigService.class)
-  TransientConfigService springTransientConfigService() {
-    return new SpringTransientConfigService();
+  @ConditionalOnMissingBean(DynamicConfigSerivce.class)
+  DynamicConfigSerivce springTransientConfigService() {
+    return new SpringDynamicConfigService();
   }
 }

--- a/kork-core/src/test/groovy/com/netflix/spinnaker/kork/dynamicconfig/SpringDynamicConfigServiceSpec.groovy
+++ b/kork-core/src/test/groovy/com/netflix/spinnaker/kork/dynamicconfig/SpringDynamicConfigServiceSpec.groovy
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.kork.transientconfig
+package com.netflix.spinnaker.kork.dynamicconfig
 
 import org.springframework.core.env.Environment
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
-import static com.netflix.spinnaker.kork.transientconfig.ScopedCriteria.*
+import static com.netflix.spinnaker.kork.dynamicconfig.ScopedCriteria.*
 
-class SpringTransientConfigServiceSpec extends Specification {
+class SpringDynamicConfigServiceSpec extends Specification {
 
   Environment environment = Mock()
 
   @Subject
-  SpringTransientConfigService subject = new SpringTransientConfigService()
+  SpringDynamicConfigService subject = new SpringDynamicConfigService()
 
   @Unroll
   def "should return correctly chained feature flag"() {


### PR DESCRIPTION
* Fixed `isEnabled` Spring implementation to uniformly format enabled flags.
* Renamed `s/Transient/Dynamic` ... since that makes more sense.
* Renamed `getTransientConfig` to simply `getConfig`

FYI @ajordens 