### PR TITLE
fix(authz): apply requestMatchers on security configurers.

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/ActuatorEndpointsConfiguration.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/ActuatorEndpointsConfiguration.java
@@ -16,18 +16,20 @@
 package com.netflix.spinnaker.config;
 
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
 @Configuration
-@Order(1000)
+@Order(Ordered.HIGHEST_PRECEDENCE + 67)
 public class ActuatorEndpointsConfiguration extends WebSecurityConfigurerAdapter {
 
   @Override
   public void configure(HttpSecurity http) throws Exception {
     // The health endpoint should always be exposed without auth.
-    http.authorizeRequests().requestMatchers(EndpointRequest.to("health")).permitAll();
+    http.requestMatcher(EndpointRequest.to(HealthEndpoint.class)).authorizeRequests().anyRequest().permitAll();
   }
 }

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/MetricsEndpointConfiguration.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/MetricsEndpointConfiguration.java
@@ -19,20 +19,23 @@ import com.netflix.spectator.api.Registry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @ConditionalOnClass(Registry.class)
 @ComponentScan(basePackages = "com.netflix.spectator.controllers")
-@Order(101)
+@Order(Ordered.HIGHEST_PRECEDENCE + 101)
 public class MetricsEndpointConfiguration extends WebSecurityConfigurerAdapter {
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     // Allow anyone to access the spectator metrics endpoint.
-    http.authorizeRequests().requestMatchers(new AntPathRequestMatcher("/spectator/metrics")).permitAll();
+    http.requestMatcher(new AntPathRequestMatcher("/spectator/metrics")).authorizeRequests().anyRequest().permitAll();
   }
 }


### PR DESCRIPTION
Without registering a requestMatcher, these WebSecurityConfigurerAdapters will handle the auth
for any request, when they really only care about allowing access to certain paths and the
opinions of how to perform application wide authentication/authorization are intended to be
configured elsewhere.