### PR TITLE
chore(dependencies): Upgrade Guava

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -68,7 +68,7 @@ dependencies {
     api("com.google.apis:google-api-services-monitoring:v3-rev477-1.25.0")
     api("com.google.apis:google-api-services-storage:v1-rev141-1.25.0")
     api("com.google.code.findbugs:jsr305:3.0.2")
-    api("com.google.guava:guava:24.0-jre") // Aligning this to the transitive version from c.g.ben-manes.caffeine:guava
+    api("com.google.guava:guava:28.0-jre")
     api("com.hubspot.jinjava:jinjava:2.2.3") // DO NOT CHANGE: MPTv1 strongly depends on this version of Jinjava
     api("com.jcraft:jsch.agentproxy.connector-factory:${versions.jsch}")
     api("com.jcraft:jsch.agentproxy.jsch:${versions.jsch}")


### PR DESCRIPTION
In Clouddriver, we have a transitive dependency on 26.0-android, which
is overriding the version we set here anyway.

I talked to @dreynaud and the issue that prompted
spinnaker/clouddriver#3692 was actually that IntelliJ was compiling
against Guava 27.1, but then using Guava 19.0 on the classpath. Then it
was getting an error about a missing method because it was trying to
call a method added in Guava 20. This error was specific to IntelliJ and
wouldn't have happened if Gradle was used (which will ensure that the
same version is used at compilation and runtime).

So I think this should be a safe thing to do.