### PR TITLE
refactor(expressions): Apply Orca changes to expressions

### DIFF
--- a/kork-expressions/kork-expressions.gradle
+++ b/kork-expressions/kork-expressions.gradle
@@ -1,5 +1,6 @@
 apply plugin: "java-library"
 apply from: "$rootDir/gradle/lombok.gradle"
+apply from: "$rootDir/gradle/kotlin.gradle"
 
 test {
   useJUnitPlatform()

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionEvaluationSummary.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionEvaluationSummary.java
@@ -76,6 +76,14 @@ public class ExpressionEvaluationSummary {
         getTotalEvaluated(), attempted, getFailureCount(), failed);
   }
 
+  public boolean wasAttempted(String expression) {
+    return attempts.contains(expression);
+  }
+
+  public boolean hasFailed(String expression) {
+    return expressionResult.containsKey(expression);
+  }
+
   public static class Result {
     private String description;
     private Class<?> exceptionType;

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionFunctionProvider.kt
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionFunctionProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.expressions
+
+interface ExpressionFunctionProvider {
+  val namespace: String?
+  val functions: Collection<FunctionDefinition>
+
+  data class FunctionDefinition(
+    val name: String,
+    val parameters: List<FunctionParameter>
+  )
+
+  data class FunctionParameter(
+    val type: Class<*>,
+    val name: String,
+    val description: String
+  )
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionFunctionProvider.kt
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionFunctionProvider.kt
@@ -17,12 +17,22 @@ package com.netflix.spinnaker.kork.expressions
 
 interface ExpressionFunctionProvider {
   val namespace: String?
-  val functions: Collection<FunctionDefinition>
+  val functions: Functions
+
+  data class Functions(
+    val functionsDefinitions: Collection<FunctionDefinition>
+  ) {
+    constructor(vararg functionsDefinitions: FunctionDefinition) :
+      this(listOf(*functionsDefinitions))
+  }
 
   data class FunctionDefinition(
     val name: String,
     val parameters: List<FunctionParameter>
-  )
+  ) {
+    constructor(name: String, vararg functionParameters: FunctionParameter) :
+      this(name, listOf(*functionParameters))
+  }
 
   data class FunctionParameter(
     val type: Class<*>,

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.kork.expressions;
 
 import static java.lang.String.format;
-import static java.util.Collections.singletonList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.kork.expressions.whitelisting.*;
@@ -128,7 +127,8 @@ public class ExpressionsSupport {
 
   private void registerExpressionProviderFunctions(StandardEvaluationContext evaluationContext) {
     for (ExpressionFunctionProvider p : expressionFunctionProviders) {
-      for (ExpressionFunctionProvider.FunctionDefinition function : p.getFunctions()) {
+      for (ExpressionFunctionProvider.FunctionDefinition function :
+          p.getFunctions().getFunctionsDefinitions()) {
         String namespacedFunctionName = function.getName();
         if (p.getNamespace() != null) {
           namespacedFunctionName = format("%s_%s", p.getNamespace(), namespacedFunctionName);
@@ -160,13 +160,12 @@ public class ExpressionsSupport {
     }
 
     @Override
-    public Collection<FunctionDefinition> getFunctions() {
-      return singletonList(
+    public Functions getFunctions() {
+      return new Functions(
           new FunctionDefinition(
               "toJson",
-              singletonList(
-                  new FunctionParameter(
-                      Object.class, "value", "An Object to marshall to a JSON String"))));
+              new FunctionParameter(
+                  Object.class, "value", "An Object to marshall to a JSON String")));
     }
 
     /**
@@ -195,39 +194,31 @@ public class ExpressionsSupport {
     }
 
     @Override
-    public Collection<FunctionDefinition> getFunctions() {
-      return Arrays.asList(
+    public Functions getFunctions() {
+      return new Functions(
           new FunctionDefinition(
               "toInt",
-              Collections.singletonList(
-                  new FunctionParameter(
-                      String.class, "value", "A String value to convert to an int"))),
+              new FunctionParameter(String.class, "value", "A String value to convert to an int")),
           new FunctionDefinition(
               "toFloat",
-              Collections.singletonList(
-                  new FunctionParameter(
-                      String.class, "value", "A String value to convert to a float"))),
+              new FunctionParameter(String.class, "value", "A String value to convert to a float")),
           new FunctionDefinition(
               "toBoolean",
-              Collections.singletonList(
-                  new FunctionParameter(
-                      String.class, "value", "A String value to convert to a boolean"))),
+              new FunctionParameter(
+                  String.class, "value", "A String value to convert to a boolean")),
           new FunctionDefinition(
               "toBase64",
-              Collections.singletonList(
-                  new FunctionParameter(String.class, "value", "A String value to base64 encode"))),
+              new FunctionParameter(String.class, "value", "A String value to base64 encode")),
           new FunctionDefinition(
               "fromBase64",
-              Collections.singletonList(
-                  new FunctionParameter(
-                      String.class, "value", "A base64-encoded String value to decode"))),
+              new FunctionParameter(
+                  String.class, "value", "A base64-encoded String value to decode")),
           new FunctionDefinition(
               "alphanumerical",
-              Collections.singletonList(
-                  new FunctionParameter(
-                      String.class,
-                      "value",
-                      "A String value to strip of all non-alphanumeric characters"))));
+              new FunctionParameter(
+                  String.class,
+                  "value",
+                  "A String value to strip of all non-alphanumeric characters")));
     }
 
     /**

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
@@ -68,7 +68,9 @@ public class ExpressionsSupport {
         new ArrayList<>(
             Arrays.asList(
                 new JsonExpressionFunctionProvider(), new StringExpressionFunctionProvider()));
-    this.expressionFunctionProviders.addAll(extraExpressionFunctionProviders);
+    if (extraExpressionFunctionProviders != null) {
+      this.expressionFunctionProviders.addAll(extraExpressionFunctionProviders);
+    }
   }
 
   private static void registerFunction(

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
@@ -16,11 +16,13 @@
 
 package com.netflix.spinnaker.kork.expressions;
 
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.kork.expressions.whitelisting.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -30,19 +32,19 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
  * classes (via whitelisting)
  */
 public class ExpressionsSupport {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExpressionsSupport.class);
   private static final ObjectMapper mapper = new ObjectMapper();
-  private final Logger LOGGER = LoggerFactory.getLogger(ExpressionsSupport.class);
-  private final Map<String, List<Class<?>>> registeredHelperFunctions = new HashMap<>();
-  private final Set<Class<?>> allowedReturnTypes;
 
-  public ExpressionsSupport(Class<?>... extraAllowedReturnTypes) {
-    this.registeredHelperFunctions.put("toJson", Collections.singletonList(Object.class));
-    Stream.of(
-            "alphanumerical", "readJson", "toInt", "toFloat", "toBoolean", "toBase64", "fromBase64")
-        .forEach(
-            fn -> {
-              this.registeredHelperFunctions.put(fn, Collections.singletonList(String.class));
-            });
+  private final Set<Class<?>> allowedReturnTypes;
+  private final List<ExpressionFunctionProvider> expressionFunctionProviders;
+
+  public ExpressionsSupport(Class<?> extraAllowedReturnType) {
+    this(new Class[] {extraAllowedReturnType}, null);
+  }
+
+  public ExpressionsSupport(
+      Class<?>[] extraAllowedReturnTypes,
+      List<ExpressionFunctionProvider> extraExpressionFunctionProviders) {
 
     this.allowedReturnTypes =
         new HashSet<>(
@@ -62,113 +64,33 @@ public class ExpressionsSupport {
                 TreeMap.class,
                 TreeSet.class));
     Collections.addAll(this.allowedReturnTypes, extraAllowedReturnTypes);
+
+    this.expressionFunctionProviders =
+        new ArrayList<>(
+            Arrays.asList(
+                new JsonExpressionFunctionProvider(), new StringExpressionFunctionProvider()));
+    this.expressionFunctionProviders.addAll(extraExpressionFunctionProviders);
   }
 
-  /** Internally registers a SpEL method to an evaluation context */
   private static void registerFunction(
-      StandardEvaluationContext context, String name, Class<?>... types)
-      throws NoSuchMethodException {
-    context.registerFunction(name, ExpressionsSupport.class.getDeclaredMethod(name, types));
-  }
-
-  /**
-   * Parses a string to an integer
-   *
-   * @param str represents an int
-   * @return an integer
-   */
-  public static Integer toInt(String str) {
-    return Integer.valueOf(str);
-  }
-
-  /*
-   * HELPER FUNCTIONS: These functions are explicitly registered with each invocation To add a new
-   * helper function, append the function below and update ExpressionHelperFunctions and
-   * registeredHelperFunctions
-   */
-
-  /**
-   * Parses a string to a float
-   *
-   * @param str represents an float
-   * @return an float
-   */
-  public static Float toFloat(String str) {
-    return Float.valueOf(str);
-  }
-
-  /**
-   * Parses a string to a boolean
-   *
-   * @param str represents an boolean
-   * @return a boolean
-   */
-  public static Boolean toBoolean(String str) {
-    return Boolean.valueOf(str);
-  }
-
-  /**
-   * Encodes a string to base64
-   *
-   * @param text plain string
-   * @return converted string
-   */
-  public static String toBase64(String text) {
-    return Base64.getEncoder().encodeToString(text.getBytes());
-  }
-
-  /**
-   * Attempts to decode a base64 string
-   *
-   * @param text plain string
-   * @return decoded string
-   */
-  public static String fromBase64(String text) {
-    return new String(Base64.getDecoder().decode(text), StandardCharsets.UTF_8);
-  }
-
-  /**
-   * Converts a String to alpha numeric
-   *
-   * @param str string to convert
-   * @return converted string
-   */
-  public static String alphanumerical(String str) {
-    return str.replaceAll("[^A-Za-z0-9]", "");
-  }
-
-  /**
-   * @param o represents an object to convert to json
-   * @return json representation of the said object
-   */
-  public static String toJson(Object o) {
+      StandardEvaluationContext context,
+      String registrationName,
+      Class<?> cls,
+      String methodName,
+      Class<?>... types) {
     try {
-      String converted = mapper.writeValueAsString(o);
-      if (converted != null && converted.contains("${")) {
-        throw new SpelHelperFunctionException("result for toJson cannot contain an expression");
-      }
-
-      return converted;
-    } catch (Exception e) {
-      throw new SpelHelperFunctionException(String.format("#toJson(%s) failed", o.toString()), e);
-    }
-  }
-
-  /**
-   * Attemps to read json from a text String. Will throw a parsing exception on bad json
-   *
-   * @param text text to read as json
-   * @return the json representation of the text
-   */
-  public static Object readJson(String text) {
-    try {
-      if (text.startsWith("[")) {
-        return mapper.readValue(text, List.class);
-      }
-
-      return mapper.readValue(text, Map.class);
-    } catch (Exception e) {
-      throw new SpelHelperFunctionException(String.format("#readJson(%s) failed", text), e);
+      context.registerFunction(registrationName, cls.getDeclaredMethod(methodName, types));
+    } catch (NoSuchMethodException e) {
+      LOGGER.error("Failed to register helper function", e);
+      throw new RuntimeException(
+          "Failed to register helper function '"
+              + registrationName
+              + "' from '"
+              + cls.getName()
+              + "#"
+              + methodName
+              + "'",
+          e);
     }
   }
 
@@ -183,6 +105,16 @@ public class ExpressionsSupport {
       Object rootObject, boolean allowUnknownKeys) {
     ReturnTypeRestrictor returnTypeRestrictor = new ReturnTypeRestrictor(allowedReturnTypes);
 
+    StandardEvaluationContext evaluationContext =
+        createEvaluationContext(rootObject, allowUnknownKeys, returnTypeRestrictor);
+
+    registerExpressionProviderFunctions(evaluationContext);
+
+    return evaluationContext;
+  }
+
+  private StandardEvaluationContext createEvaluationContext(
+      Object rootObject, boolean allowUnknownKeys, ReturnTypeRestrictor returnTypeRestrictor) {
     StandardEvaluationContext evaluationContext = new StandardEvaluationContext(rootObject);
     evaluationContext.setTypeLocator(new WhitelistTypeLocator());
     evaluationContext.setMethodResolvers(
@@ -191,18 +123,171 @@ public class ExpressionsSupport {
         Arrays.asList(
             new MapPropertyAccessor(allowUnknownKeys),
             new FilteredPropertyAccessor(returnTypeRestrictor)));
+    return evaluationContext;
+  }
 
-    try {
-      for (Map.Entry<String, List<Class<?>>> m : registeredHelperFunctions.entrySet()) {
-        registerFunction(evaluationContext, m.getKey(), m.getValue().toArray(new Class<?>[0]));
+  private void registerExpressionProviderFunctions(StandardEvaluationContext evaluationContext) {
+    for (ExpressionFunctionProvider p : expressionFunctionProviders) {
+      for (ExpressionFunctionProvider.FunctionDefinition function : p.getFunctions()) {
+        String namespacedFunctionName = function.getName();
+        if (p.getNamespace() != null) {
+          namespacedFunctionName = format("%s_%s", p.getNamespace(), namespacedFunctionName);
+        }
+
+        Class[] functionTypes =
+            function.getParameters().stream()
+                .map(ExpressionFunctionProvider.FunctionParameter::getType)
+                .toArray(Class[]::new);
+
+        LOGGER.info(
+            "Registering Expression Function: {}({})", namespacedFunctionName, functionTypes);
+
+        registerFunction(
+            evaluationContext,
+            namespacedFunctionName,
+            p.getClass(),
+            function.getName(),
+            functionTypes);
       }
-    } catch (NoSuchMethodException e) {
-      // Indicates a function was not properly registered. This should not happen. Please fix the
-      // faulty
-      // function
-      LOGGER.error("Failed to register helper functions for rootObject {}", rootObject, e);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class JsonExpressionFunctionProvider implements ExpressionFunctionProvider {
+    @Override
+    public String getNamespace() {
+      return null;
     }
 
-    return evaluationContext;
+    @Override
+    public Collection<FunctionDefinition> getFunctions() {
+      return singletonList(
+          new FunctionDefinition(
+              "toJson",
+              singletonList(
+                  new FunctionParameter(
+                      Object.class, "value", "An Object to marshall to a JSON String"))));
+    }
+
+    /**
+     * @param o represents an object to convert to json
+     * @return json representation of the said object
+     */
+    public static String toJson(Object o) {
+      try {
+        String converted = mapper.writeValueAsString(o);
+        if (converted != null && converted.contains("${")) {
+          throw new SpelHelperFunctionException("result for toJson cannot contain an expression");
+        }
+
+        return converted;
+      } catch (Exception e) {
+        throw new SpelHelperFunctionException(format("#toJson(%s) failed", o.toString()), e);
+      }
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class StringExpressionFunctionProvider implements ExpressionFunctionProvider {
+    @Override
+    public String getNamespace() {
+      return null;
+    }
+
+    @Override
+    public Collection<FunctionDefinition> getFunctions() {
+      return Arrays.asList(
+          new FunctionDefinition(
+              "toInt",
+              Collections.singletonList(
+                  new FunctionParameter(
+                      String.class, "value", "A String value to convert to an int"))),
+          new FunctionDefinition(
+              "toFloat",
+              Collections.singletonList(
+                  new FunctionParameter(
+                      String.class, "value", "A String value to convert to a float"))),
+          new FunctionDefinition(
+              "toBoolean",
+              Collections.singletonList(
+                  new FunctionParameter(
+                      String.class, "value", "A String value to convert to a boolean"))),
+          new FunctionDefinition(
+              "toBase64",
+              Collections.singletonList(
+                  new FunctionParameter(String.class, "value", "A String value to base64 encode"))),
+          new FunctionDefinition(
+              "fromBase64",
+              Collections.singletonList(
+                  new FunctionParameter(
+                      String.class, "value", "A base64-encoded String value to decode"))),
+          new FunctionDefinition(
+              "alphanumerical",
+              Collections.singletonList(
+                  new FunctionParameter(
+                      String.class,
+                      "value",
+                      "A String value to strip of all non-alphanumeric characters"))));
+    }
+
+    /**
+     * Parses a string to an integer
+     *
+     * @param str represents an int
+     * @return an integer
+     */
+    public static Integer toInt(String str) {
+      return Integer.valueOf(str);
+    }
+
+    /**
+     * Parses a string to a float
+     *
+     * @param str represents an float
+     * @return an float
+     */
+    public static Float toFloat(String str) {
+      return Float.valueOf(str);
+    }
+
+    /**
+     * Parses a string to a boolean
+     *
+     * @param str represents an boolean
+     * @return a boolean
+     */
+    public static Boolean toBoolean(String str) {
+      return Boolean.valueOf(str);
+    }
+
+    /**
+     * Encodes a string to base64
+     *
+     * @param text plain string
+     * @return converted string
+     */
+    public static String toBase64(String text) {
+      return Base64.getEncoder().encodeToString(text.getBytes());
+    }
+
+    /**
+     * Attempts to decode a base64 string
+     *
+     * @param text plain string
+     * @return decoded string
+     */
+    public static String fromBase64(String text) {
+      return new String(Base64.getDecoder().decode(text), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Converts a String to alpha numeric
+     *
+     * @param str string to convert
+     * @return converted string
+     */
+    public static String alphanumerical(String str) {
+      return str.replaceAll("[^A-Za-z0-9]", "");
+    }
   }
 }


### PR DESCRIPTION
To support extracting expression handling from Orca, 

* Apply Orca changes from https://github.com/spinnaker/orca/commit/a4815ce1b5f12e551d5d6dc05526a2158775a6a0
* Apply Orca changes from https://github.com/spinnaker/orca/commit/52d35db40474e2b8fefaa318f36495d439e64f4e
* Encapsulate all expression-handling functions in implementations of `ExpressionFunctionsProvider`
* Enhance `ExpressionFunctionsProvider` to reduce `Arrays.asList()` and `Collections.singletonList` boilerplate