### PR TITLE
fix(redis): name clients correctly to 'primaryDefault' (vs 'default')

### DIFF
--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientConfiguration.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientConfiguration.java
@@ -56,10 +56,22 @@ public class RedisClientConfiguration {
 
     redisClientConfigurations.clients.forEach((name, config) -> {
       if (config.primary != null) {
-        clients.add(getClientFactoryForDriver(config.primary.driver).build(name, config.primary.config));
+        clients
+          .add(getClientFactoryForDriver(config.primary.driver)
+            .build(
+              RedisClientSelector.getName(true, name),
+              config.primary.config
+            )
+          );
       }
       if (config.previous != null) {
-        clients.add(getClientFactoryForDriver(config.previous.driver).build(name, config.previous.config));
+        clients
+          .add(getClientFactoryForDriver(config.previous.driver)
+            .build(
+              RedisClientSelector.getName(false, name),
+              config.previous.config
+            )
+          );
       }
     });
     otherRedisClientDelegates.ifPresent(clients::addAll);


### PR DESCRIPTION
Previously, clients were getting initialized as "default", which did not take into account the fact that they may have been "primary". This PR fixes that naming to correctly make the name as either "primaryDefault" or "previousDefault".

Verified this does the right thing by triumphantly getting Swabbie to use a locally published kork 🎊 