### PR TITLE
fix(sql): force jooq version at 3.9.6

### DIFF
--- a/kork-sql/kork-sql.gradle
+++ b/kork-sql/kork-sql.gradle
@@ -8,7 +8,9 @@ dependencies {
   api project(":kork-security")
   api "org.springframework:spring-jdbc"
   api "org.springframework:spring-tx"
-  api "org.jooq:jooq"
+  api("org.jooq:jooq:3.9.6"){
+    force = true
+  }
   api "org.liquibase:liquibase-core"
   api "com.zaxxer:HikariCP"
 


### PR DESCRIPTION
Looks like this version wasn't actually being forced in kork-sql