### PR TITLE
fix(dependencies): pin back jinjava version

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -67,7 +67,7 @@ dependencies {
     api("com.google.apis:google-api-services-monitoring:v3-rev477-1.25.0")
     api("com.google.apis:google-api-services-storage:v1-rev141-1.25.0")
     api("com.google.code.findbugs:jsr305:3.0.2")
-    api("com.hubspot.jinjava:jinjava:2.4.12")
+    api("com.hubspot.jinjava:jinjava:2.2.3") // DO NOT CHANGE: MPTv1 strongly depends on this version of Jinjava
     api("com.jcraft:jsch.agentproxy.connector-factory:${versions.jsch}")
     api("com.jcraft:jsch.agentproxy.jsch:${versions.jsch}")
     api("com.natpryce:hamkrest:1.4.2.2")


### PR DESCRIPTION
MPTv1 has a strong dependency on jinjava 2.2.3 and anything higher breaks it