### PR TITLE
perf(redis): Optimize payloadSize

### DIFF
--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/telemetry/TelemetryHelper.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/telemetry/TelemetryHelper.java
@@ -65,11 +65,11 @@ public class TelemetryHelper {
   }
 
   static long payloadSize(String... payload) {
-    StringBuilder b = new StringBuilder();
+    long size = 0;
     for (String p : payload) {
-      b.append(p);
+      size += payloadSize(p);
     }
-    return payloadSize(b.toString());
+    return size;
   }
 
   static long payloadSize(Map<String, String> payload) {


### PR DESCRIPTION
Instead of builing a long string and getting the payload size of that string, just compute the size of each string in the list and return the sum.  This significantly reduces allocations during caching cycles for the kubernetes provider, which often calls mset with a long list of parameters.