### PR TITLE
feat(secrets): improve error messages for S3 secret engine decryption

### DIFF
--- a/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/engines/AbstractStorageSecretEngine.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/engines/AbstractStorageSecretEngine.java
@@ -126,7 +126,7 @@ public abstract class AbstractStorageSecretEngine implements SecretEngine {
         parsed = (Map<String, Object>) o;
       } else if (o instanceof List) {
         parsed = ((List<Map<String, Object>>) o).get(Integer.valueOf(pathElt));
-      } else {
+      } else if (o != null){
         return (String) o;
       }
     }


### PR DESCRIPTION
The current error messages aren't as helpful as they could be. Adding a specific errors for the following:

- bucket unauthorized
- bucket not found
- file not found
- key not found