### PR TITLE
fix(config): fix config server bootstrap location

### DIFF
--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigServerBootstrap.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigServerBootstrap.java
@@ -23,7 +23,7 @@ public class ConfigServerBootstrap {
     // of https://github.com/spring-cloud/spring-cloud-commons/issues/466
     defaultSystemProperty(
         "spring.cloud.bootstrap.location",
-        "classpath:/,classpath:/config/,file:./,file:./config/,${user.home}/.spinnaker/");
+        "classpath:/,classpath:/config/,file:./,file:./config/,/opt/spinnaker/config/,${user.home}/.spinnaker/");
     defaultSystemProperty(
         "spring.cloud.bootstrap.name", "spinnakerconfig,${spring.application.name}config");
     defaultSystemProperty("spring.cloud.config.server.bootstrap", "true");


### PR DESCRIPTION
when deployed by halyard, all config lands in `/opt/spinnaker/config` so we need to set the config server bootstrap location to include `/opt/spinnaker/config` so that it gets picked up.