### PR TITLE
feat(web): Add request content length to metrics

### DIFF
--- a/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptorSpec.groovy
+++ b/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptorSpec.groovy
@@ -53,6 +53,7 @@ class MetricsInterceptorSpec extends Specification {
     def request = Mock(HttpServletRequest) {
       1 * getAttribute(MetricsInterceptor.TIMER_ATTRIBUTE) >> { return startTime }
       1 * getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE) >> templateVariables
+      1 * getContentLengthLong() >> { 10L }
       0 * _
     }
     def response = Mock(HttpServletResponse) {
@@ -80,7 +81,6 @@ class MetricsInterceptorSpec extends Specification {
     where:
     exception                  | variablesToTag | expectedTags
     null                       | []             | [success: "true", statusCode: "200", status: "2xx", "method": "get", controller: "Example"]
-    new NullPointerException() | []             | [success: "false", statusCode: "500", status: "5xx", "method": "get", controller: "Example", cause: "NullPointerException"]
     new NullPointerException() | []             | [success: "false", statusCode: "500", status: "5xx", "method": "get", controller: "Example", cause: "NullPointerException"]
     null                       | ["account"]    | [success: "true", statusCode: "200", status: "2xx", "method": "get", controller: "Example", "account": "test"]
 


### PR DESCRIPTION
Some prep work for Q3 pubsub work. I want to know what sort of payload sizes we're shipping around between services, as different sizes will dictate different approaches. Hard use case: If a request payload `orca -> echo` is greater than 256KB, we won't be able to ship the actual message via SQS and would instead need to store it in S3, or maybe use a log stream instead, or solution Z.