### PR TITLE
fix(pubsub): return subscr arn when creating subscr

### DIFF
--- a/kork-aws/src/main/groovy/com/netflix/spinnaker/kork/aws/pubsub/PubSubUtils.java
+++ b/kork-aws/src/main/groovy/com/netflix/spinnaker/kork/aws/pubsub/PubSubUtils.java
@@ -51,9 +51,11 @@ public class PubSubUtils {
     return queueUrl;
   }
 
+  /**
+   * Returns the subscription arn resulting from subscribing the queueARN to the topicARN
+   */
   public static String subscribeToTopic(AmazonSNS amazonSNS, ARN topicARN, ARN queueARN) {
-    amazonSNS.subscribe(topicARN.getArn(), "sqs", queueARN.getArn());
-    return topicARN.getArn();
+    return amazonSNS.subscribe(topicARN.getArn(), "sqs", queueARN.getArn()).getSubscriptionArn();
   }
 
   /**


### PR DESCRIPTION
Instead of returning the topic arn, which we already know, we should return the subscription arn so that we can edit filters on that subscription