### PR TITLE
 feat(artifacts): Artifact matching should use entire string

### DIFF
--- a/kork-artifacts/kork-artifacts.gradle
+++ b/kork-artifacts/kork-artifacts.gradle
@@ -1,5 +1,11 @@
 dependencies {
   compile project(":kork-core")
 
+  compile spinnaker.dependency('groovy')
+
   compileOnly spinnaker.dependency("lombok")
+
+  spinnaker.group('spockBase')
 }
+
+apply plugin: 'groovy'

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -46,31 +46,31 @@ public class ExpectedArtifact {
   public boolean matches(Artifact other) {
     String thisType = matchArtifact.getType();
     String otherType = other.getType();
-    if (StringUtils.isNotEmpty(thisType) && (otherType == null || !matches(thisType, otherType))) {
+    if (!matches(thisType, otherType)) {
       return false;
     }
 
     String thisName = matchArtifact.getName();
     String otherName = other.getName();
-    if (StringUtils.isNotEmpty(thisName) && (otherName == null || !matches(thisName, otherName))) {
+    if (!matches(thisName, otherName)) {
       return false;
     }
 
     String thisVersion = matchArtifact.getVersion();
     String otherVersion = other.getVersion();
-    if (StringUtils.isNotEmpty(thisVersion) && (otherVersion == null || !matches(thisVersion, otherVersion))) {
+    if (!matches(thisVersion, otherVersion)) {
       return false;
     }
 
     String thisLocation = matchArtifact.getLocation();
     String otherLocation = other.getLocation();
-    if (StringUtils.isNotEmpty(thisLocation) && (otherLocation == null || !matches(thisLocation, otherLocation))) {
+    if (!matches(thisLocation, otherLocation)) {
       return false;
     }
 
     String thisReference = matchArtifact.getReference();
     String otherReference = other.getReference();
-    if (StringUtils.isNotEmpty(thisReference) && (otherReference == null || !matches(thisReference, otherReference))) {
+    if (!matches(thisReference, otherReference)) {
       return false;
     }
 
@@ -80,6 +80,10 @@ public class ExpectedArtifact {
   }
 
   private boolean matches(String us, String other) {
+    return StringUtils.isEmpty(us) || (other != null && patternMatches(us, other));
+  }
+
+  private boolean patternMatches(String us, String other) {
     return Pattern.compile(us).asPredicate().test(other);
   }
 }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -84,6 +84,6 @@ public class ExpectedArtifact {
   }
 
   private boolean patternMatches(String us, String other) {
-    return Pattern.compile(us).asPredicate().test(other);
+    return Pattern.compile(us).matcher(other).matches();
   }
 }

--- a/kork-artifacts/src/test/groovy/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactSpec.groovy
+++ b/kork-artifacts/src/test/groovy/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactSpec.groovy
@@ -27,27 +27,27 @@ class ExepectedArtifactSpec extends Specification {
     Artifact.builder().type(input).build()
   }
 
-  @Shared nameFactory = {String input ->
+  @Shared nameFactory = { String input ->
     Artifact.builder().name(input).build()
   }
 
-  @Shared versionFactory = {String input ->
+  @Shared versionFactory = { String input ->
     Artifact.builder().version(input).build()
   }
 
-  @Shared locationFactory = {String input ->
+  @Shared locationFactory = { String input ->
     Artifact.builder().location(input).build()
   }
 
-  @Shared referenceFactory = {String input ->
+  @Shared referenceFactory = { String input ->
     Artifact.builder().reference(input).build()
   }
 
-  @Shared uuidFactory = {String input ->
+  @Shared uuidFactory = { String input ->
     Artifact.builder().uuid(input).build()
   }
 
-  @Shared provenanceFactory = {String input ->
+  @Shared provenanceFactory = { String input ->
     Artifact.builder().provenance(input).build()
   }
 

--- a/kork-artifacts/src/test/groovy/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactSpec.groovy
+++ b/kork-artifacts/src/test/groovy/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactSpec.groovy
@@ -61,9 +61,9 @@ class ExepectedArtifactSpec extends Specification {
 
     where:
     expectedName | incomingName | result
-    'abc'        | 'abcde'      | true
+    'abc'        | 'abcde'      | false
     'abc.*'      | 'abcde'      | true
-    'bc.*'       | 'abcde'      | true
+    'bc.*'       | 'abcde'      | false
     '.*bc.*'     | 'abcde'      | true
     'abcde$'     | 'abcde'      | true
     '^abcde$'    | 'abcde'      | true

--- a/kork-artifacts/src/test/groovy/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactSpec.groovy
+++ b/kork-artifacts/src/test/groovy/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactSpec.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.artifacts.model
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ExepectedArtifactSpec extends Specification {
+  private static final EXPECTED_STRING = 'abc.*'
+  private static final MATCH_STRING = 'abcd'
+  private static final NO_MATCH_STRING = 'zzz'
+
+  @Shared typeFactory = { String input ->
+    Artifact.builder().type(input).build()
+  }
+
+  @Shared nameFactory = {String input ->
+    Artifact.builder().name(input).build()
+  }
+
+  @Shared versionFactory = {String input ->
+    Artifact.builder().version(input).build()
+  }
+
+  @Shared locationFactory = {String input ->
+    Artifact.builder().location(input).build()
+  }
+
+  @Shared referenceFactory = {String input ->
+    Artifact.builder().reference(input).build()
+  }
+
+  @Shared uuidFactory = {String input ->
+    Artifact.builder().uuid(input).build()
+  }
+
+  @Shared provenanceFactory = {String input ->
+    Artifact.builder().provenance(input).build()
+  }
+
+  def "test regex matching"() {
+    when:
+    def expectedArtifact = ExpectedArtifact.builder().matchArtifact(Artifact.builder().name(expectedName).build()).build()
+    def incomingArtifact = Artifact.builder().name(incomingName).build()
+
+    then:
+    expectedArtifact.matches(incomingArtifact) == result
+
+    where:
+    expectedName | incomingName | result
+    'abc'        | 'abcde'      | true
+    'abc.*'      | 'abcde'      | true
+    'bc.*'       | 'abcde'      | true
+    '.*bc.*'     | 'abcde'      | true
+    'abcde$'     | 'abcde'      | true
+    '^abcde$'    | 'abcde'      | true
+    'abc'        | null         | false
+    'abc'        | ''           | false
+    ''           | 'abcde'      | true
+    null         | 'abcde'      | true
+  }
+
+  def "each considered field must match"() {
+    when:
+    def expectedArtifact = ExpectedArtifact.builder().matchArtifact(factory(MATCH_STRING)).build()
+
+    then:
+    expectedArtifact.matches(factory(MATCH_STRING))
+    !expectedArtifact.matches(factory(NO_MATCH_STRING))
+
+    where:
+    factory << [typeFactory, nameFactory, versionFactory, locationFactory, referenceFactory]
+  }
+
+  def "uuid and provenance do not need to match"() {
+    when:
+    def expectedArtifact = ExpectedArtifact.builder().matchArtifact(factory(MATCH_STRING)).build()
+
+    then:
+    expectedArtifact.matches(factory(MATCH_STRING))
+    expectedArtifact.matches(factory(NO_MATCH_STRING))
+
+    where:
+    factory << [uuidFactory, provenanceFactory]
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: This change affects the way in which artifacts injected
into a pipeline are matched to expected artifacts. Prior to this change,
a match was successful if the regular expression in the expected artifact
matched any substring of the corresponding field in the incoming artifact;
after this change, the regular expression in the expected artifact must
match the entire corresponding field incoming artifact.

As an example, consider an incoming artifact with name 'artifact123'. Before
this change, it would match expected artifacts with names 'artifact' and
'artifact.*'.  After this change, the incoming artifact will no longer
match an expected artifact with name 'artifact' but will continue to match
'artifact*'; users will need to explicitly add a wildcard (or some more
complex regular expression) if substring matching is desired.
