### PR TITLE
fix(artifacts): Ignore kind in serialized artifact

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.kork.artifacts.model;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,6 +31,7 @@ import java.util.Map;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties("kind")
 public class Artifact {
   @JsonProperty("type")
   private String type;


### PR DESCRIPTION
The kind field in artifacts is used only in the UI, and is not intended to be part of the server-side specification. Currently the artifact deserializer is putting the kind into the metadata hash; instead let's just ignore it as this is not intended to be used server-side at all.