### PR TITLE
fix(bom): Fix generated pom.xml to omit invalid lombok declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ buildscript {
     if (Boolean.valueOf(enablePublishing)) {
       classpath("com.netflix.spinnaker.gradle:spinnaker-dependency-bump-plugin:$spinnakerGradleVersion")
       classpath("com.netflix.spinnaker.gradle:spinnaker-gradle-project:$spinnakerGradleVersion")
+// TODO: nebula-publishing-plugin version override should be removed as soon as spinnaker-gradle-project is updated
+// this override is needed to omit compileOnly dependencies from generated pom.xml
+      classpath "com.netflix.nebula:nebula-publishing-plugin:12.0.1"
     }
     classpath("com.netflix.nebula:nebula-kotlin-plugin:1.3.30")
     classpath("org.jetbrains.kotlin:kotlin-allopen:1.3.30")

--- a/kork-bom/kork-bom.gradle
+++ b/kork-bom/kork-bom.gradle
@@ -1,11 +1,6 @@
 apply plugin: "java-platform"
 apply plugin: "maven-publish"
 
-// without this building the pom fails when using the Nebula publishing plugin
-configurations {
-  compileOnly
-}
-
 javaPlatform {
   allowDependencies()
 }


### PR DESCRIPTION
compileOnly dependency should not be added to generated pom.xml,
see discussion: https://discuss.gradle.org/t/publishing-plugin-should-respect-compileonly-configuration/22903/2
see related commit: nebula-plugins/nebula-publishing-plugin@a5432aa

Currently all published `pom.xml` contain:
```
    <dependency>
      <groupId>org.projectlombok</groupId>
      <artifactId>lombok</artifactId>
      <version/>
      <scope>provided</scope>
    </dependency>
```
which is considered invalid by Maven and thus all transitive dependencies of such artifacts are omitted.
