### PR TITLE
feat(tomcat): allow relaxed URI support

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy
@@ -45,8 +45,9 @@ class TomcatConfiguration {
 
   @Bean
   TomcatContainerCustomizerUtil tomcatContainerCustomizerUtil(OkHttpClientConfigurationProperties okHttpClientConfigurationProperties,
-                                                              SslExtensionConfigurationProperties sslExtensionConfigurationProperties) {
-    return new TomcatContainerCustomizerUtil(okHttpClientConfigurationProperties, sslExtensionConfigurationProperties)
+                                                              SslExtensionConfigurationProperties sslExtensionConfigurationProperties,
+                                                              TomcatConfigurationProperties tomcatConfigurationProperties) {
+    return new TomcatContainerCustomizerUtil(okHttpClientConfigurationProperties, sslExtensionConfigurationProperties, tomcatConfigurationProperties)
   }
 
   /**
@@ -69,6 +70,7 @@ class TomcatConfiguration {
         @Override
         void customize(Connector connector) {
           tomcatContainerCustomizerUtil.applySSLSettings(connector)
+          tomcatContainerCustomizerUtil.applyRelaxedURIProperties(connector)
         }
       })
 
@@ -90,6 +92,7 @@ class TomcatConfiguration {
         def sslCustomizer = new SslConnectorCustomizer(ssl, tomcat.getSslStoreProvider())
         sslCustomizer.customize(apiConnector)
         tomcatContainerCustomizerUtil.applySSLSettings(apiConnector)
+        tomcatContainerCustomizerUtil.applyRelaxedURIProperties(apiConnector)
         tomcat.addAdditionalTomcatConnectors(apiConnector)
       }
     } as WebServerFactoryCustomizer

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfigurationProperties.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfigurationProperties.java
@@ -24,6 +24,9 @@ public class TomcatConfigurationProperties {
 
   private int apiPort = -1;
 
+  private String relaxedQueryCharacters = "";
+  private String relaxedPathCharacters = "";
+
   public int getLegacyServerPort() {
     return legacyServerPort;
   }
@@ -38,5 +41,21 @@ public class TomcatConfigurationProperties {
 
   public void setApiPort(int apiPort) {
     this.apiPort = apiPort;
+  }
+
+  public String getRelaxedQueryCharacters() {
+    return relaxedQueryCharacters;
+  }
+
+  public void setRelaxedQueryCharacters(String relaxedQueryCharacters) {
+    this.relaxedQueryCharacters = relaxedQueryCharacters;
+  }
+
+  public String getRelaxedPathCharacters() {
+    return relaxedPathCharacters;
+  }
+
+  public void setRelaxedPathCharacters(String relaxedPathCharacters) {
+    this.relaxedPathCharacters = relaxedPathCharacters;
   }
 }

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/TomcatContainerCustomizerUtil.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/tomcat/TomcatContainerCustomizerUtil.groovy
@@ -1,23 +1,32 @@
 package com.netflix.spinnaker.tomcat
 
+import com.netflix.spinnaker.config.TomcatConfigurationProperties
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import com.netflix.spinnaker.tomcat.x509.BlacklistingSSLImplementation
 import com.netflix.spinnaker.tomcat.x509.SslExtensionConfigurationProperties
 import org.apache.catalina.connector.Connector
 import org.apache.coyote.http11.AbstractHttp11JsseProtocol
+import org.apache.coyote.http11.AbstractHttp11Protocol
 import org.apache.tomcat.util.net.SSLHostConfig
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory
 import org.springframework.boot.web.server.Ssl
 
 class TomcatContainerCustomizerUtil {
 
+  private final Logger log = LoggerFactory.getLogger(getClass())
+
   private final OkHttpClientConfigurationProperties okHttpClientConfigurationProperties
   private final SslExtensionConfigurationProperties sslExtensionConfigurationProperties
+  private final TomcatConfigurationProperties tomcatConfigurationProperties
 
   TomcatContainerCustomizerUtil(OkHttpClientConfigurationProperties okHttpClientConfigurationProperties,
-                                SslExtensionConfigurationProperties sslExtensionConfigurationProperties) {
+                                SslExtensionConfigurationProperties sslExtensionConfigurationProperties,
+                                TomcatConfigurationProperties tomcatConfigurationProperties) {
     this.okHttpClientConfigurationProperties = okHttpClientConfigurationProperties
     this.sslExtensionConfigurationProperties = sslExtensionConfigurationProperties
+    this.tomcatConfigurationProperties = tomcatConfigurationProperties
   }
 
   Ssl copySslConfigurationWithClientAuth(TomcatServletWebServerFactory tomcat) {
@@ -47,6 +56,24 @@ class TomcatContainerCustomizerUtil {
         sslHostConfig.setProtocols(okHttpClientConfigurationProperties.tlsVersions.join(","))
         sslHostConfig.setCertificateRevocationListFile(sslExtensionConfigurationProperties.getCrlFile())
       }
+    }
+  }
+
+  void applyRelaxedURIProperties(Connector connector) {
+    if (!(tomcatConfigurationProperties.relaxedPathCharacters || tomcatConfigurationProperties.relaxedQueryCharacters)) {
+      return
+    }
+
+    def protocolHandler = connector.protocolHandler
+    if (protocolHandler instanceof AbstractHttp11Protocol) {
+      if (tomcatConfigurationProperties.relaxedPathCharacters) {
+        protocolHandler.relaxedPathChars = tomcatConfigurationProperties.relaxedPathCharacters
+      }
+      if (tomcatConfigurationProperties.relaxedQueryCharacters) {
+        protocolHandler.relaxedQueryChars = tomcatConfigurationProperties.relaxedQueryCharacters
+      }
+    } else {
+      log.warn("Can't apply relaxedPath/Query config to connector of type $connector.protocolHandlerClassName")
     }
   }
 }


### PR DESCRIPTION
newer tomcat as part of the upgrade to boot2 is stricter about
which characters are allowed in a URI path or query, but does
support relaxed mode for those characters.

this exposes two additional configuration options:
```yaml
default:
  relaxedPathCharacters: "[]"
  relaxedQueryCharacters: ${default.relaxedPathCharacters}
```

These strings consist of characters that are allowable in URIs
even if they don't strictly conform to the RFC.

An example we found was the square bracket characters were
previously acceptable, and were used in pipeline configuration
names. This setting allows us to preserve that capability
until we can migrate callers to properly URLEncode paths and
queries