### PR TITLE
chore(kork): Use a consistent bouncycastle version.

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -21,6 +21,7 @@ publishing {
 ext {
   versions = [
     aws           : "1.11.534",
+    bouncycastle  : "1.61",
     coroutines    : "1.2.1",
     groovy        : "2.5.6", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
     hystrix       : "1.4.21",
@@ -119,7 +120,8 @@ dependencies {
     api("net.logstash.logback:logstash-logback-encoder:4.11")
     api("org.apache.commons:commons-exec:1.3")
     api("org.assertj:assertj-core:3.11.1")
-    api("org.bouncycastle:bcprov-jdk15on:1.61")
+    api("org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}")
+    api("org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}")
     api("org.codehaus.groovy:groovy-all:${versions.groovy}")
     api("org.funktionale:funktionale-partials:1.2")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}")


### PR DESCRIPTION
Clouddriver was using bcpkix 1.60 with bcprov 1.61. The former depends on the latter, so we should make sure the versions are consistent.