### PR TITLE
fix(artifacts): Add kind to artifact model

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -31,8 +31,9 @@ import java.util.Map;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonIgnoreProperties("kind")
 public class Artifact {
+  @JsonProperty("kind")
+  private String kind;
   @JsonProperty("type")
   private String type;
   @JsonProperty("name")


### PR DESCRIPTION
While artifact kind was initially intended to only exist on the front-end, we have been persisting it, and actually depend on its existence in the back-end to differentiate between artifacts configured as 'custom' with all fields visible and artifacts configured by selecting a particular type.

Let's officially add this field to the back-end so that persistence doesn't break in workflows that deserialize as an Artifact (instead of just a Map).