### PR TITLE
fix(compat): adds backwards compatible constructors for interceptors

### DIFF
--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttp3MetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttp3MetricsInterceptor.java
@@ -22,6 +22,10 @@ import okhttp3.Response;
 
 public class OkHttp3MetricsInterceptor extends MetricsInterceptor implements okhttp3.Interceptor {
 
+  public OkHttp3MetricsInterceptor(Registry registry) {
+    this(registry, false);
+  }
+
   public OkHttp3MetricsInterceptor(Registry registry, boolean skipHeaderCheck) {
     super(registry, skipHeaderCheck);
   }

--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttpMetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttpMetricsInterceptor.java
@@ -23,6 +23,10 @@ import java.io.IOException;
 
 public class OkHttpMetricsInterceptor extends MetricsInterceptor
     implements com.squareup.okhttp.Interceptor {
+  public OkHttpMetricsInterceptor(Registry registry) {
+    this(registry, false);
+  }
+
   public OkHttpMetricsInterceptor(Registry registry, boolean skipHeaderCheck) {
     super(registry, skipHeaderCheck);
   }


### PR DESCRIPTION
the fiat api needs the old signature, going to put this in as well as getting fiat-api consumers bumped to a newer fiat-api