### PR TITLE
fix(exceptions): correctly log uncaught exceptions

### DIFF
--- a/kork-core/src/main/resources/META-INF/spring.factories
+++ b/kork-core/src/main/resources/META-INF/spring.factories
@@ -3,4 +3,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 
 
 org.springframework.context.ApplicationListener=\
-  com.netflix.spinnaker.kork.spring.SpringBoot1CompatibilityApplicationListener
+  com.netflix.spinnaker.kork.spring.SpringBoot1CompatibilityApplicationListener,\
+  com.netflix.spinnaker.kork.web.exceptions.ThreadUncaughtExceptionHandler

--- a/kork-core/src/main/resources/META-INF/spring.factories
+++ b/kork-core/src/main/resources/META-INF/spring.factories
@@ -4,4 +4,4 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 
 org.springframework.context.ApplicationListener=\
   com.netflix.spinnaker.kork.spring.SpringBoot1CompatibilityApplicationListener,\
-  com.netflix.spinnaker.kork.web.exceptions.ThreadUncaughtExceptionHandler
+  com.netflix.spinnaker.kork.web.exceptions.DefaultThreadUncaughtExceptionHandler

--- a/kork-sql/kork-sql.gradle
+++ b/kork-sql/kork-sql.gradle
@@ -17,4 +17,5 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 
   testRuntimeOnly project(":kork-sql-test")
+  testRuntimeOnly project(":kork-web")
 }

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -170,7 +170,7 @@ class DefaultSqlConfiguration {
   fun sqlHealthProvider(
     jooq: DSLContext,
     registry: Registry,
-    @Value("\${sql.readOnly:false}") readOnly: Boolean
+    @Value("\${sql.read-only:false}") readOnly: Boolean
   ): SqlHealthProvider =
     SqlHealthProvider(jooq, registry, readOnly)
 

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/DefaultThreadUncaughtExceptionHandler.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/DefaultThreadUncaughtExceptionHandler.java
@@ -21,11 +21,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.context.ApplicationListener;
 
-public class ThreadUncaughtExceptionHandler
+public class DefaultThreadUncaughtExceptionHandler
     implements Thread.UncaughtExceptionHandler,
         ApplicationListener<ApplicationEnvironmentPreparedEvent> {
   private static final Logger logger =
-      LoggerFactory.getLogger(ThreadUncaughtExceptionHandler.class);
+      LoggerFactory.getLogger(DefaultThreadUncaughtExceptionHandler.class);
   private Thread.UncaughtExceptionHandler priorHandler;
 
   @Override
@@ -41,8 +41,7 @@ public class ThreadUncaughtExceptionHandler
 
   @Override
   public void uncaughtException(Thread thread, Throwable exception) {
-    logger.error(
-        "Uncaught exception in thread {}:{}\n{}", thread.getName(), thread.getId(), exception);
+    logger.error("Uncaught exception in thread", exception);
 
     if (priorHandler != null) {
       priorHandler.uncaughtException(thread, exception);

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/ThreadUncaughtExceptionHandler.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/ThreadUncaughtExceptionHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.web.exceptions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.context.ApplicationListener;
+
+public class ThreadUncaughtExceptionHandler
+    implements Thread.UncaughtExceptionHandler,
+        ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ThreadUncaughtExceptionHandler.class);
+  private Thread.UncaughtExceptionHandler priorHandler;
+
+  @Override
+  public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+    boolean isEnabled =
+        event.getEnvironment().getProperty("globalExceptionHandlingEnabled", boolean.class, true);
+
+    if (isEnabled) {
+      priorHandler = Thread.getDefaultUncaughtExceptionHandler();
+      Thread.setDefaultUncaughtExceptionHandler(this);
+    }
+  }
+
+  @Override
+  public void uncaughtException(Thread thread, Throwable exception) {
+    logger.error(
+        "Uncaught exception in thread {}:{}\n{}", thread.getName(), thread.getId(), exception);
+
+    if (priorHandler != null) {
+      priorHandler.uncaughtException(thread, exception);
+    }
+  }
+}


### PR DESCRIPTION
While investigating another issue, I realized that uncaught thread exceptions aren't logged correctly.
They are logged to `stderr` and, depending on logstash config, may or may not show up in the logs.

This change configures a default uncaught thread exception handler and logs the exceptions as `error`s.
It then, optionally, passes the exception to the previous handler (if there was one).

This behavior can be disabled with `globalExceptionHandlingEnabled=false`