### PR TITLE
feat(aws): adding sns/sqs utils

### DIFF
--- a/kork-aws/kork-aws.gradle
+++ b/kork-aws/kork-aws.gradle
@@ -18,6 +18,7 @@ dependencies {
   compile spinnaker.dependency('groovy')
   compile spinnaker.dependency('bootAutoConfigure')
   compile spinnaker.dependency('awsCore')
+  compile spinnaker.dependency("aws")
   compile 'com.jcraft:jsch.agentproxy.jsch:0.0.9'
   compile 'com.jcraft:jsch.agentproxy.connector-factory:0.0.9'
   compile 'com.aestasit.infrastructure.sshoogr:sshoogr:0.9.25'

--- a/kork-aws/src/main/groovy/com/netflix/spinnaker/kork/aws/ARN.java
+++ b/kork-aws/src/main/groovy/com/netflix/spinnaker/kork/aws/ARN.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.aws;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Util for easy parsing of an Amazon Resource Names (ARNS)
+ * https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+ */
+public class ARN {
+
+  static final Pattern PATTERN = Pattern.compile("arn:aws(?:-cn|-us-gov)?:.*:(.*):(\\d+):(.*)");
+
+  private String arn;
+  private String region;
+  private String name;
+  private String account;
+
+  public ARN(String arn) {
+    this.arn = arn;
+
+    Matcher arnMatcher = PATTERN.matcher(arn);
+    if (!arnMatcher.matches()) {
+      throw new IllegalArgumentException(arn + " is not a valid ARN");
+    }
+
+    this.region = arnMatcher.group(1);
+    this.account = arnMatcher.group(2);
+    this.name = arnMatcher.group(3);
+  }
+
+  public String getArn() {
+    return arn;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getAccount() {
+    return account;
+  }
+}

--- a/kork-aws/src/main/groovy/com/netflix/spinnaker/kork/aws/pubsub/PubSubUtils.java
+++ b/kork-aws/src/main/groovy/com/netflix/spinnaker/kork/aws/pubsub/PubSubUtils.java
@@ -1,0 +1,56 @@
+package com.netflix.spinnaker.kork.aws.pubsub;
+
+import com.amazonaws.auth.policy.*;
+import com.amazonaws.auth.policy.actions.SQSActions;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.netflix.spinnaker.kork.aws.ARN;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+/**
+ * Utils for working with AWS SNS and SQS across services
+ */
+public class PubSubUtils {
+  private static final Logger log = LoggerFactory.getLogger(PubSubUtils.class);
+
+  public static String ensureQueueExists(AmazonSQS amazonSQS,
+                                  ARN queueARN,
+                                  ARN topicARN,
+                                  int sqsMessageRetentionPeriodSeconds) {
+    String queueUrl = amazonSQS.createQueue(queueARN.getName()).getQueueUrl();
+    log.debug("Created queue " + queueUrl);
+
+    HashMap<String, String> attributes = new HashMap<>();
+    attributes.put("Policy", buildSQSPolicy(queueARN, topicARN).toJson());
+    attributes.put("MessageRetentionPeriod", Integer.toString(sqsMessageRetentionPeriodSeconds));
+    amazonSQS.setQueueAttributes(
+      queueUrl,
+      attributes
+    );
+
+    return queueUrl;
+  }
+
+  public static String subscribeToTopic(AmazonSNS amazonSNS, ARN topicARN, ARN queueARN) {
+    amazonSNS.subscribe(topicARN.getArn(), "sqs", queueARN.getArn());
+    return topicARN.getArn();
+  }
+
+  /**
+   * This policy allows messages to be sent from an SNS topic.
+   */
+  public static Policy buildSQSPolicy(ARN queue, ARN topic) {
+    Statement snsStatement = new Statement(Statement.Effect.Allow).withActions(SQSActions.SendMessage);
+    snsStatement.setPrincipals(Principal.All);
+    snsStatement.setResources(Collections.singletonList(new Resource(queue.getArn())));
+    snsStatement.setConditions(Collections.singletonList(
+      new Condition().withType("ArnEquals").withConditionKey("aws:SourceArn").withValues(topic.getArn())
+    ));
+
+    return new Policy("allow-sns-send", Collections.singletonList(snsStatement));
+  }
+}


### PR DESCRIPTION
Pulling sns and sqs management to Kork for ease of use across services.
Fixing permissions on sqs creation to be more narrow. 