### PR TITLE
fix(hystrix): Avoid an `NaN` when publishing `hystrix.currentTime`

### DIFF
--- a/kork-hystrix/src/main/groovy/com/netflix/spinnaker/hystrix/spectator/HystrixSpectatorPublisherCommand.groovy
+++ b/kork-hystrix/src/main/groovy/com/netflix/spinnaker/hystrix/spectator/HystrixSpectatorPublisherCommand.groovy
@@ -64,7 +64,7 @@ class HystrixSpectatorPublisherCommand implements HystrixMetricsPublisherCommand
       }
     })
 
-    metricRegistry.gauge(createMetricName("currentTime"), null, new ToDoubleFunction() {
+    metricRegistry.gauge(createMetricName("currentTime"), metrics, new ToDoubleFunction() {
       @Override
       double applyAsDouble(Object ref) {
         return System.currentTimeMillis()

--- a/kork-hystrix/src/main/groovy/com/netflix/spinnaker/hystrix/spectator/HystrixSpectatorPublisherThreadPool.groovy
+++ b/kork-hystrix/src/main/groovy/com/netflix/spinnaker/hystrix/spectator/HystrixSpectatorPublisherThreadPool.groovy
@@ -48,7 +48,7 @@ class HystrixSpectatorPublisherThreadPool implements HystrixMetricsPublisherThre
 
   @Override
   public void initialize() {
-    metricRegistry.gauge(createMetricName("currentTime"), null, new ToDoubleFunction() {
+    metricRegistry.gauge(createMetricName("currentTime"), metrics, new ToDoubleFunction() {
       @Override
       double applyAsDouble(Object ref) {
         return System.currentTimeMillis()


### PR DESCRIPTION
Same as spinnaker/gate#558