### PR TITLE
fix(secrets): return original file path if not encrypted

### DIFF
--- a/kork-secrets/kork-secrets.gradle
+++ b/kork-secrets/kork-secrets.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile spinnaker.dependency('spectatorWebSpring')
   compile spinnaker.dependency('lombok')
   compile spinnaker.dependency('guava')
+  compile spinnaker.dependency('commonsLang')
 
   testCompile spinnaker.dependency('groovy')
   spinnaker.group('spockBase')

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/SecretManager.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/SecretManager.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.config.secrets;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -91,8 +93,8 @@ public class SecretManager {
     }
 
     String decryptedContents = decrypt(filePathOrEncrypted);
-    if (decryptedContents == null) {
-      return null;
+    if (StringUtils.equals(decryptedContents, filePathOrEncrypted)) {
+      return Paths.get(filePathOrEncrypted);
     }
 
     decryptedFile = decryptedFilePath("tmp", decryptedContents);


### PR DESCRIPTION
`decryptAsFile()` should have been returning the original string passed in if that string is unencrypted. `decrypt()` also behaves this way, so the change here just checks if the string returned matches the string passed in.