### PR TITLE
fix(bom): make sure we get spock 1.1

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -48,10 +48,10 @@ dependencies {
   api(platform("org.jetbrains.kotlin:kotlin-bom:1.3.30"))
   api(platform("org.junit:junit-bom:5.4.1"))
   api(platform("com.fasterxml.jackson:jackson-bom:2.9.8"))
+  api(platform("org.spockframework:spock-bom:1.1-groovy-2.4"))
   api(platform("org.springframework.boot:spring-boot-dependencies:1.5.17.RELEASE"))
   api(platform("com.amazonaws:aws-java-sdk-bom:1.11.469"))
   api(platform("io.strikt:strikt-bom:0.20.0"))
-  api(platform("org.spockframework:spock-bom:1.1-groovy-2.4"))
 
   constraints {
     api("cglib:cglib-nodep:3.2.0")


### PR DESCRIPTION
Use Spock 1.1 that we explicitly specify vs one provided in spring-dependencies