### PR TITLE
fix(spring): disambiguate EurekaClient beans so they can be injected without a qualifier

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaComponents.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaComponents.java
@@ -54,6 +54,7 @@ public class EurekaComponents {
   }
 
   @Bean
+  @Primary
   public EurekaClient eurekaClient(DiscoveryClient discoveryClient) {
     return discoveryClient;
   }


### PR DESCRIPTION
This messed me up in Keel as I injected `EurekaClient` but there are actually 2 beans of that interface. Both are actually the same object. Using `@Primary` means that clients that wire `EurekaClient` will get just one bean rather than a stacktrace. Anyone still wiring `DiscoveryClient` won't be affected.