### PR TITLE
chore(dependencies): Upgrade Spring Cloud to Greenwich.SR2

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -33,7 +33,7 @@ ext {
     spectator     : "0.75.0",
     spek          : "1.1.5",
     springBoot    : "2.1.6.RELEASE",
-    springCloud   : "Greenwich.SR1",
+    springCloud   : "Greenwich.SR2",
     swagger       : "2.7.0",
     testcontainers: "1.11.2"
   ]


### PR DESCRIPTION
Spring Cloud release train Greenwich.SR2 includes a fix for using [Hashicorp Vault with an embedded Config Server](https://github.com/spring-cloud/spring-cloud-config/issues/1393), as used by clouddriver. 