### PR TITLE
feat(headers): add ability to skip auth header checks

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttpClientComponents.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttpClientComponents.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import com.netflix.spinnaker.okhttp.OkHttpMetricsInterceptor
 import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -34,12 +35,18 @@ class OkHttpClientComponents {
   }
 
   @Bean
-  OkHttpMetricsInterceptor okHttpMetricsInterceptor(Registry registry) {
-    return new OkHttpMetricsInterceptor(registry)
+  OkHttpMetricsInterceptor okHttpMetricsInterceptor(
+    Registry registry,
+    @Value('${ok-http-client.interceptor.skip-header-check:false}') boolean skipHeaderCheck) {
+
+    return new OkHttpMetricsInterceptor(registry, skipHeaderCheck)
   }
 
   @Bean
-  OkHttp3MetricsInterceptor okHttp3MetricsInterceptor(Registry registry) {
-    return new OkHttp3MetricsInterceptor(registry)
+  OkHttp3MetricsInterceptor okHttp3MetricsInterceptor(
+    Registry registry,
+    @Value('${ok-http-client.interceptor.skip-header-check:false}') boolean skipHeaderCheck) {
+
+    return new OkHttp3MetricsInterceptor(registry, skipHeaderCheck)
   }
 }

--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/MetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/MetricsInterceptor.java
@@ -26,10 +26,12 @@ import org.springframework.util.StringUtils;
  */
 class MetricsInterceptor {
   private final Registry registry;
+  private final boolean skipHeaderCheck;
   private final Logger log;
 
-  MetricsInterceptor(Registry registry) {
+  MetricsInterceptor(Registry registry, boolean skipHeaderCheck) {
     this.registry = registry;
+    this.skipHeaderCheck = skipHeaderCheck;
     this.log = LoggerFactory.getLogger(getClass());
   }
 
@@ -55,7 +57,7 @@ class MetricsInterceptor {
     try {
       String xSpinAnonymous = MDC.get(AuthenticatedRequest.Header.XSpinnakerAnonymous);
 
-      if (xSpinAnonymous == null) {
+      if (xSpinAnonymous == null && !skipHeaderCheck) {
         for (AuthenticatedRequest.Header header : AuthenticatedRequest.Header.values()) {
           String headerValue =
               (request != null)

--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttp3MetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttp3MetricsInterceptor.java
@@ -22,8 +22,8 @@ import okhttp3.Response;
 
 public class OkHttp3MetricsInterceptor extends MetricsInterceptor implements okhttp3.Interceptor {
 
-  public OkHttp3MetricsInterceptor(Registry registry) {
-    super(registry);
+  public OkHttp3MetricsInterceptor(Registry registry, boolean skipHeaderCheck) {
+    super(registry, skipHeaderCheck);
   }
 
   @Override

--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttpMetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttpMetricsInterceptor.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 
 public class OkHttpMetricsInterceptor extends MetricsInterceptor
     implements com.squareup.okhttp.Interceptor {
-  public OkHttpMetricsInterceptor(Registry registry) {
-    super(registry);
+  public OkHttpMetricsInterceptor(Registry registry, boolean skipHeaderCheck) {
+    super(registry, skipHeaderCheck);
   }
 
   @Override


### PR DESCRIPTION
For local development, it is tedious to see all the "anonymous" request warnings.
Add ability to disable the check via config variable, e.g:

```yaml
spring:
  profiles: local

okHttpClient:
  interceptor:
    skipHeaderCheck: true
```