### PR TITLE
feat(plugins): Download remote plugins

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/kork/plugins/spring/PluginLoader.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/kork/plugins/spring/PluginLoader.java
@@ -22,7 +22,6 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -133,19 +132,22 @@ public class PluginLoader {
     return pluginConfigurations.stream()
         .map(PluginProperties.PluginConfiguration::getJars)
         .flatMap(Collection::stream)
-        .map(Paths::get)
-        .map(this::getUrlFromPath)
+        .map(this::convertToUrl)
         .distinct()
         .toArray(URL[]::new);
   }
 
   /**
-   * @param path
+   * @param jarLocation
    * @return path as a URL
    */
-  private URL getUrlFromPath(Path path) {
+  private URL convertToUrl(String jarLocation) {
     try {
-      return path.toUri().toURL();
+      if (jarLocation.startsWith("/")) {
+        return Paths.get(jarLocation).toUri().toURL();
+      } else {
+        return new URL(jarLocation);
+      }
     } catch (MalformedURLException e) {
       throw new MalformedPluginConfigurationException(e);
     }

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/kork/plugins/spring/PluginProperties.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/kork/plugins/spring/PluginProperties.java
@@ -33,6 +33,9 @@ public class PluginProperties {
   @JsonProperty("plugins")
   List<PluginConfiguration> pluginConfigurationList;
 
+  @JsonProperty("downloadingEnabled")
+  public Boolean downloadingEnabled;
+
   public void validate() {
     validateUniquePlugins();
     for (PluginConfiguration pluginConfiguration : pluginConfigurationList) {

--- a/kork-plugins/src/test/groovy/com/netflix/spinnaker/kork/plugins/spring/PluginLoaderSpec.groovy
+++ b/kork-plugins/src/test/groovy/com/netflix/spinnaker/kork/plugins/spring/PluginLoaderSpec.groovy
@@ -118,6 +118,19 @@ class PluginLoaderSpec extends Specification {
     thrown MalformedPluginConfigurationException
   }
 
+  def "should be able to get URL from path"() {
+    when:
+    subject = new PluginLoader()
 
+
+    then:
+    subject.convertToUrl(jarLocation) == expected
+
+    where:
+    jarLocation                               | expected
+    "/opt/spinnaker/plugin/foo-bar-1.2.3.jar" | Paths.get("/opt/spinnaker/plugin/foo-bar-1.2.3.jar").toUri().toURL()
+    "http://example.com/foo-bar-1.2.3.jar"    | new URL("http://example.com/foo-bar-1.2.3.jar")
+
+  }
 
 }

--- a/kork-plugins/src/test/resources/plugins.yml
+++ b/kork-plugins/src/test/resources/plugins.yml
@@ -1,4 +1,6 @@
 plugins:
+  downloadingEnabled: true
+  plugins:
   - name: namespace/stage-plugin
     enabled: true
     jars:


### PR DESCRIPTION
This PR is related to spinnaker/spinnaker#4181.

Different environments used to run Spinnaker have varying constraints, in order to ensure plugins can be used in all environments, we added the ability to download plugins via Kork at runtime. By default, downloading of plugin jars will be disabled, but if the Spinnaker administrator trusts the download location, they can enable plugin jar downloading. Spinnaker users (application owners) will not have the ability to add plugins.

To ensure Spinnaker is running as expected, a Spinnaker service will fail to start if it fails to download the plugin JARs. 