### PR TITLE
refactor(locking): Differentiate heartbeat status

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/lock/RefreshableLockManager.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/lock/RefreshableLockManager.java
@@ -107,19 +107,19 @@ public interface RefreshableLockManager extends LockManager {
 
   class HeartbeatResponse {
     private final Lock lock;
-    private final LockStatus lockStatus;
+    private final LockHeartbeatStatus lockHeartbeatStatus;
 
-    public HeartbeatResponse(Lock lock, LockStatus lockStatus) {
+    public HeartbeatResponse(Lock lock, LockHeartbeatStatus lockHeartbeatStatus) {
       this.lock = lock;
-      this.lockStatus = lockStatus;
+      this.lockHeartbeatStatus = lockHeartbeatStatus;
     }
 
     public Lock getLock() {
       return lock;
     }
 
-    public LockStatus getLockStatus() {
-      return lockStatus;
+    public LockHeartbeatStatus getLockStatus() {
+      return lockHeartbeatStatus;
     }
 
     @Override
@@ -128,12 +128,12 @@ public interface RefreshableLockManager extends LockManager {
       if (o == null || getClass() != o.getClass()) return false;
       HeartbeatResponse that = (HeartbeatResponse) o;
       return Objects.equals(lock, that.lock) &&
-        lockStatus == that.lockStatus;
+        lockHeartbeatStatus == that.lockHeartbeatStatus;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(lock, lockStatus);
+      return Objects.hash(lock, lockHeartbeatStatus);
     }
   }
 
@@ -149,5 +149,12 @@ public interface RefreshableLockManager extends LockManager {
     public LockFailedHeartbeatException(Throwable cause) {
       super(cause);
     }
+  }
+
+  enum LockHeartbeatStatus {
+    SUCCESS,
+    EXPIRED,
+    ERROR,
+    MAX_HEARTBEAT_REACHED
   }
 }

--- a/kork-jedis/src/test/groovy/com/netflix/spinnaker/kork/jedis/locking/RedisLockManagerSpec.groovy
+++ b/kork-jedis/src/test/groovy/com/netflix/spinnaker/kork/jedis/locking/RedisLockManagerSpec.groovy
@@ -202,7 +202,7 @@ class RedisLockManagerSpec extends Specification {
     Thread.sleep(10)
 
     then:
-    response.lockStatus == ACQUIRED
+    response.lockStatus == LockHeartbeatStatus.SUCCESS
 
     when: "Late heartbeat resulting in expired lock "
     request = new HeartbeatLockRequest(lock, heartbeatRetriesOnFailure, clock, Duration.ofMillis(200))
@@ -211,7 +211,7 @@ class RedisLockManagerSpec extends Specification {
     response = redisLockManager.heartbeat(request)
 
     then:
-    response.lockStatus == EXPIRED
+    response.lockStatus == LockHeartbeatStatus.EXPIRED
   }
 
   def "should support success and failure intervals when releasing a lock"() {


### PR DESCRIPTION
- added `MAX_HEARTBEAT_REACHED` to heartbeat
- added a new metric for when a lock reaches the max lock duration