### PR TITLE
fix(requests): Correctly compare header names

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/filters/AuthenticatedRequestFilter.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/filters/AuthenticatedRequestFilter.groovy
@@ -95,8 +95,10 @@ class AuthenticatedRequestFilter implements Filter {
       Enumeration<String> headers = httpServletRequest.getHeaderNames()
 
       for (header in headers) {
-        if (header.startsWith(Header.XSpinnakerPrefix)) {
-          otherSpinnakerHeaders.put(header, httpServletRequest.getHeader(header))
+        String headerUpper = header.toUpperCase()
+
+        if (headerUpper.startsWith(Header.XSpinnakerPrefix)) {
+          otherSpinnakerHeaders.put(headerUpper, httpServletRequest.getHeader(header))
         }
       }
     }


### PR DESCRIPTION
Fixes a bug resulting from https://github.com/spinnaker/kork/pull/270
where X-SPINNAKER-* headers stopped being propagated because they were
not compared in a case insensitive way