### PR TITLE
feat(secrets): decrypt saml keystore in services

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/secrets/SecretAwarePropertySource.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/secrets/SecretAwarePropertySource.java
@@ -39,7 +39,7 @@ public class SecretAwarePropertySource extends EnumerablePropertySource<Enumerab
       if (secretManager == null) {
         throw new SecretException("No secret manager to decrypt value of " + name);
       }
-      if (name.toLowerCase().endsWith("file") || name.toLowerCase().endsWith("path")) {
+      if (name.toLowerCase().endsWith("file") || name.toLowerCase().endsWith("path") || name.equalsIgnoreCase("keystore")) {
         return secretManager.decryptAsFile((String) o).toString();
       } else {
         return secretManager.decrypt((String) o);


### PR DESCRIPTION
The saml keystore doesn't end with "file" or "path" so currently it won't be decrypted in the services. This change enables decryption.