### PR TITLE
fix(configuration): Fix default property values

### DIFF
--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/boot/DefaultPropertiesBuilder.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/boot/DefaultPropertiesBuilder.java
@@ -28,8 +28,8 @@ public class DefaultPropertiesBuilder {
     defaults.put("netflix.environment", "test");
     defaults.put("netflix.account", "${netflix.environment}");
     defaults.put("netflix.stack", "test");
-    defaults.put("spring.config.node", "${user.home}/.spinnaker/");
-    defaults.put("spring.config.name", "${spring.application.name}");
+    defaults.put("spring.config.name", "spinnaker,${spring.application.name}");
+    defaults.put("spring.config.additional-location", "${user.home}/.spinnaker/");
     defaults.put("spring.profiles.active", "${netflix.environment},local");
     // add the Spring Cloud Config "composite" profile to default to a configuration
     // source that won't prevent app startup if custom configuration is not provided


### PR DESCRIPTION
A few default property names and values were copied incorrectly to this new central utility class. 