### PR TITLE
feat(secrets): clear secret caches at the end of each session

### DIFF
--- a/kork-secrets-aws/src/main/java/com/netflix/spinnaker/config/secrets/engines/S3SecretEngine.java
+++ b/kork-secrets-aws/src/main/java/com/netflix/spinnaker/config/secrets/engines/S3SecretEngine.java
@@ -17,22 +17,14 @@
 package com.netflix.spinnaker.config.secrets.engines;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.S3Object;
 import com.netflix.spinnaker.config.secrets.EncryptedSecret;
-import com.netflix.spinnaker.config.secrets.InvalidSecretFormatException;
-import com.netflix.spinnaker.config.secrets.SecretEngine;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashSet;
-import java.util.Set;
 
 @Component
 public class S3SecretEngine extends AbstractStorageSecretEngine {

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/SecretEngine.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/SecretEngine.java
@@ -41,4 +41,6 @@ public interface SecretEngine {
   default EncryptedSecret encrypt(String secretToEncrypt) {
     throw new UnsupportedOperationException("This operation is not supported");
   }
+
+  void clearCache();
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/SecretManager.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/SecretManager.java
@@ -120,6 +120,13 @@ public class SecretManager {
     secretFileCache.remove(encryptedFilePath);
   }
 
+  public void clearCachedSecrets() {
+    secretCache.clear();
+    for (SecretEngine se : secretEngineRegistry.getSecretEngineList()) {
+      se.clearCache();
+    }
+  }
+
   public String getCachedSecret(String encryptedSecret) {
     return secretCache.get(encryptedSecret);
   }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/engines/AbstractStorageSecretEngine.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/engines/AbstractStorageSecretEngine.java
@@ -132,4 +132,8 @@ public abstract class AbstractStorageSecretEngine implements SecretEngine {
     }
     throw new SecretDecryptionException("Invalid secret key specified: " + yamlPath);
   }
+
+  public void clearCache() {
+    cache.clear();
+  }
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/engines/NoopSecretEngine.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/engines/NoopSecretEngine.java
@@ -41,4 +41,7 @@ public class NoopSecretEngine implements SecretEngine {
 
   @Override
   public void validate(EncryptedSecret encryptedSecret) {}
+
+  @Override
+  public void clearCache() {}
 }


### PR DESCRIPTION
We need to clear the secret caches at the end of each session so the code picks up any user changes to secret fields or files.

Part of https://github.com/spinnaker/spinnaker/issues/3649