### PR TITLE
feat(okhttp): A simple metrics network interceptor for okhttp/okhttp3

### DIFF
--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttp3MetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttp3MetricsInterceptor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.okhttp;
+
+import com.netflix.spectator.api.Registry;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+public class OkHttp3MetricsInterceptor implements okhttp3.Interceptor {
+  private final Registry registry;
+
+  public OkHttp3MetricsInterceptor(Registry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public Response intercept(Chain chain) throws IOException {
+    long start = System.nanoTime();
+    boolean wasSuccessful = false;
+    int statusCode = -1;
+
+    Request request = chain.request();
+
+    try {
+      Response response = chain.proceed(request);
+      wasSuccessful = true;
+      statusCode = response.code();
+
+      return response;
+    } finally {
+      recordTimer(registry, request.url().url(), System.nanoTime() - start, statusCode, wasSuccessful);
+    }
+  }
+
+  static void recordTimer(Registry registry, URL requestUrl, Long durationNs, int statusCode, boolean wasSuccessful) {
+    registry.timer(
+        registry.createId("okhttp.requests")
+            .withTag("requestHost", requestUrl.getHost())
+            .withTag("statusCode", String.valueOf(statusCode))
+            .withTag("status", bucket(statusCode))
+            .withTag("success", wasSuccessful)
+    )
+        .record(durationNs, TimeUnit.NANOSECONDS);
+  }
+
+  private static String bucket(int statusCode) {
+    if (statusCode < 0) {
+      return "Unknown";
+    }
+
+    return Integer.toString(statusCode).charAt(0) + "xx";
+  }
+}

--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttpMetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttpMetricsInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.okhttp;
+
+import com.netflix.spectator.api.Registry;
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+
+import java.io.IOException;
+
+import static com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor.recordTimer;
+
+public class OkHttpMetricsInterceptor implements com.squareup.okhttp.Interceptor {
+  private final Registry registry;
+
+  public OkHttpMetricsInterceptor(Registry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public Response intercept(Interceptor.Chain chain) throws IOException {
+    long start = System.nanoTime();
+    boolean wasSuccessful = false;
+    int statusCode = -1;
+
+    Request request = chain.request();
+
+    try {
+      Response response = chain.proceed(request);
+      wasSuccessful = true;
+      statusCode = response.code();
+
+      return response;
+    } finally {
+      recordTimer(registry, request.url(), System.nanoTime() - start, statusCode, wasSuccessful);
+    }
+  }
+}


### PR DESCRIPTION
Reports a timer with sufficient tag detail to identify communication
issues between services.

ie) requests from `orca` to `echo` are failing

Only the host is identified, see the `controller.invocations` tag on the
destination service if you'd like more information about specific
endpoints that may be problematic.