### PR TITLE
fix(auth): converts allowAnonymous to unchecked exceptions

### DIFF
--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java
@@ -77,12 +77,16 @@ public class AuthenticatedRequest {
    *
    * <pre><code>AuthenticatedRequest.allowAnonymous(() -&gt; { // do HTTP call here });</code></pre>
    */
-  public static <V> V allowAnonymous(Callable<V> closure) throws Exception {
+  public static <V> V allowAnonymous(Callable<V> closure) {
     String originalValue = MDC.get(Header.XSpinnakerAnonymous);
     MDC.put(Header.XSpinnakerAnonymous, "anonymous");
 
     try {
       return closure.call();
+    } catch (RuntimeException re) {
+      throw re;
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
     } finally {
       setOrRemoveMdc(Header.XSpinnakerAnonymous, originalValue);
     }


### PR DESCRIPTION
Since the typical usage pattern for allowAnonymous is to inline wrap a call to a retrofit service,
and the retrofit exceptions are already unchecked, it simplifies coding (in java) not to have to
try catch around calls to allowAnonymous