### PR TITLE
refactor(expressions): Move common expression logic from orca-core

### DIFF
--- a/kork-expressions/kork-expressions.gradle
+++ b/kork-expressions/kork-expressions.gradle
@@ -1,0 +1,15 @@
+test {
+  useJUnitPlatform()
+}
+
+dependencies {
+  compile "com.fasterxml.jackson.core:jackson-databind:${spinnaker.version('jackson')}"
+  compile "org.springframework:spring-context:${spinnaker.version('spring')}"
+  compile spinnaker.dependency('slf4jApi')
+  compile spinnaker.dependency('lombok')
+
+  testCompile "org.assertj:assertj-core:${spinnaker.version('assertj')}"
+  testCompile "org.junit.jupiter:junit-jupiter-api:${spinnaker.version('jupiter')}"
+  testRuntime "org.junit.jupiter:junit-jupiter-engine:${spinnaker.version('jupiter')}"
+  testRuntime spinnaker.dependency('slf4jSimple')
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionEvaluationSummary.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionEvaluationSummary.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * Represents an evaluation summary
+ * Includes INO and ERROR Level messages
+ * ERROR is anything evaluation that results in thrown Exception
+ * INFO unresolved value returned that doesn't throw
+ */
+public class ExpressionEvaluationSummary {
+  private Map<String, Set<Result>> expressionResult;
+  private Set<String> attempts;
+  private AtomicInteger failureCount;
+  private AtomicInteger totalEvaluated;
+
+  public ExpressionEvaluationSummary() {
+    this.expressionResult = new HashMap<>();
+    this.failureCount = new AtomicInteger();
+    this.totalEvaluated = new AtomicInteger();
+    this.attempts = new HashSet<>();
+  }
+
+  public int getTotalEvaluated() {
+    return totalEvaluated.get();
+  }
+
+  public int getFailureCount() {
+    return failureCount.get();
+  }
+
+  public Map<String, Set<Result>> getExpressionResult() {
+    return expressionResult;
+  }
+
+  public void add(String escapedExpression, Result.Level level, String description, Class<?> exceptionType) {
+    Set<Result> messages = expressionResult.getOrDefault(escapedExpression, new HashSet<>());
+    messages.add(new Result(level, System.currentTimeMillis(), description, exceptionType));
+    expressionResult.put(escapedExpression, messages);
+    failureCount.incrementAndGet();
+  }
+
+  public void incrementTotalEvaluated() {
+    totalEvaluated.incrementAndGet();
+  }
+
+  public void appendAttempted(String expression) {
+    attempts.add(expression);
+  }
+
+  public String toString() {
+    String attempted = attempts.stream().collect(Collectors.joining(","));
+    String failed = expressionResult.keySet().stream().collect(Collectors.joining(","));
+    return String.format("%d expression(s) - (%s), %d failed - (%s)",
+      getTotalEvaluated(),
+      attempted,
+      getFailureCount(),
+      failed
+    );
+  }
+
+  static class Result {
+    private String description;
+    private Class<?> exceptionType;
+    private long timestamp;
+    private Level level;
+
+    public Result(Level level, long timestamp, String description, Class<?> exceptionType) {
+      this.level = level;
+      this.timestamp = timestamp;
+      this.description = description;
+      this.exceptionType = exceptionType;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public void setDescription(String description) {
+      this.description = description;
+    }
+
+    public long getTimestamp() {
+      return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+      this.timestamp = timestamp;
+    }
+
+    public Level getLevel() {
+      return level;
+    }
+
+    public void setLevel(Level level) {
+      this.level = level;
+    }
+
+    public Class<?> getExceptionType() {
+      return exceptionType;
+    }
+
+    public void setExceptionType(Class<?> exceptionType) {
+      this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public String toString() {
+      return "Result {" +
+        "description='" + description + '\'' +
+        ", exceptionType=" + exceptionType +
+        ", timestamp=" + timestamp +
+        ", level=" + level +
+        '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Result result = (Result) o;
+
+      return (description != null ? description.equals(result.description) : result.description == null)
+        && (exceptionType != null ? exceptionType.equals(result.exceptionType) : result.exceptionType == null)
+        && level == result.level;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = description != null ? description.hashCode() : 0;
+      result = 31 * result + (exceptionType != null ? exceptionType.hashCode() : 0);
+      result = 31 * result + (level != null ? level.hashCode() : 0);
+      return result;
+    }
+
+    enum Level {
+      ERROR,
+      INFO
+    }
+  }
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionTransform.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionTransform.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.ParserContext;
+import org.springframework.expression.common.CompositeStringExpression;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
+
+public class ExpressionTransform {
+  private final Logger logger = LoggerFactory.getLogger(ExpressionTransform.class);
+
+  private final ParserContext parserContext;
+  private final ExpressionParser parser;
+  private final Function<String, String> stringExpressionPreprocessor;
+  private final Collection<Class<?>> typesToStringify;
+
+  public ExpressionTransform(ParserContext parserContext, ExpressionParser parser,
+                      Function<String, String> stringExpressionPreprocessor,
+                      Class<?>... typesToStringify) {
+    this.parserContext = parserContext;
+    this.parser = parser;
+    this.stringExpressionPreprocessor = stringExpressionPreprocessor;
+    this.typesToStringify = Arrays.asList(typesToStringify);
+  }
+
+  private static Stream<?> flatten(Object o) {
+    if (o instanceof Map) {
+      Map map = (Map) o;
+      List<Object> tokens = new ArrayList<>();
+      tokens.addAll(map.keySet());
+      tokens.addAll(map.values());
+      return tokens
+        .stream()
+        .flatMap(ExpressionTransform::flatten);
+    }
+
+    return Stream.of(o);
+  }
+
+  /**
+   * Finds the original exception in the exception hierarchy
+   */
+  private static Throwable unwrapOriginalException(Throwable e) {
+    if (e == null || e.getCause() == null) return e;
+    return unwrapOriginalException(e.getCause());
+  }
+
+  /**
+   * Helper to escape  a simple expression string
+   * Used to extract a simple expression when parsing fails
+   */
+  private static String escapeSimpleExpression(String expression) {
+    String escaped = null;
+    Matcher matcher = Pattern.compile("\\$\\{(.*)}").matcher(expression);
+    if (matcher.matches()) {
+      escaped = matcher.group(1).trim();
+    }
+
+    return escaped != null ? escaped : expression.replaceAll("\\$", "");
+  }
+
+  /**
+   * Traverses and attempts to evaluate expressions
+   * Failures can either be INFO (for a simple unresolved expression) or ERROR when an exception is thrown
+   *
+   * @return the transformed source object
+   */
+  public Map<String, Object> transformMap(Map<String, Object> source,
+                                          EvaluationContext evaluationContext,
+                                          ExpressionEvaluationSummary summary) {
+    Map<String, Object> result = new HashMap<>();
+    Map<String, Object> copy = Collections.unmodifiableMap(source);
+    source.forEach((key, value) -> {
+      if (value instanceof Map) {
+        result.put(
+          transform(key, evaluationContext, summary, copy).toString(),
+          transformMap((Map) value, evaluationContext, summary)
+        );
+      } else if (value instanceof List) {
+        result.put(
+          transform(key, evaluationContext, summary, copy).toString(),
+          transformList((List) value, evaluationContext, summary, copy)
+        );
+      } else {
+        result.put(
+          transform(key, evaluationContext, summary, copy).toString(),
+          transform(value, evaluationContext, summary, copy)
+        );
+      }
+    });
+
+    return result;
+  }
+
+  private List transformList(List source,
+                             EvaluationContext evaluationContext,
+                             ExpressionEvaluationSummary summary,
+                             Map<String, Object> additionalContext) {
+    List<Object> result = new ArrayList<>();
+    for (Object obj : source) {
+      if (obj instanceof Map) {
+        result.add(
+          transformMap((Map<String, Object>) obj, evaluationContext, summary)
+        );
+      } else if (obj instanceof List) {
+        result.addAll(
+          transformList((List) obj, evaluationContext, summary, additionalContext)
+        );
+      } else {
+        result.add(
+          transform(obj, evaluationContext, summary, additionalContext)
+        );
+      }
+    }
+
+    return result;
+  }
+
+  public String transformString(String source,
+                                EvaluationContext evaluationContext,
+                                ExpressionEvaluationSummary summary) {
+    return (String) transform(source, evaluationContext, summary, Collections.emptyMap());
+  }
+
+  private Object transform(Object source,
+                           EvaluationContext evaluationContext,
+                           ExpressionEvaluationSummary summary,
+                           Map<String, Object> additionalContext) {
+    boolean hasUnresolvedExpressions = false;
+    if (isExpression(source)) {
+      String preprocessed = stringExpressionPreprocessor.apply(source.toString());
+      Object result = null;
+      String escapedExpressionString = null;
+      Throwable exception = null;
+      try {
+        Expression exp = parser.parseExpression(preprocessed, parserContext);
+        escapedExpressionString = escapeExpression(exp);
+        if (exp instanceof CompositeStringExpression) {
+          StringBuilder sb = new StringBuilder();
+          Expression[] expressions = ((CompositeStringExpression) exp).getExpressions();
+          for (Expression e : expressions) {
+            String value = e.getValue(evaluationContext, String.class);
+            if (value == null) {
+              value = String.format("${%s}", e.getExpressionString());
+              hasUnresolvedExpressions = true;
+            }
+            sb.append(value);
+          }
+
+          result = sb.toString();
+        } else {
+          result = exp.getValue(evaluationContext);
+        }
+      } catch (Exception e) {
+        logger.info("Failed to evaluate {}, returning raw value {}", source, e.getMessage());
+        exception = e;
+      } finally {
+        Set keys = getKeys(source, additionalContext);
+        Object fields = !keys.isEmpty() ? keys : preprocessed;
+        String errorDescription = format("Failed to evaluate %s ", fields);
+        escapedExpressionString = escapedExpressionString != null ? escapedExpressionString : escapeSimpleExpression(source.toString());
+        if (exception != null) {
+          Throwable originalException = unwrapOriginalException(exception);
+          if (originalException == null || originalException.getMessage() == null || originalException.getMessage().contains(exception.getMessage())) {
+            errorDescription += exception.getMessage();
+          } else {
+            errorDescription += originalException.getMessage() + " - " + exception.getMessage();
+          }
+
+          summary.add(
+            escapedExpressionString,
+            ExpressionEvaluationSummary.Result.Level.ERROR,
+            errorDescription.replaceAll("\\$", ""),
+            Optional.ofNullable(originalException).map(Object::getClass).orElse(null)
+          );
+
+          result = source;
+        } else if (result == null || hasUnresolvedExpressions) {
+          summary.add(
+            escapedExpressionString,
+            ExpressionEvaluationSummary.Result.Level.INFO,
+            format("%s: %s not found", errorDescription, escapedExpressionString),
+            null
+          );
+
+          if (result == null) {
+            result = source;
+          }
+        }
+
+        summary.appendAttempted(escapedExpressionString);
+        summary.incrementTotalEvaluated();
+      }
+
+      if (typesToStringify.contains(result.getClass())) {
+        result = result.toString();
+      }
+
+      return result;
+    }
+
+    return source;
+  }
+
+  private boolean isExpression(Object obj) {
+    return (obj instanceof String && obj.toString().contains(parserContext.getExpressionPrefix()));
+  }
+
+  /**
+   * finds parent keys by value in a nested map
+   */
+  private Set<String> getKeys(Object value, final Map<String, Object> map) {
+    if (map == null || map.isEmpty()) {
+      return emptySet();
+    }
+
+    return map
+      .entrySet()
+      .stream()
+      .filter(it ->
+        flatten(it.getValue()).collect(toSet()).stream().flatMap(Stream::of).collect(toSet()).contains(value)
+      )
+      .map(Map.Entry::getKey)
+      .collect(toSet());
+  }
+
+  /**
+   * Helper to escape an expression: stripping ${ }
+   */
+  private String escapeExpression(Expression expression) {
+    if (expression instanceof CompositeStringExpression) {
+      StringBuilder sb = new StringBuilder();
+      for (Expression e : ((CompositeStringExpression) expression).getExpressions()) {
+        sb.append(e.getExpressionString());
+      }
+
+      return sb.toString();
+    }
+
+    return expression.getExpressionString();
+  }
+}
+
+

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.expressions.whitelisting.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Stream;
+
+/**
+ * Provides utility support for SpEL integration
+ * Supports registering SpEL functions, ACLs to classes (via whitelisting)
+ */
+public class ExpressionsSupport {
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private final Logger LOGGER = LoggerFactory.getLogger(ExpressionsSupport.class);
+  private final Map<String, List<Class<?>>> registeredHelperFunctions = new HashMap<>();
+  private final Set<Class<?>> allowedReturnTypes;
+
+  public ExpressionsSupport(Class<?>... extraAllowedReturnTypes) {
+    this.registeredHelperFunctions.put("toJson", Collections.singletonList(Object.class));
+    Stream.of("alphanumerical", "readJson", "toInt", "toFloat", "toBoolean", "toBase64", "fromBase64").forEach(fn -> {
+      this.registeredHelperFunctions.put(fn, Collections.singletonList(String.class));
+    });
+
+    this.allowedReturnTypes = new HashSet<>(Arrays.asList(Collection.class,
+      Map.class,
+      SortedMap.class,
+      List.class,
+      Set.class,
+      SortedSet.class,
+      ArrayList.class,
+      LinkedList.class,
+      HashSet.class,
+      LinkedHashSet.class,
+      HashMap.class,
+      LinkedHashMap.class,
+      TreeMap.class,
+      TreeSet.class));
+    Collections.addAll(this.allowedReturnTypes, extraAllowedReturnTypes);
+  }
+
+  /**
+   * Internally registers a SpEL method to an evaluation context
+   */
+  private static void registerFunction(StandardEvaluationContext context, String name, Class<?>... types) throws NoSuchMethodException {
+    context.registerFunction(name, ExpressionsSupport.class.getDeclaredMethod(name, types));
+  }
+
+  /**
+   * Parses a string to an integer
+   *
+   * @param str represents an int
+   * @return an integer
+   */
+  public static Integer toInt(String str) {
+    return Integer.valueOf(str);
+  }
+
+  /*
+    HELPER FUNCTIONS: These functions are explicitly registered with each invocation
+    To add a new helper function, append the function below and update ExpressionHelperFunctions and registeredHelperFunctions
+   */
+
+  /**
+   * Parses a string to a float
+   *
+   * @param str represents an float
+   * @return an float
+   */
+  public static Float toFloat(String str) {
+    return Float.valueOf(str);
+  }
+
+  /**
+   * Parses a string to a boolean
+   *
+   * @param str represents an boolean
+   * @return a boolean
+   */
+  public static Boolean toBoolean(String str) {
+    return Boolean.valueOf(str);
+  }
+
+  /**
+   * Encodes a string to base64
+   *
+   * @param text plain string
+   * @return converted string
+   */
+  public static String toBase64(String text) {
+    return Base64.getEncoder().encodeToString(text.getBytes());
+  }
+
+  /**
+   * Attempts to decode a base64 string
+   *
+   * @param text plain string
+   * @return decoded string
+   */
+  public static String fromBase64(String text) {
+    return new String(Base64.getDecoder().decode(text), StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Converts a String to alpha numeric
+   *
+   * @param str string to convert
+   * @return converted string
+   */
+  public static String alphanumerical(String str) {
+    return str.replaceAll("[^A-Za-z0-9]", "");
+  }
+
+  /**
+   * @param o represents an object to convert to json
+   * @return json representation of the said object
+   */
+  public static String toJson(Object o) {
+    try {
+      String converted = mapper.writeValueAsString(o);
+      if (converted != null && converted.contains("${")) {
+        throw new SpelHelperFunctionException("result for toJson cannot contain an expression");
+      }
+
+      return converted;
+    } catch (Exception e) {
+      throw new SpelHelperFunctionException(String.format("#toJson(%s) failed", o.toString()), e);
+    }
+  }
+
+  /**
+   * Attemps to read json from a text String. Will throw a parsing exception on bad json
+   *
+   * @param text text to read as json
+   * @return the json representation of the text
+   */
+  public static Object readJson(String text) {
+    try {
+      if (text.startsWith("[")) {
+        return mapper.readValue(text, List.class);
+      }
+
+      return mapper.readValue(text, Map.class);
+    } catch (Exception e) {
+      throw new SpelHelperFunctionException(String.format("#readJson(%s) failed", text), e);
+    }
+  }
+
+  /**
+   * Creates a configured SpEL evaluation context
+   *
+   * @param rootObject       the root object to transform
+   * @param allowUnknownKeys flag to control what helper functions are available
+   * @return an evaluation context hooked with helper functions and correct ACL via whitelisting
+   */
+  public StandardEvaluationContext buildEvaluationContext(Object rootObject, boolean allowUnknownKeys) {
+    ReturnTypeRestrictor returnTypeRestrictor = new ReturnTypeRestrictor(allowedReturnTypes);
+
+    StandardEvaluationContext evaluationContext = new StandardEvaluationContext(rootObject);
+    evaluationContext.setTypeLocator(new WhitelistTypeLocator());
+    evaluationContext.setMethodResolvers(Collections.singletonList(
+      new FilteredMethodResolver(returnTypeRestrictor)));
+    evaluationContext.setPropertyAccessors(Arrays.asList(new MapPropertyAccessor(allowUnknownKeys),
+      new FilteredPropertyAccessor(returnTypeRestrictor)));
+
+    try {
+      for (Map.Entry<String, List<Class<?>>> m : registeredHelperFunctions.entrySet()) {
+        registerFunction(evaluationContext, m.getKey(), m.getValue().toArray(new Class<?>[0]));
+      }
+    } catch (NoSuchMethodException e) {
+      // Indicates a function was not properly registered. This should not happen. Please fix the faulty function
+      LOGGER.error("Failed to register helper functions for rootObject {}", rootObject, e);
+    }
+
+    return evaluationContext;
+  }
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/SpelHelperFunctionException.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/SpelHelperFunctionException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions;
+
+public class SpelHelperFunctionException extends RuntimeException {
+  public SpelHelperFunctionException(String message) {
+    super(message);
+  }
+
+  public SpelHelperFunctionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/FilteredMethodResolver.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/FilteredMethodResolver.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions.whitelisting;
+
+import org.springframework.expression.spel.support.ReflectiveMethodResolver;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
+public class FilteredMethodResolver extends ReflectiveMethodResolver {
+  private static final List<Method> rejectedMethods = buildRejectedMethods();
+  private final ReturnTypeRestrictor returnTypeRestrictor;
+
+  public FilteredMethodResolver(ReturnTypeRestrictor returnTypeRestrictor) {
+    this.returnTypeRestrictor = returnTypeRestrictor;
+  }
+
+  private static List<Method> buildRejectedMethods() {
+    try {
+      List<Method> allowedObjectMethods = asList(
+        Object.class.getMethod("equals", Object.class),
+        Object.class.getMethod("hashCode"),
+        Object.class.getMethod("toString")
+      );
+      return Stream.concat(stream(Object.class.getMethods()).filter(it -> !allowedObjectMethods.contains(it)),
+        Stream.concat(stream(Boolean.class.getMethods()).filter(it -> it.getName().equals("getBoolean")),
+          Stream.concat(stream(Integer.class.getMethods()).filter(it -> it.getName().equals("getInteger")),
+            Stream.concat(stream(Long.class.getMethods()).filter(it -> it.getName().equals("getLong")),
+              stream(Class.class.getMethods())))))
+        .collect(toList());
+    } catch (NoSuchMethodException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  protected Method[] getMethods(Class<?> type) {
+    Method[] methods = super.getMethods(type);
+
+    List<Method> m = new ArrayList<>(asList(methods));
+    m.removeAll(rejectedMethods);
+    m = m.stream()
+      .filter(it -> returnTypeRestrictor.supports(it.getReturnType()))
+      .collect(toList());
+
+    return m.toArray(new Method[0]);
+  }
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/FilteredPropertyAccessor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/FilteredPropertyAccessor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions.whitelisting;
+
+import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static java.lang.String.format;
+
+public class FilteredPropertyAccessor extends ReflectivePropertyAccessor {
+  private final ReturnTypeRestrictor returnTypeRestrictor;
+
+  public FilteredPropertyAccessor(ReturnTypeRestrictor returnTypeRestrictor) {
+    this.returnTypeRestrictor = returnTypeRestrictor;
+  }
+
+  @Override
+  protected Method findGetterForProperty(String propertyName, Class<?> clazz, boolean mustBeStatic) {
+    Method getter = super.findGetterForProperty(propertyName, clazz, mustBeStatic);
+    if (getter == null) {
+      throw new IllegalArgumentException(format("requested getter %s not found on type %s", propertyName, clazz));
+    } else if (!returnTypeRestrictor.supports(getter.getReturnType())) {
+      throw new IllegalArgumentException(format("found getter for requested %s but rejected due to return type %s", propertyName, getter.getReturnType()));
+    }
+    return getter;
+  }
+
+  @Override
+  protected Field findField(String name, Class<?> clazz, boolean mustBeStatic) {
+    Field field = super.findField(name, clazz, mustBeStatic);
+    if (field == null) {
+      throw new IllegalArgumentException(format("requested field %s not found on type %s", name, clazz));
+    } else if (!returnTypeRestrictor.supports(field.getType())) {
+      throw new IllegalArgumentException(format("found field %s but rejected due to unsupported type %s", name, clazz));
+    }
+    return field;
+  }
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/InstantiationTypeRestrictor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/InstantiationTypeRestrictor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions.whitelisting;
+
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+public class InstantiationTypeRestrictor {
+  private Set<Class<?>> allowedTypes = Collections.unmodifiableSet(
+    new HashSet<>(
+      Arrays.asList(
+        String.class,
+        Date.class,
+        Integer.class,
+        Long.class,
+        Double.class,
+        Byte.class,
+        SimpleDateFormat.class,
+        Math.class,
+        Random.class,
+        UUID.class,
+        Boolean.class,
+        LocalDate.class,
+        Instant.class,
+        ChronoUnit.class
+      )
+    )
+  );
+
+  boolean supports(Class<?> type) {
+    return allowedTypes.contains(type);
+  }
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/MapPropertyAccessor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/MapPropertyAccessor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions.whitelisting;
+
+import org.springframework.context.expression.MapAccessor;
+import org.springframework.expression.AccessException;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.TypedValue;
+
+public class MapPropertyAccessor extends MapAccessor {
+  private final boolean allowUnknownKeys;
+
+  public MapPropertyAccessor(boolean allowUnknownKeys) {
+    this.allowUnknownKeys = allowUnknownKeys;
+  }
+
+  @Override
+  public boolean canRead(
+    final EvaluationContext context,
+    final Object target,
+    final String name
+  ) throws AccessException {
+    if (allowUnknownKeys) {
+      return true;
+    }
+    return super.canRead(context, target, name);
+  }
+
+  @Override
+  public TypedValue read(
+    final EvaluationContext context,
+    final Object target,
+    final String name
+  ) throws AccessException {
+    try {
+      return super.read(context, target, name);
+    } catch (AccessException ae) {
+      if (allowUnknownKeys) {
+        return TypedValue.NULL;
+      }
+      throw ae;
+    }
+  }
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/ReturnTypeRestrictor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/ReturnTypeRestrictor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions.whitelisting;
+
+import java.util.Set;
+
+public class ReturnTypeRestrictor extends InstantiationTypeRestrictor {
+  private final Set<Class<?>> allowedReturnTypes;
+
+  public ReturnTypeRestrictor(Set<Class<?>> allowedReturnTypes) {
+    this.allowedReturnTypes = allowedReturnTypes;
+  }
+
+  @Override
+  boolean supports(Class<?> type) {
+    Class<?> returnType = type.isArray() ? type.getComponentType() : type;
+    return returnType.isPrimitive() || super.supports(returnType) || allowedReturnTypes.contains(returnType);
+  }
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/WhitelistTypeLocator.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/WhitelistTypeLocator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions.whitelisting;
+
+import org.springframework.expression.EvaluationException;
+import org.springframework.expression.TypeLocator;
+import org.springframework.expression.spel.SpelEvaluationException;
+import org.springframework.expression.spel.SpelMessage;
+import org.springframework.expression.spel.support.StandardTypeLocator;
+
+public class WhitelistTypeLocator implements TypeLocator {
+  private final InstantiationTypeRestrictor instantiationTypeRestrictor = new InstantiationTypeRestrictor();
+  private final TypeLocator delegate = new StandardTypeLocator();
+
+  @Override
+  public Class<?> findType(String typeName) throws EvaluationException {
+    Class<?> type = delegate.findType(typeName);
+    if (instantiationTypeRestrictor.supports(type)) {
+      return type;
+    }
+    throw new SpelEvaluationException(SpelMessage.EXCEPTION_DURING_PROPERTY_READ, typeName);
+  }
+}

--- a/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionTransformTest.java
+++ b/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionTransformTest.java
@@ -1,0 +1,44 @@
+package com.netflix.spinnaker.kork.expressions;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.ParserContext;
+import org.springframework.expression.common.TemplateParserContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExpressionTransformTest {
+  private final ExpressionParser parser = new SpelExpressionParser();
+  private final ParserContext parserContext = new TemplateParserContext("${", "}");
+
+  @Test
+  void evaluateCompositeExpression() {
+    ExpressionEvaluationSummary summary = new ExpressionEvaluationSummary();
+    StandardEvaluationContext evaluationContext = new ExpressionsSupport(Trigger.class)
+      .buildEvaluationContext(new Pipeline(new Trigger(100)), true);
+
+    String evaluated = new ExpressionTransform(parserContext, parser, Function.identity())
+      .transformString("group:artifact:${trigger['buildNumber']}", evaluationContext, summary);
+
+    assertThat(evaluated).isEqualTo("group:artifact:100");
+    assertThat(summary.getFailureCount()).isEqualTo(0);
+  }
+
+  @AllArgsConstructor
+  @Data
+  static class Pipeline {
+    Trigger trigger;
+  }
+
+  @AllArgsConstructor
+  @Data
+  static class Trigger {
+    int buildNumber;
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,8 @@ include 'kork-core',
   'kork-sql',
   'kork-sql-test',
   'kork-test',
-  'kork-telemetry'
+  'kork-telemetry',
+  'kork-expressions'
 
 rootProject.name='kork'
 


### PR DESCRIPTION
We need basic expression evaluation to exist in echo to be able to evaluate expressions in expected artifact inputs before they are matched to trigger artifacts. Moving the common logic here.

Leaving the addition of functions related to stage context and server group identification in Orca as that model is specific to Orca and we only need trigger context evaluation in Echo. The relationship between kork-expressions and Orca's extension to them will become more apparent with the follow-on Orca PR.