### PR TITLE
fix(jedis): Allow services to override connection pool settings

### DIFF
--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisClientDelegateFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisClientDelegateFactory.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.kork.jedis;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.kork.jedis.RedisClientConfiguration.Driver;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 import java.util.Map;
 
@@ -27,10 +28,14 @@ public class JedisClientDelegateFactory implements RedisClientDelegateFactory<Je
 
   private Registry registry;
   private ObjectMapper objectMapper;
+  private GenericObjectPoolConfig objectPoolConfig;
 
-  public JedisClientDelegateFactory(Registry registry, ObjectMapper objectMapper) {
+  public JedisClientDelegateFactory(Registry registry,
+                                    ObjectMapper objectMapper,
+                                    GenericObjectPoolConfig objectPoolConfig) {
     this.registry = registry;
     this.objectMapper = objectMapper;
+    this.objectPoolConfig = objectPoolConfig;
   }
 
   @Override
@@ -43,7 +48,7 @@ public class JedisClientDelegateFactory implements RedisClientDelegateFactory<Je
     JedisDriverProperties props = objectMapper.convertValue(properties, JedisDriverProperties.class);
     return new JedisClientDelegate(
       name,
-      new JedisPoolFactory(registry).build(name, props)
+      new JedisPoolFactory(registry).build(name, props, objectPoolConfig)
     );
   }
 }

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisDriverProperties.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisDriverProperties.java
@@ -31,6 +31,8 @@ public class JedisDriverProperties {
 
   /**
    * Redis object pool configuration.
+   *
+   * If left null, the default object pool as defined in {@code JedisClientConfiguration} will be used.
    */
-  public GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
+  public GenericObjectPoolConfig poolConfig;
 }

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
@@ -26,6 +26,7 @@ import redis.clients.jedis.Protocol;
 import redis.clients.util.Pool;
 
 import java.net.URI;
+import java.util.Optional;
 
 public class JedisPoolFactory {
 
@@ -39,7 +40,7 @@ public class JedisPoolFactory {
     this.registry = registry;
   }
 
-  public Pool<Jedis> build(String name, JedisDriverProperties properties) {
+  public Pool<Jedis> build(String name, JedisDriverProperties properties, GenericObjectPoolConfig objectPoolConfig) {
     if (properties.connection == null || "".equals(properties.connection)) {
       throw new MissingRequiredConfiguration("Jedis client must have a connection defined");
     }
@@ -50,13 +51,13 @@ public class JedisPoolFactory {
     int port = redisConnection.getPort() == -1 ? Protocol.DEFAULT_PORT : redisConnection.getPort();
     int database = parseDatabase(redisConnection.getPath());
     String password = parsePassword(redisConnection.getUserInfo());
-    GenericObjectPoolConfig objectPoolConfig = properties.poolConfig;
+    GenericObjectPoolConfig poolConfig = Optional.ofNullable(properties.poolConfig).orElse(objectPoolConfig);
     boolean isSSL = redisConnection.getScheme().equals("rediss");
 
     return new InstrumentedJedisPool(
       registry,
       // Pool name should always be "null", as setting this is incompat with some SaaS Redis offerings
-      new JedisPool(objectPoolConfig, host, port, properties.timeoutMs, password, database, null, isSSL),
+      new JedisPool(poolConfig, host, port, properties.timeoutMs, password, database, null, isSSL),
       name
     );
   }


### PR DESCRIPTION
While working on a fix for https://github.com/spinnaker/spinnaker/issues/3309, I noticed a few bugs / missing items.

* Adds a `GenericObjectPoolConfig` as a fallback bean to the `JedisClientConfiguration`. This will now allow kork to use any service-provided override but fallback to default settings if not provided. `GenericObjectPoolConfig` can still be provided on a per-client basis.
* Fixed a bug where two `primaryDefault` clients could be created. For example, Orca currently creates its own `primaryDefault` client, then kork was creating its own as well. Kork will now only create these default clients if one has not already been created by a service.
* Backwards compatibility for `redis.connectionPrevious` was not present. I added this following the same semantics as the `primaryDefault` fix above.
* `InstrumentedJedisPool` had a reference to its own `GenericObjectPoolConfig` that wasn't really being used. While I haven't seen any cases of this pool being used, I overrode the other methods on the `JedisPool` and `Pool<Jedis>` interfaces to use the delegate's internal pool instead.

There will be a followup PR that also cleans up Orca's configuration. Bullets 2 & 3 will allow me to remove all of the `@Deprecated` bean methods within Orca, pushing all redis client setup down to kork.