### PR TITLE
feat(core/secrets): decrypt application secrets

### DIFF
--- a/kork-core/kork-core.gradle
+++ b/kork-core/kork-core.gradle
@@ -9,9 +9,10 @@ dependencies {
     compile spinnaker.dependency('spectatorGc')
     compile spinnaker.dependency('spectatorJvm')
     compile spinnaker.dependency('spectatorWebSpring')
-
+    compile project(":kork-secrets-aws")
 
     testCompile spinnaker.dependency('groovy')
     spinnaker.group('spockBase')
     testRuntime spinnaker.dependency('slf4jSimple')
+    testCompile(group: 'org.mockito', name: 'mockito-core', version: '2.23.4')
 }

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/secrets/SecretApplicationContextInitializer.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/secrets/SecretApplicationContextInitializer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public class SecretApplicationContextInitializer implements ApplicationContextInitializer {
+
+  @Override
+  public void initialize(ConfigurableApplicationContext applicationContext) {
+    applicationContext.getBeanFactory().addBeanPostProcessor(new SecretBeanPostProcessor(applicationContext));
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/secrets/SecretAwarePropertySource.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/secrets/SecretAwarePropertySource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets;
+
+import com.netflix.spinnaker.config.secrets.EncryptedSecret;
+import com.netflix.spinnaker.config.secrets.SecretException;
+import com.netflix.spinnaker.config.secrets.SecretManager;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.core.env.EnumerablePropertySource;
+
+public class SecretAwarePropertySource extends EnumerablePropertySource<EnumerablePropertySource> {
+  @Setter @Getter
+  private SecretManager secretManager;
+
+  public SecretAwarePropertySource(EnumerablePropertySource source, SecretManager secretManager) {
+    super(source.getName(), source);
+    this.secretManager = secretManager;
+  }
+
+  @Override
+  public Object getProperty(String name) {
+    Object o = source.getProperty(name);
+    if (o instanceof String && EncryptedSecret.isEncryptedSecret((String) o)) {
+      if (secretManager == null) {
+        throw new SecretException("No secret manager to decrypt value of " + name);
+      }
+      if (name.toLowerCase().endsWith("file") || name.toLowerCase().endsWith("path")) {
+        return secretManager.decryptAsFile((String) o).toString();
+      } else {
+        return secretManager.decrypt((String) o);
+      }
+    }
+    return o;
+  }
+
+
+  @Override
+  public String[] getPropertyNames() {
+    return this.source.getPropertyNames();
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/secrets/SecretBeanPostProcessor.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/secrets/SecretBeanPostProcessor.java
@@ -1,0 +1,48 @@
+package com.netflix.spinnaker.kork.secrets;
+
+import com.netflix.spinnaker.config.secrets.SecretManager;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SecretBeanPostProcessor implements BeanPostProcessor {
+
+  private ConfigurableApplicationContext applicationContext;
+
+  SecretBeanPostProcessor(ConfigurableApplicationContext applicationContext) {
+    this.applicationContext = applicationContext;
+  }
+
+  @Override
+  public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+    return bean;
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    if ("secretManager".equals(beanName)) {
+      MutablePropertySources propertySources = applicationContext.getEnvironment().getPropertySources();
+      List<EnumerablePropertySource> enumerableSources = new ArrayList<>();
+
+      for (PropertySource ps : propertySources) {
+        if (ps instanceof EnumerablePropertySource) {
+          enumerableSources.add((EnumerablePropertySource) ps);
+        }
+      }
+
+      for (EnumerablePropertySource s : enumerableSources) {
+        propertySources.replace(s.getName(), new SecretAwarePropertySource(s, (SecretManager) bean));
+      }
+    }
+
+    return bean;
+  }
+
+
+}

--- a/kork-core/src/main/resources/META-INF/spring.factories
+++ b/kork-core/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   com.netflix.spinnaker.kork.PlatformComponents
+
+org.springframework.context.ApplicationContextInitializer=\
+  com.netflix.spinnaker.kork.secrets.SecretApplicationContextInitializer

--- a/kork-core/src/test/java/com/netflix/spinnaker/kork/secrets/SecretAwarePropertySourceTest.java
+++ b/kork-core/src/test/java/com/netflix/spinnaker/kork/secrets/SecretAwarePropertySourceTest.java
@@ -1,0 +1,95 @@
+package com.netflix.spinnaker.kork.secrets;
+
+import com.netflix.spinnaker.config.secrets.SecretException;
+import com.netflix.spinnaker.config.secrets.SecretManager;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.core.env.EnumerablePropertySource;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SecretAwarePropertySourceTest {
+
+  private SecretAwarePropertySource secretAwarePropertySource;
+  private SecretManager secretManager;
+  private Map<String, String> testValues = new HashMap<>();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setup() {
+    EnumerablePropertySource source  = new EnumerablePropertySource("testSource") {
+      @Override
+      public String[] getPropertyNames() {
+        return new String[0];
+      }
+      @Override
+      public Object getProperty(String name) {
+        return testValues.get(name);
+      }
+    };
+
+    testValues.put("testSecretFile", "encrypted:noop!k:testValue");
+    testValues.put("testSecretPath", "encrypted:noop!k:testValue");
+    testValues.put("testSecretString", "encrypted:noop!k:testValue");
+    testValues.put("testNotSoSecret", "unencrypted");
+
+    secretManager = mock(SecretManager.class);
+    secretAwarePropertySource = new SecretAwarePropertySource(source, secretManager);
+
+    when(secretManager.decryptAsFile(any())).thenReturn(Paths.get("decryptedFile"));
+    when(secretManager.decrypt(any())).thenReturn("decryptedString");
+  }
+
+  @Test
+  public void secretPropertyShouldGetDecrypted() {
+    secretAwarePropertySource.getProperty("testSecretString");
+    verify(secretManager, times(1)).decrypt(any());
+    verify(secretManager, never()).decryptAsFile(any());
+  }
+
+  @Test
+  public void secretFileShouldGetDecryptedAsFile() {
+    secretAwarePropertySource.getProperty("testSecretFile");
+    verify(secretManager, never()).decrypt(any());
+    verify(secretManager, times(1)).decryptAsFile(any());
+  }
+
+  @Test
+  public void secretPathShouldGetDecryptedAsFile() {
+    secretAwarePropertySource.getProperty("testSecretPath");
+    verify(secretManager, never()).decrypt(any());
+    verify(secretManager, times(1)).decryptAsFile(any());
+  }
+
+  @Test
+  public void unencryptedPropertyShouldDoNothing() {
+    String notSecretKey = "testNotSoSecret";
+    Object returnedValue = secretAwarePropertySource.getProperty(notSecretKey);
+    verify(secretManager, never()).decrypt(any());
+    verify(secretManager, never()).decryptAsFile(any());
+    assertEquals(testValues.get(notSecretKey), returnedValue);
+  }
+
+  @Test
+  public void noSecretManagerShouldThrowException() {
+    secretAwarePropertySource.setSecretManager(null);
+    thrown.expect(SecretException.class);
+    thrown.expectMessage("No secret manager to decrypt value of testSecretString");
+    secretAwarePropertySource.getProperty("testSecretString");
+  }
+
+}

--- a/kork-core/src/test/java/com/netflix/spinnaker/kork/secrets/SecretBeanPostProcessorTest.java
+++ b/kork-core/src/test/java/com/netflix/spinnaker/kork/secrets/SecretBeanPostProcessorTest.java
@@ -1,0 +1,95 @@
+package com.netflix.spinnaker.kork.secrets;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SecretBeanPostProcessorTest {
+
+  @Mock
+  private ConfigurableApplicationContext applicationContext;
+
+  @Mock
+  private ConfigurableEnvironment environment;
+
+  private Object regularBean = new Object();
+  private SecretBeanPostProcessor secretBeanPostProcessor;
+  private MutablePropertySources mutablePropertySources = new MutablePropertySources();
+
+  private PropertySource propertySource = new PropertySource("testPropertySource") {
+    @Override
+    public Object getProperty(String name) {
+      return null;
+    }
+  };
+
+  private EnumerablePropertySource enumerablePropertySource = new EnumerablePropertySource("testEnumerableSource") {
+    @Override
+    public String[] getPropertyNames() {
+      return new String[0];
+    }
+
+    @Override
+    public Object getProperty(String name) {
+      return null;
+    }
+  };
+
+  @Before
+  public void setup() {
+    mutablePropertySources.addLast(propertySource);
+    mutablePropertySources.addLast(enumerablePropertySource);
+
+    MockitoAnnotations.initMocks(this);
+    when(applicationContext.getEnvironment()).thenReturn(environment);
+    when(environment.getPropertySources()).thenReturn(mutablePropertySources);
+
+    secretBeanPostProcessor = new SecretBeanPostProcessor(applicationContext);
+  }
+
+  @Test
+  public void secretManagerBeanShouldGetProcessed() {
+    secretBeanPostProcessor.postProcessAfterInitialization(null, "secretManager");
+    verify(applicationContext, times(1)).getEnvironment();
+  }
+
+  @Test
+  public void replaceEnumerableSourceWithSecretAwareSourceInSecretManagerBean() {
+    assertTrue(mutablePropertySources.get("testEnumerableSource") instanceof EnumerablePropertySource);
+    assertFalse(mutablePropertySources.get("testPropertySource") instanceof EnumerablePropertySource);
+
+    secretBeanPostProcessor.postProcessAfterInitialization(null, "secretManager");
+
+    assertTrue(mutablePropertySources.get("testEnumerableSource") instanceof SecretAwarePropertySource);
+    assertFalse(mutablePropertySources.get("testPropertySource") instanceof SecretAwarePropertySource);
+  }
+
+  @Test
+  public void nonSecretManagerBeanShouldDoNothingAndReturnSameBean() {
+    assertTrue(mutablePropertySources.get("testEnumerableSource") instanceof EnumerablePropertySource);
+    assertFalse(mutablePropertySources.get("testPropertySource") instanceof EnumerablePropertySource);
+
+    Object returnedBean = secretBeanPostProcessor.postProcessAfterInitialization(regularBean, "notSecretManager");
+
+    assertTrue(mutablePropertySources.get("testEnumerableSource") instanceof EnumerablePropertySource);
+    assertFalse(mutablePropertySources.get("testEnumerableSource") instanceof SecretAwarePropertySource);
+    assertFalse(mutablePropertySources.get("testPropertySource") instanceof SecretAwarePropertySource);
+
+    verify(applicationContext, never()).getEnvironment();
+    assertEquals(regularBean, returnedBean);
+  }
+}

--- a/kork-secrets-aws/kork-secrets-aws.gradle
+++ b/kork-secrets-aws/kork-secrets-aws.gradle
@@ -1,6 +1,5 @@
 dependencies {
   compile spinnaker.dependency('lombok')
-  compile project(':kork-core')
   compile project(':kork-secrets')
   compile spinnaker.dependency('awsS3')
 }


### PR DESCRIPTION
Part of secrets management project: [spinnaker/spinnaker#3649](https://github.com/spinnaker/spinnaker/issues/3649)

Adds a Spring PropertySource to allow for decryption of secrets in the services when configs are read in.