### PR TITLE
fix(artifacts): Add customKind to artifact model

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -35,6 +35,8 @@ import java.util.Map;
 public class Artifact {
   @JsonProperty("type")
   private String type;
+  @JsonProperty("customKind")
+  private boolean customKind;
   @JsonProperty("name")
   private String name;
   @JsonProperty("version")


### PR DESCRIPTION
While artifact kind was initially intended to only exist on the front-end, we have been persisting it, and actually depend on its existence in the back-end to differentiate between artifacts configured as 'custom' with all fields visible and artifacts configured by selecting a particular type.

In order to support storing whether an artifact was edited in 'custom' mode (with all fields visible) or using the type-specific editor, add a 'customKind' boolean to the artifact model to indicate this.