### PR TITLE
feat(configuration): Add kork-config module for Spring Cloud Config Server integration

### DIFF
--- a/kork-config/kork-config.gradle
+++ b/kork-config/kork-config.gradle
@@ -1,0 +1,21 @@
+apply plugin: "java-library"
+apply from: "$rootDir/gradle/lombok.gradle"
+
+dependencies {
+  api(platform(project(":spinnaker-dependencies")))
+
+  implementation "commons-io:commons-io"
+  implementation "org.apache.commons:commons-lang3"
+
+  api "org.springframework.cloud:spring-cloud-context"
+  api "org.springframework.cloud:spring-cloud-config-server"
+
+  testImplementation "org.springframework.boot:spring-boot-starter-test"
+  testImplementation "org.assertj:assertj-core"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-engine"
+  testImplementation "org.junit.jupiter:junit-jupiter-params"
+  testImplementation "org.mockito:mockito-core"
+
+  testRuntimeOnly "org.slf4j:slf4j-simple"
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/boot/DefaultPropertiesBuilder.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/boot/DefaultPropertiesBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.boot;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DefaultPropertiesBuilder {
+  private final Map<String, Object> defaults;
+
+  public DefaultPropertiesBuilder() {
+    defaults = new HashMap<>();
+    defaults.put("netflix.environment", "test");
+    defaults.put("netflix.account", "${netflix.environment}");
+    defaults.put("netflix.stack", "test");
+    defaults.put("spring.config.node", "${user.home}/.spinnaker/");
+    defaults.put("spring.config.name", "${spring.application.name}");
+    defaults.put("spring.profiles.active", "${netflix.environment},local");
+    // add the Spring Cloud Config "composite" profile to default to a configuration
+    // source that won't prevent app startup if custom configuration is not provided
+    defaults.put("spring.profiles.include", "composite");
+  }
+
+  public DefaultPropertiesBuilder property(String key, Object value) {
+    defaults.put(key, value);
+    return this;
+  }
+
+  public Map<String, Object> build() {
+    return Collections.unmodifiableMap(defaults);
+  }
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigFileService.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigFileService.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.environment.EnvironmentRepository;
+import org.springframework.cloud.config.server.resource.NoSuchResourceException;
+import org.springframework.cloud.config.server.resource.ResourceRepository;
+import org.springframework.cloud.config.server.support.EnvironmentPropertySource;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.Resource;
+
+@Slf4j
+public class ConfigFileService implements EnvironmentAware {
+  private static final String CONFIG_SERVER_RESOURCE_PREFIX = "configserver:";
+  private static final String CLASSPATH_FILE_PREFIX = "classpath:";
+
+  private final ResourceRepository resourceRepository;
+  private final EnvironmentRepository environmentRepository;
+
+  @Value("${spring.application.name:application}")
+  private String applicationName = "application";
+
+  private String profiles;
+
+  public ConfigFileService() {
+    resourceRepository = null;
+    environmentRepository = null;
+  }
+
+  public ConfigFileService(
+      ResourceRepository resourceRepository, EnvironmentRepository environmentRepository) {
+    this.resourceRepository = resourceRepository;
+    this.environmentRepository = environmentRepository;
+  }
+
+  public String getLocalPath(String path) {
+    if (StringUtils.isNotEmpty(path)) {
+      if (isCloudConfigResource(path)) {
+        String configServerContents = retrieveFromConfigServer(path);
+        return writeToTempFile(
+            configServerContents, getResourceName(path, CONFIG_SERVER_RESOURCE_PREFIX));
+      } else {
+        return verifyLocalPath(path);
+      }
+    }
+
+    return null;
+  }
+
+  public String getLocalPathForContents(String contents, String path) {
+    if (StringUtils.isNotEmpty(contents)) {
+      return writeToTempFile(contents, path);
+    }
+
+    return null;
+  }
+
+  public String getContents(String path) {
+    if (StringUtils.isNotEmpty(path)) {
+      if (isCloudConfigResource(path)) {
+        return retrieveFromConfigServer(path);
+      }
+
+      if (isClasspathResource(path)) {
+        return retrieveFromClasspath(path);
+      }
+
+      return retrieveFromLocalPath(path);
+    }
+
+    return null;
+  }
+
+  private boolean isCloudConfigResource(String path) {
+    return path.startsWith(CONFIG_SERVER_RESOURCE_PREFIX);
+  }
+
+  private boolean isClasspathResource(String path) {
+    return path.startsWith(CLASSPATH_FILE_PREFIX);
+  }
+
+  private String verifyLocalPath(String path) {
+    if (Files.isReadable(Paths.get(path))) {
+      return path;
+    } else {
+      throw new RuntimeException("File \"" + path + "\" not found or is not readable");
+    }
+  }
+
+  private String retrieveFromLocalPath(String path) {
+    try {
+      Path filePath = Paths.get(path);
+      return new String(Files.readAllBytes(filePath));
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException("File \"" + path + "\" not found or is not readable", e);
+    } catch (IOException e) {
+      throw new RuntimeException("Exception reading file " + path, e);
+    }
+  }
+
+  private String retrieveFromClasspath(String path) {
+    try {
+      String filePath = getResourceName(path, CLASSPATH_FILE_PREFIX);
+      InputStream inputStream = getClass().getResourceAsStream(filePath);
+      return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException("Exception reading classpath resource \"" + path + "\"", e);
+    }
+  }
+
+  private String retrieveFromConfigServer(String path) {
+    if (resourceRepository == null || environmentRepository == null) {
+      throw new RuntimeException(
+          "Config Server repository not configured for resource \"" + path + "\"");
+    }
+
+    try {
+      String fileName = getResourceName(path, CONFIG_SERVER_RESOURCE_PREFIX);
+      Resource resource =
+          this.resourceRepository.findOne(applicationName, profiles, null, fileName);
+      try (InputStream inputStream = resource.getInputStream()) {
+        Environment environment =
+            this.environmentRepository.findOne(applicationName, profiles, null);
+
+        String text = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        StandardEnvironment preparedEnvironment =
+            EnvironmentPropertySource.prepareEnvironment(environment);
+        return EnvironmentPropertySource.resolvePlaceholders(preparedEnvironment, text);
+      }
+    } catch (NoSuchResourceException e) {
+      throw new RuntimeException("The resource \"" + path + "\" was not found in config server", e);
+    } catch (IOException e) {
+      throw new RuntimeException("Exception reading config server resource \"" + path + "\"", e);
+    }
+  }
+
+  private String getResourceName(String path, String prefix) {
+    return path.substring(prefix.length());
+  }
+
+  private String writeToTempFile(String contents, String resourceName) {
+    try {
+      Path tempDirPath = Paths.get(System.getProperty("java.io.tmpdir"), resourceName);
+      createParentDirsIfNecessary(tempDirPath);
+      Files.write(
+          tempDirPath,
+          contents.getBytes(),
+          StandardOpenOption.WRITE,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING);
+
+      log.info("Configuration for {} written to local file {}", resourceName, tempDirPath);
+
+      return tempDirPath.toString();
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Exception writing local file for resource \"" + resourceName + "\": " + e.getMessage(),
+          e);
+    }
+  }
+
+  private void createParentDirsIfNecessary(Path tempDirPath) throws IOException {
+    if (Files.notExists(tempDirPath) && tempDirPath.getParent() != null) {
+      Files.createDirectories(tempDirPath.getParent());
+    }
+  }
+
+  @Override
+  public void setEnvironment(org.springframework.core.env.Environment environment) {
+    profiles = StringUtils.join(environment.getActiveProfiles(), ",");
+  }
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigServerBootstrap.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigServerBootstrap.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+public class ConfigServerBootstrap {
+  public static void systemProperties(String applicationName) {
+    defaultSystemProperty("spring.application.name", applicationName);
+    // default locations must be included pending the resolution
+    // of https://github.com/spring-cloud/spring-cloud-commons/issues/466
+    defaultSystemProperty(
+        "spring.cloud.bootstrap.location",
+        "classpath:/,classpath:/config/,file:./,file:./config/,${user.home}/.spinnaker/");
+    defaultSystemProperty(
+        "spring.cloud.bootstrap.name", "spinnakerconfig,${spring.application.name}config");
+    defaultSystemProperty("spring.cloud.config.server.bootstrap", "true");
+  }
+
+  private static void defaultSystemProperty(String key, String value) {
+    if (System.getProperty(key) == null) {
+      System.setProperty(key, value);
+    }
+  }
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/ConfigFileServiceAutoConfiguration.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/ConfigFileServiceAutoConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver.autoconfig;
+
+import com.netflix.spinnaker.kork.configserver.ConfigFileService;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.config.server.EnableConfigServer;
+import org.springframework.cloud.config.server.config.ConfigServerAutoConfiguration;
+import org.springframework.cloud.config.server.environment.EnvironmentRepository;
+import org.springframework.cloud.config.server.resource.ResourceRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigureAfter(ConfigServerAutoConfiguration.class)
+public class ConfigFileServiceAutoConfiguration {
+  @Configuration
+  @Conditional(RemoteConfigSourceConfigured.class)
+  @EnableConfigServer
+  static class RemoteConfigSourceConfiguration {
+    @Bean
+    ConfigFileService configFileService(
+        ResourceRepository resourceRepository, EnvironmentRepository environmentRepository) {
+      return new ConfigFileService(resourceRepository, environmentRepository);
+    }
+  }
+
+  @Configuration
+  static class DefaultConfiguration {
+    @Bean
+    @ConditionalOnMissingBean(ConfigFileService.class)
+    ConfigFileService configFileService() {
+      return new ConfigFileService();
+    }
+  }
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/RemoteConfigSourceConfigured.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/RemoteConfigSourceConfigured.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver.autoconfig;
+
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class RemoteConfigSourceConfigured implements Condition {
+  @Override
+  public boolean matches(ConditionContext context, @NotNull AnnotatedTypeMetadata metadata) {
+    ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+    if (beanFactory != null) {
+      return
+      // beans added via Spring Cloud Config profile activation
+      beanFactory.containsBean("defaultEnvironmentRepository")
+          || beanFactory.containsBean("vaultEnvironmentRepository")
+          || beanFactory.containsBean("jdbcEnvironmentRepository")
+          || beanFactory.containsBean("credhubEnvironmentRepository")
+          // beans added via composite Spring Cloud Config profile
+          || beanFactory.containsBean("git-env-repo0")
+          || beanFactory.containsBean("vault-env-repo0")
+          || beanFactory.containsBean("jdbc-env-repo0")
+          || beanFactory.containsBean("credhub-env-repo0");
+    }
+    return false;
+  }
+}

--- a/kork-config/src/main/resources/META-INF/spring.factories
+++ b/kork-config/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.netflix.spinnaker.kork.configserver.autoconfig.ConfigFileServiceAutoConfiguration

--- a/kork-config/src/main/resources/spinnakerconfig.yml
+++ b/kork-config/src/main/resources/spinnakerconfig.yml
@@ -1,0 +1,10 @@
+spring:
+  # default Spring Cloud Config Server environment repository configuration
+  # to something that won't prevent app startup when explicit configuration
+  # is not provided
+  cloud:
+    config:
+      server:
+        composite:
+          - type: native
+            search-locations: ${user.home}/config

--- a/kork-config/src/test/java/com/netflix/spinnaker/kork/configserver/ConfigFileServiceTest.java
+++ b/kork-config/src/test/java/com/netflix/spinnaker/kork/configserver/ConfigFileServiceTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.environment.EnvironmentRepository;
+import org.springframework.cloud.config.server.resource.NoSuchResourceException;
+import org.springframework.cloud.config.server.resource.ResourceRepository;
+import org.springframework.core.io.ByteArrayResource;
+
+class ConfigFileServiceTest {
+  private static final String TEST_FILE_NAME = "testfile";
+  private static final String TEST_FILE_PATH =
+      Paths.get(System.getProperty("java.io.tmpdir"), TEST_FILE_NAME).toString();
+  private static final String CLOUD_TEST_FILE_NAME = "configserver:" + TEST_FILE_NAME;
+  private static final String TEST_FILE_CONTENTS = "test file contents";
+
+  private ResourceRepository resourceRepository = mock(ResourceRepository.class);
+  private EnvironmentRepository environmentRepository = mock(EnvironmentRepository.class);
+
+  private ConfigFileService configFileService;
+
+  @BeforeEach
+  void setUp() {
+    configFileService = new ConfigFileService(resourceRepository, environmentRepository);
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    Files.deleteIfExists(Paths.get(TEST_FILE_PATH));
+  }
+
+  @Test
+  void getLocalPathWhenFileExists() throws IOException {
+    createExpectedFile();
+
+    String fileName = configFileService.getLocalPath(TEST_FILE_PATH);
+    assertThat(fileName).isEqualTo(TEST_FILE_PATH);
+  }
+
+  @Test
+  void getLocalPathWhenFileDoesNotExist() {
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> configFileService.getLocalPath(TEST_FILE_PATH));
+    assertThat(exception.getMessage()).contains(TEST_FILE_PATH);
+  }
+
+  @Test
+  void getLocalPathWhenFileInConfigServer() {
+    expectFileInConfigServer();
+
+    String fileName = configFileService.getLocalPath(CLOUD_TEST_FILE_NAME);
+    assertThat(fileName).isEqualTo(TEST_FILE_PATH);
+  }
+
+  @Test
+  void getLocalPathWhenFileNotInConfigServer() {
+    expectFileNotInConfigServer();
+
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class, () -> configFileService.getLocalPath(CLOUD_TEST_FILE_NAME));
+    assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
+  }
+
+  @Test
+  void getLocalPathWhenConfigServerNotConfigured() {
+    configFileService = new ConfigFileService();
+
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class, () -> configFileService.getLocalPath(CLOUD_TEST_FILE_NAME));
+    assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
+  }
+
+  @Test
+  void getLocalPathWhenContentProvided() {
+    String fileName = configFileService.getLocalPathForContents(TEST_FILE_CONTENTS, TEST_FILE_NAME);
+    assertThat(fileName).isEqualTo(TEST_FILE_PATH);
+  }
+
+  @Test
+  void getContentsWhenFileExists() throws IOException {
+    createExpectedFile();
+
+    String contents = configFileService.getContents(TEST_FILE_PATH);
+    assertThat(contents).isEqualTo(TEST_FILE_CONTENTS);
+  }
+
+  @Test
+  void getContentsWhenFileInConfigServer() {
+    expectFileInConfigServer();
+
+    String contents = configFileService.getContents(CLOUD_TEST_FILE_NAME);
+    assertThat(contents).isEqualTo(TEST_FILE_CONTENTS);
+  }
+
+  @Test
+  void getContentsWhenFileNotInConfigServer() {
+    expectFileNotInConfigServer();
+
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class, () -> configFileService.getContents(CLOUD_TEST_FILE_NAME));
+    assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
+  }
+
+  private void createExpectedFile() throws IOException {
+    File file = new File(TEST_FILE_PATH);
+    file.deleteOnExit();
+
+    FileWriter fileWriter = new FileWriter(file);
+    fileWriter.write(TEST_FILE_CONTENTS);
+    fileWriter.close();
+  }
+
+  private void expectFileInConfigServer() {
+    when(resourceRepository.findOne(anyString(), isNull(), isNull(), eq(TEST_FILE_NAME)))
+        .thenReturn(new ByteArrayResource(TEST_FILE_CONTENTS.getBytes()));
+    when(environmentRepository.findOne(anyString(), isNull(), isNull()))
+        .thenReturn(new Environment("application"));
+  }
+
+  private void expectFileNotInConfigServer() {
+    when(resourceRepository.findOne(anyString(), isNull(), isNull(), eq(TEST_FILE_NAME)))
+        .thenThrow(new NoSuchResourceException(TEST_FILE_NAME));
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ include(
   "kork-artifacts",
   "kork-aws",
   "kork-bom",
+  "kork-config",
   "kork-core",
   "kork-core-tck",
   "kork-dynomite",


### PR DESCRIPTION
This PR mostly contains code extracted from clouddriver that will be required by other services for integration with Spring Cloud Config Server. It will also reduce some duplicated Spring Boot default properties. 