### PR TITLE
feat(secrets): add decryption as bytes for binary secret files

### DIFF
--- a/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/SecretEngine.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/SecretEngine.java
@@ -24,7 +24,7 @@ package com.netflix.spinnaker.config.secrets;
 public interface SecretEngine {
   String identifier();
 
-  String decrypt(EncryptedSecret encryptedSecret);
+  byte[] decrypt(EncryptedSecret encryptedSecret);
 
   /**
    * In order for a secretEngine to decrypt an EncryptedSecret, it may require extra information (e.g.

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/SecretSession.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/SecretSession.java
@@ -34,6 +34,10 @@ public class SecretSession {
     return decryptedFile;
   }
 
+  public byte[] decryptAsBytes(String encrypted) {
+    return secretManager.decryptAsBytes(encrypted);
+  }
+
   public void clearCachedSecrets() {
     secretCache.clear();
     secretFileCache.clear();

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/engines/AbstractStorageSecretEngine.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/engines/AbstractStorageSecretEngine.java
@@ -39,7 +39,7 @@ public abstract class AbstractStorageSecretEngine implements SecretEngine {
   protected Yaml yamlParser = new Yaml();
 
 
-  public String decrypt(EncryptedSecret encryptedSecret) {
+  public byte[] decrypt(EncryptedSecret encryptedSecret) {
     String fileUri = encryptedSecret.getParams().get(STORAGE_FILE_URI);
     String key = encryptedSecret.getParams().get(STORAGE_PROP_KEY);
 
@@ -52,7 +52,7 @@ public abstract class AbstractStorageSecretEngine implements SecretEngine {
 
       // Return the whole content as a string
       if (key == null) {
-        return new String(readAll(is));
+        return readAll(is);
       }
 
       // Parse as YAML
@@ -116,7 +116,7 @@ public abstract class AbstractStorageSecretEngine implements SecretEngine {
     cache.put(fileURI, parsed);
   }
 
-  protected String getParsedValue(String fileURI, String yamlPath) throws SecretDecryptionException {
+  protected byte[] getParsedValue(String fileURI, String yamlPath) throws SecretDecryptionException {
     Map<String,Object> parsed = cache.get(fileURI);
 
     for (Iterator<String> it = Splitter.on(".").split(yamlPath).iterator(); it.hasNext(); ) {
@@ -126,8 +126,8 @@ public abstract class AbstractStorageSecretEngine implements SecretEngine {
         parsed = (Map<String, Object>) o;
       } else if (o instanceof List) {
         parsed = ((List<Map<String, Object>>) o).get(Integer.valueOf(pathElt));
-      } else if (o != null){
-        return (String) o;
+      } else {
+        return ((String) o).getBytes();
       }
     }
     throw new SecretDecryptionException("Invalid secret key specified: " + yamlPath);

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/engines/NoopSecretEngine.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/config/secrets/engines/NoopSecretEngine.java
@@ -35,8 +35,8 @@ public class NoopSecretEngine implements SecretEngine {
   }
 
   @Override
-  public String decrypt(EncryptedSecret encryptedSecret) {
-    return encryptedSecret.getParams().get(PARAM_VALUE);
+  public byte[] decrypt(EncryptedSecret encryptedSecret) {
+    return encryptedSecret.getParams().get(PARAM_VALUE).getBytes();
   }
 
   @Override

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/config/secrets/SecretManagerTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/config/secrets/SecretManagerTest.java
@@ -60,7 +60,7 @@ public class SecretManagerTest {
   @Test
   public void decryptTest() throws SecretDecryptionException {
     String secretConfig = "encrypted:s3!paramName:paramValue";
-    when(secretEngine.decrypt(any())).thenReturn("test");
+    when(secretEngine.decrypt(any())).thenReturn("test".getBytes());
     assertEquals("test", secretManager.decrypt(secretConfig));
   }
 
@@ -68,7 +68,7 @@ public class SecretManagerTest {
   public void decryptSecretEngineNotFound() throws SecretDecryptionException {
     when(secretEngineRegistry.getEngine("does-not-exist")).thenReturn(null);
     String secretConfig = "encrypted:does-not-exist!paramName:paramValue";
-    exceptionRule.expect(InvalidSecretFormatException.class);
+    exceptionRule.expect(SecretDecryptionException.class);
     exceptionRule.expectMessage("Secret Engine does not exist: does-not-exist");
     secretManager.decrypt(secretConfig);
   }
@@ -84,7 +84,7 @@ public class SecretManagerTest {
   @Test
   public void decryptFile() throws SecretDecryptionException, IOException {
     String secretConfig = "encrypted:s3!paramName:paramValue";
-    when(secretEngine.decrypt(any())).thenReturn("test");
+    when(secretEngine.decrypt(any())).thenReturn("test".getBytes());
     Path path = secretManager.decryptAsFile(secretConfig);
     assertTrue(path.toAbsolutePath().toString().matches(".*.secret$"));
     BufferedReader reader = new BufferedReader(new FileReader(path.toFile()));
@@ -96,7 +96,7 @@ public class SecretManagerTest {
   public void decryptFileSecretEngineNotFound() throws SecretDecryptionException {
     when(secretEngineRegistry.getEngine("does-not-exist")).thenReturn(null);
     String secretConfig = "encrypted:does-not-exist!paramName:paramValue";
-    exceptionRule.expect(InvalidSecretFormatException.class);
+    exceptionRule.expect(SecretDecryptionException.class);
     exceptionRule.expectMessage("Secret Engine does not exist: does-not-exist");
     secretManager.decryptAsFile(secretConfig);
   }

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/config/secrets/engines/AbstractStorageEngineTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/config/secrets/engines/AbstractStorageEngineTest.java
@@ -24,8 +24,10 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class AbstractStorageEngineTest {
   AbstractStorageSecretEngine engine;
@@ -54,8 +56,8 @@ public class AbstractStorageEngineTest {
     ByteArrayInputStream bis = readStream("test: value\na:\n  b: othervalue\nc:\n  - d\n  - e");
     engine.yamlParser = new Yaml();
     engine.parseAsYaml("a/b", bis);
-    assertEquals("value", engine.getParsedValue("a/b", "test"));
-    assertEquals("othervalue", engine.getParsedValue("a/b", "a.b"));
+    assertTrue(Arrays.equals("value".getBytes(), engine.getParsedValue("a/b", "test")));
+    assertTrue(Arrays.equals("othervalue".getBytes(), engine.getParsedValue("a/b", "a.b")));
   }
 
 }


### PR DESCRIPTION
Some secret files such as java keystores will require decryption in the form of bytes instead of strings.

Part of spinnaker/spinnaker#3649