### PR TITLE
feat(exceptions): Adding tiered root-level exceptions

### DIFF
--- a/kork-exceptions/kork-exceptions.gradle
+++ b/kork-exceptions/kork-exceptions.gradle
@@ -3,6 +3,7 @@ apply plugin: "groovy"
 
 dependencies {
   api(platform(project(":spinnaker-dependencies")))
+  api "com.google.code.findbugs:jsr305"
 
   testImplementation "org.codehaus.groovy:groovy-all"
   testImplementation "org.spockframework:spock-core"

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/core/RetrySupport.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/core/RetrySupport.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.kork.core;
 
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import java.util.function.Supplier;
 
 public class RetrySupport {
@@ -25,6 +26,12 @@ public class RetrySupport {
       try {
         return fn.get();
       } catch (Exception e) {
+        if (e instanceof SpinnakerException) {
+          Boolean retryable = ((SpinnakerException) e).getRetryable();
+          if (retryable != null && !retryable) {
+            throw e;
+          }
+        }
         if (retries >= (maxRetries - 1)) {
           throw e;
         }

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/ConstraintViolationException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/ConstraintViolationException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.exceptions;
+
+/**
+ * Thrown when an "expected" possible constraint is violated. This isn't necessarily the fault of
+ * the system, an integration, or a user. A prime example would be a preconditions check, traffic
+ * guards, and the like.
+ */
+public class ConstraintViolationException extends SpinnakerException {
+  public ConstraintViolationException(String message) {
+    super(message);
+  }
+
+  public ConstraintViolationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ConstraintViolationException(Throwable cause) {
+    super(cause);
+  }
+
+  public ConstraintViolationException(String message, String userMessage) {
+    super(message, userMessage);
+  }
+
+  public ConstraintViolationException(String message, Throwable cause, String userMessage) {
+    super(message, cause, userMessage);
+  }
+
+  public ConstraintViolationException(Throwable cause, String userMessage) {
+    super(cause, userMessage);
+  }
+}

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/HasAdditionalAttributes.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/HasAdditionalAttributes.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.web.exceptions;
+package com.netflix.spinnaker.kork.exceptions;
 
 import java.util.Collections;
 import java.util.Map;
 
+/** Provides a standard way of attaching untyped, arbitrary metadata to an Exception. */
 public interface HasAdditionalAttributes {
   default Map<String, Object> getAdditionalAttributes() {
     return Collections.emptyMap();

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/IntegrationException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/IntegrationException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.exceptions;
+
+/** An exception thrown by non-core Spinnaker code (e.g. cloud providers, vendor stages, etc.) */
+public class IntegrationException extends SpinnakerException {
+  public IntegrationException(String message) {
+    super(message);
+  }
+
+  public IntegrationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public IntegrationException(Throwable cause) {
+    super(cause);
+  }
+
+  public IntegrationException(String message, String userMessage) {
+    super(message, userMessage);
+  }
+
+  public IntegrationException(String message, Throwable cause, String userMessage) {
+    super(message, cause, userMessage);
+  }
+
+  public IntegrationException(Throwable cause, String userMessage) {
+    super(cause, userMessage);
+  }
+}

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/SpinnakerException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/SpinnakerException.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.exceptions;
+
+import javax.annotation.Nullable;
+
+/** A root-level marker interface for all exceptions to be thrown by Spinnaker code. */
+public class SpinnakerException extends RuntimeException implements HasAdditionalAttributes {
+
+  /**
+   * An optional, end-user friendly message.
+   *
+   * <p>In most cases, an exception message is more suitable for developers and operators, but can
+   * be confusing for an end-user. This field provides a standard method of propagating messaging up
+   * to the edge.
+   */
+  @Nullable private String userMessage;
+
+  /**
+   * Whether or not the exception is explicitly known to be retryable.
+   *
+   * <p>If the result is NULL, the exception's retry characteristics are undefined and thus retries
+   * on the original logic that caused the exception may have undefined behavior.
+   */
+  @Nullable private Boolean retryable;
+
+  public SpinnakerException() {}
+
+  public SpinnakerException(String message) {
+    super(message);
+  }
+
+  public SpinnakerException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public SpinnakerException(Throwable cause) {
+    super(cause);
+  }
+
+  public SpinnakerException(String message, String userMessage) {
+    super(message);
+    this.userMessage = userMessage;
+  }
+
+  public SpinnakerException(String message, Throwable cause, String userMessage) {
+    super(message, cause);
+    this.userMessage = userMessage;
+  }
+
+  public SpinnakerException(Throwable cause, String userMessage) {
+    super(cause);
+    this.userMessage = userMessage;
+  }
+
+  public SpinnakerException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+  @Nullable
+  public String getUserMessage() {
+    return userMessage;
+  }
+
+  public void setUserMessage(@Nullable String userMessage) {
+    this.userMessage = userMessage;
+  }
+
+  @Nullable
+  public Boolean getRetryable() {
+    return retryable;
+  }
+
+  public void setRetryable(@Nullable Boolean retryable) {
+    this.retryable = retryable;
+  }
+}

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/SystemException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/SystemException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.exceptions;
+
+/**
+ * An exception thrown by core Spinnaker; this will represent a system-level defect, interruption,
+ * etc.
+ */
+public class SystemException extends SpinnakerException {
+  public SystemException(String message) {
+    super(message);
+  }
+
+  public SystemException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public SystemException(Throwable cause) {
+    super(cause);
+  }
+
+  public SystemException(String message, String userMessage) {
+    super(message, userMessage);
+  }
+
+  public SystemException(String message, Throwable cause, String userMessage) {
+    super(message, cause, userMessage);
+  }
+
+  public SystemException(Throwable cause, String userMessage) {
+    super(cause, userMessage);
+  }
+}

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/UserException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/UserException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,28 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.netflix.spinnaker.kork.exceptions;
 
-package com.netflix.spinnaker.kork.web.exceptions;
+/** An exception thrown when the cause is a user (e.g. bad input). */
+public class UserException extends SpinnakerException {
+  public UserException() {}
 
-import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
-
-public class NotFoundException extends SpinnakerException {
-  public NotFoundException() {}
-
-  public NotFoundException(String message) {
+  public UserException(String message) {
     super(message);
   }
 
-  public NotFoundException(String message, Throwable cause) {
+  public UserException(String message, Throwable cause) {
     super(message, cause);
   }
 
-  public NotFoundException(Throwable cause) {
+  public UserException(Throwable cause) {
     super(cause);
   }
 
-  public NotFoundException(
+  public UserException(
       String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+  public UserException(String message, String userMessage) {
+    super(message, userMessage);
+  }
+
+  public UserException(String message, Throwable cause, String userMessage) {
+    super(message, cause, userMessage);
+  }
+
+  public UserException(Throwable cause, String userMessage) {
+    super(cause, userMessage);
   }
 }

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/web/exceptions/InvalidRequestException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/web/exceptions/InvalidRequestException.java
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.kork.web.exceptions;
 
-public class InvalidRequestException extends RuntimeException {
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+
+public class InvalidRequestException extends SpinnakerException {
   public InvalidRequestException() {}
 
   public InvalidRequestException(String message) {

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/web/exceptions/ValidationException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/web/exceptions/ValidationException.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.kork.web.exceptions;
 
+import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/controllers/GenericErrorController.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/controllers/GenericErrorController.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.kork.web.controllers;
 
-import com.netflix.spinnaker.kork.web.exceptions.HasAdditionalAttributes;
+import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes;
 import java.util.Map;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorController;

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/GenericExceptionHandlers.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/GenericExceptionHandlers.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.kork.web.exceptions;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
+import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Collections;


### PR DESCRIPTION
Adds a hierarchy of root-level Spinnaker exception interface types:

```
SpinnakerException      # root-level interface
|
+- UserException        # exceptional conditions caused by an end-user
|
+- IntegrationException # exceptional conditions caused by non-core Spinnaker
|                       # code (cloud providers, extensions, etc)
|
+- SystemException      # exceptional conditions caused by core Spinnaker
                        # (defects, infra/db errors, etc)
```

Some basic `*RuntimeException` types are included which can be extended;
however it would be preferable to avoid direct usage, preferring concrete,
exception types.

The problem I'm trying to solve here is how difficult it is to classify errors into the three buckets (user vs integration vs core). How does this seem?