### PR TITLE
feat(config): Resolve configfiles using a custom PropertySource

### DIFF
--- a/kork-config/kork-config.gradle
+++ b/kork-config/kork-config.gradle
@@ -7,6 +7,8 @@ dependencies {
   implementation "commons-io:commons-io"
   implementation "org.apache.commons:commons-lang3"
 
+  api project(':kork-secrets')
+
   api "org.springframework.cloud:spring-cloud-context"
   api "org.springframework.cloud:spring-cloud-config-server"
 

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/CloudConfigApplicationListener.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/CloudConfigApplicationListener.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+import com.netflix.spinnaker.kork.secrets.SecretAwarePropertySource;
+import org.springframework.boot.context.event.ApplicationPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertySource;
+
+public class CloudConfigApplicationListener
+    implements ApplicationListener<ApplicationPreparedEvent> {
+  private static final String APPLICATION_CONFIG_PROPERTY_SOURCE_PREFIX = "applicationConfig:";
+  private static final String CONFIG_SERVER_PROPERTY_SOURCE_NAME = "bootstrapProperties";
+
+  @Override
+  public void onApplicationEvent(ApplicationPreparedEvent event) {
+    ConfigurableApplicationContext context = event.getApplicationContext();
+    ConfigurableEnvironment environment = context.getEnvironment();
+
+    for (PropertySource propertySource : environment.getPropertySources()) {
+      if (shouldWrap(propertySource)) {
+        CloudConfigAwarePropertySource wrapper =
+            new CloudConfigAwarePropertySource(propertySource, context);
+        environment.getPropertySources().replace(propertySource.getName(), wrapper);
+      }
+    }
+  }
+
+  private boolean shouldWrap(PropertySource propertySource) {
+    return (propertySource.getName().startsWith(APPLICATION_CONFIG_PROPERTY_SOURCE_PREFIX)
+            || propertySource.getName().equals(CONFIG_SERVER_PROPERTY_SOURCE_NAME))
+        && !((propertySource instanceof CloudConfigAwarePropertySource)
+            || (propertySource instanceof SecretAwarePropertySource));
+  }
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/CloudConfigAwarePropertySource.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/CloudConfigAwarePropertySource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.PropertySource;
+
+public class CloudConfigAwarePropertySource extends EnumerablePropertySource<PropertySource> {
+  private final ConfigurableApplicationContext context;
+  private CloudConfigResourceService resourceService;
+
+  CloudConfigAwarePropertySource(PropertySource source, ConfigurableApplicationContext context) {
+    super(source.getName(), source);
+    this.context = context;
+  }
+
+  @Override
+  public Object getProperty(String name) {
+    Object value = source.getProperty(name);
+    if (value instanceof String) {
+      String stringValue = (String) value;
+      if (CloudConfigResourceService.isCloudConfigResource(stringValue)) {
+        resolveResourceService(stringValue);
+        value = resourceService.getLocalPath(stringValue);
+      }
+    }
+    return value;
+  }
+
+  private void resolveResourceService(String path) {
+    if (resourceService == null) {
+      try {
+        resourceService = context.getBean(CloudConfigResourceService.class);
+      } catch (BeansException e) {
+        throw new ConfigFileLoadingException(
+            "Config Server repository not configured for resource \"" + path + "\"");
+      }
+    }
+  }
+
+  @Override
+  public String[] getPropertyNames() {
+    if (source instanceof EnumerablePropertySource) {
+      return ((EnumerablePropertySource) source).getPropertyNames();
+    } else {
+      return new String[0];
+    }
+  }
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/CloudConfigResourceService.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/CloudConfigResourceService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.environment.EnvironmentRepository;
+import org.springframework.cloud.config.server.resource.NoSuchResourceException;
+import org.springframework.cloud.config.server.resource.ResourceRepository;
+import org.springframework.cloud.config.server.support.EnvironmentPropertySource;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.Resource;
+
+public class CloudConfigResourceService implements EnvironmentAware {
+  private static final String CONFIG_SERVER_RESOURCE_PREFIX = "configserver:";
+
+  private final ResourceRepository resourceRepository;
+  private final EnvironmentRepository environmentRepository;
+
+  @Value("${spring.application.name:application}")
+  private String applicationName = "application";
+
+  private String profiles;
+
+  public CloudConfigResourceService() {
+    this.resourceRepository = null;
+    this.environmentRepository = null;
+  }
+
+  public CloudConfigResourceService(
+      ResourceRepository resourceRepository, EnvironmentRepository environmentRepository) {
+    this.resourceRepository = resourceRepository;
+    this.environmentRepository = environmentRepository;
+  }
+
+  public String getLocalPath(String path) {
+    String contents = retrieveFromConfigServer(path);
+    return ConfigFileUtils.writeToTempFile(contents, getResourceName(path));
+  }
+
+  private String retrieveFromConfigServer(String path) {
+    if (resourceRepository == null || environmentRepository == null) {
+      throw new ConfigFileLoadingException(
+          "Config Server repository not configured for resource \"" + path + "\"");
+    }
+
+    try {
+      String fileName = getResourceName(path);
+      Resource resource =
+          this.resourceRepository.findOne(applicationName, profiles, null, fileName);
+      try (InputStream inputStream = resource.getInputStream()) {
+        Environment environment =
+            this.environmentRepository.findOne(applicationName, profiles, null);
+
+        String text = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        StandardEnvironment preparedEnvironment =
+            EnvironmentPropertySource.prepareEnvironment(environment);
+        return EnvironmentPropertySource.resolvePlaceholders(preparedEnvironment, text);
+      }
+    } catch (NoSuchResourceException e) {
+      throw new ConfigFileLoadingException(
+          "The resource \"" + path + "\" was not found in config server", e);
+    } catch (IOException e) {
+      throw new ConfigFileLoadingException(
+          "Exception reading config server resource \"" + path + "\"", e);
+    }
+  }
+
+  private String getResourceName(String path) {
+    return path.substring(CONFIG_SERVER_RESOURCE_PREFIX.length());
+  }
+
+  @Override
+  public void setEnvironment(org.springframework.core.env.Environment environment) {
+    profiles = StringUtils.join(environment.getActiveProfiles(), ",");
+  }
+
+  public static boolean isCloudConfigResource(String path) {
+    return path.startsWith(CONFIG_SERVER_RESOURCE_PREFIX);
+  }
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigFileLoadingException.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigFileLoadingException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+public class ConfigFileLoadingException extends RuntimeException {
+  public ConfigFileLoadingException(String message) {
+    super(message);
+  }
+
+  public ConfigFileLoadingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ConfigFileLoadingException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigFileService.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigFileService.java
@@ -23,61 +23,24 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.config.environment.Environment;
-import org.springframework.cloud.config.server.environment.EnvironmentRepository;
-import org.springframework.cloud.config.server.resource.NoSuchResourceException;
-import org.springframework.cloud.config.server.resource.ResourceRepository;
-import org.springframework.cloud.config.server.support.EnvironmentPropertySource;
-import org.springframework.context.EnvironmentAware;
-import org.springframework.core.env.StandardEnvironment;
-import org.springframework.core.io.Resource;
 
 @Slf4j
-public class ConfigFileService implements EnvironmentAware {
-  private static final String CONFIG_SERVER_RESOURCE_PREFIX = "configserver:";
+public class ConfigFileService {
   private static final String CLASSPATH_FILE_PREFIX = "classpath:";
 
-  private final ResourceRepository resourceRepository;
-  private final EnvironmentRepository environmentRepository;
-
-  @Value("${spring.application.name:application}")
-  private String applicationName = "application";
-
-  private String profiles;
-
-  public ConfigFileService() {
-    resourceRepository = null;
-    environmentRepository = null;
-  }
-
-  public ConfigFileService(
-      ResourceRepository resourceRepository, EnvironmentRepository environmentRepository) {
-    this.resourceRepository = resourceRepository;
-    this.environmentRepository = environmentRepository;
-  }
+  public ConfigFileService() {}
 
   public String getLocalPath(String path) {
-    if (StringUtils.isNotEmpty(path)) {
-      if (isCloudConfigResource(path)) {
-        String configServerContents = retrieveFromConfigServer(path);
-        return writeToTempFile(
-            configServerContents, getResourceName(path, CONFIG_SERVER_RESOURCE_PREFIX));
-      } else {
-        return verifyLocalPath(path);
-      }
-    }
-
-    return null;
+    verifyLocalPath(path);
+    return path;
   }
 
   public String getLocalPathForContents(String contents, String path) {
     if (StringUtils.isNotEmpty(contents)) {
-      return writeToTempFile(contents, path);
+      return ConfigFileUtils.writeToTempFile(contents, path);
     }
 
     return null;
@@ -85,10 +48,6 @@ public class ConfigFileService implements EnvironmentAware {
 
   public String getContents(String path) {
     if (StringUtils.isNotEmpty(path)) {
-      if (isCloudConfigResource(path)) {
-        return retrieveFromConfigServer(path);
-      }
-
       if (isClasspathResource(path)) {
         return retrieveFromClasspath(path);
       }
@@ -99,19 +58,13 @@ public class ConfigFileService implements EnvironmentAware {
     return null;
   }
 
-  private boolean isCloudConfigResource(String path) {
-    return path.startsWith(CONFIG_SERVER_RESOURCE_PREFIX);
-  }
-
   private boolean isClasspathResource(String path) {
     return path.startsWith(CLASSPATH_FILE_PREFIX);
   }
 
-  private String verifyLocalPath(String path) {
-    if (Files.isReadable(Paths.get(path))) {
-      return path;
-    } else {
-      throw new RuntimeException("File \"" + path + "\" not found or is not readable");
+  private void verifyLocalPath(String path) {
+    if (StringUtils.isNotEmpty(path) && !Files.isReadable(Paths.get(path))) {
+      throw new ConfigFileLoadingException("File \"" + path + "\" not found or is not readable");
     }
   }
 
@@ -120,81 +73,20 @@ public class ConfigFileService implements EnvironmentAware {
       Path filePath = Paths.get(path);
       return new String(Files.readAllBytes(filePath));
     } catch (FileNotFoundException e) {
-      throw new RuntimeException("File \"" + path + "\" not found or is not readable", e);
+      throw new ConfigFileLoadingException("File \"" + path + "\" not found or is not readable", e);
     } catch (IOException e) {
-      throw new RuntimeException("Exception reading file " + path, e);
+      throw new ConfigFileLoadingException("Exception reading file " + path, e);
     }
   }
 
   private String retrieveFromClasspath(String path) {
     try {
-      String filePath = getResourceName(path, CLASSPATH_FILE_PREFIX);
+      String filePath = path.substring(ConfigFileService.CLASSPATH_FILE_PREFIX.length());
       InputStream inputStream = getClass().getResourceAsStream(filePath);
       return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
     } catch (IOException e) {
-      throw new RuntimeException("Exception reading classpath resource \"" + path + "\"", e);
+      throw new ConfigFileLoadingException(
+          "Exception reading classpath resource \"" + path + "\"", e);
     }
-  }
-
-  private String retrieveFromConfigServer(String path) {
-    if (resourceRepository == null || environmentRepository == null) {
-      throw new RuntimeException(
-          "Config Server repository not configured for resource \"" + path + "\"");
-    }
-
-    try {
-      String fileName = getResourceName(path, CONFIG_SERVER_RESOURCE_PREFIX);
-      Resource resource =
-          this.resourceRepository.findOne(applicationName, profiles, null, fileName);
-      try (InputStream inputStream = resource.getInputStream()) {
-        Environment environment =
-            this.environmentRepository.findOne(applicationName, profiles, null);
-
-        String text = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
-        StandardEnvironment preparedEnvironment =
-            EnvironmentPropertySource.prepareEnvironment(environment);
-        return EnvironmentPropertySource.resolvePlaceholders(preparedEnvironment, text);
-      }
-    } catch (NoSuchResourceException e) {
-      throw new RuntimeException("The resource \"" + path + "\" was not found in config server", e);
-    } catch (IOException e) {
-      throw new RuntimeException("Exception reading config server resource \"" + path + "\"", e);
-    }
-  }
-
-  private String getResourceName(String path, String prefix) {
-    return path.substring(prefix.length());
-  }
-
-  private String writeToTempFile(String contents, String resourceName) {
-    try {
-      Path tempDirPath = Paths.get(System.getProperty("java.io.tmpdir"), resourceName);
-      createParentDirsIfNecessary(tempDirPath);
-      Files.write(
-          tempDirPath,
-          contents.getBytes(),
-          StandardOpenOption.WRITE,
-          StandardOpenOption.CREATE,
-          StandardOpenOption.TRUNCATE_EXISTING);
-
-      log.info("Configuration for {} written to local file {}", resourceName, tempDirPath);
-
-      return tempDirPath.toString();
-    } catch (IOException e) {
-      throw new RuntimeException(
-          "Exception writing local file for resource \"" + resourceName + "\": " + e.getMessage(),
-          e);
-    }
-  }
-
-  private void createParentDirsIfNecessary(Path tempDirPath) throws IOException {
-    if (Files.notExists(tempDirPath) && tempDirPath.getParent() != null) {
-      Files.createDirectories(tempDirPath.getParent());
-    }
-  }
-
-  @Override
-  public void setEnvironment(org.springframework.core.env.Environment environment) {
-    profiles = StringUtils.join(environment.getActiveProfiles(), ",");
   }
 }

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigFileUtils.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigFileUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ConfigFileUtils {
+  static String writeToTempFile(String contents, String resourceName) {
+    try {
+      Path tempDirPath = Paths.get(System.getProperty("java.io.tmpdir"), resourceName);
+      createParentDirsIfNecessary(tempDirPath);
+      Files.write(
+          tempDirPath,
+          contents.getBytes(),
+          StandardOpenOption.WRITE,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING);
+
+      return tempDirPath.toString();
+    } catch (IOException e) {
+      throw new ConfigFileLoadingException(
+          "Exception writing local file for resource \"" + resourceName + "\": " + e.getMessage(),
+          e);
+    }
+  }
+
+  private static void createParentDirsIfNecessary(Path tempDirPath) throws IOException {
+    if (Files.notExists(tempDirPath) && tempDirPath.getParent() != null) {
+      Files.createDirectories(tempDirPath.getParent());
+    }
+  }
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/CloudConfigAutoConfiguration.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/CloudConfigAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.kork.configserver.autoconfig;
 
+import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
 import com.netflix.spinnaker.kork.configserver.ConfigFileService;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -33,7 +34,12 @@ import org.springframework.context.annotation.Import;
 
 @Configuration
 @AutoConfigureAfter({ConfigServerAutoConfiguration.class, ConfigServerBootstrapConfiguration.class})
-public class ConfigFileServiceAutoConfiguration {
+public class CloudConfigAutoConfiguration {
+  @Bean
+  ConfigFileService configFileService() {
+    return new ConfigFileService();
+  }
+
   @Configuration
   @Conditional(RemoteConfigSourceConfigured.class)
   @Import({
@@ -43,18 +49,18 @@ public class ConfigFileServiceAutoConfiguration {
   })
   static class RemoteConfigSourceConfiguration {
     @Bean
-    ConfigFileService configFileService(
+    CloudConfigResourceService cloudConfigResourceService(
         ResourceRepository resourceRepository, EnvironmentRepository environmentRepository) {
-      return new ConfigFileService(resourceRepository, environmentRepository);
+      return new CloudConfigResourceService(resourceRepository, environmentRepository);
     }
   }
 
   @Configuration
   static class DefaultConfiguration {
     @Bean
-    @ConditionalOnMissingBean(ConfigFileService.class)
-    ConfigFileService configFileService() {
-      return new ConfigFileService();
+    @ConditionalOnMissingBean(CloudConfigResourceService.class)
+    CloudConfigResourceService cloudConfigResourceService() {
+      return new CloudConfigResourceService();
     }
   }
 }

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/ConfigFileServiceAutoConfiguration.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/ConfigFileServiceAutoConfiguration.java
@@ -19,20 +19,28 @@ package com.netflix.spinnaker.kork.configserver.autoconfig;
 import com.netflix.spinnaker.kork.configserver.ConfigFileService;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.cloud.config.server.EnableConfigServer;
+import org.springframework.cloud.config.server.bootstrap.ConfigServerBootstrapConfiguration;
+import org.springframework.cloud.config.server.config.CompositeConfiguration;
 import org.springframework.cloud.config.server.config.ConfigServerAutoConfiguration;
+import org.springframework.cloud.config.server.config.ConfigServerEncryptionConfiguration;
+import org.springframework.cloud.config.server.config.ResourceRepositoryConfiguration;
 import org.springframework.cloud.config.server.environment.EnvironmentRepository;
 import org.springframework.cloud.config.server.resource.ResourceRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
-@AutoConfigureAfter(ConfigServerAutoConfiguration.class)
+@AutoConfigureAfter({ConfigServerAutoConfiguration.class, ConfigServerBootstrapConfiguration.class})
 public class ConfigFileServiceAutoConfiguration {
   @Configuration
   @Conditional(RemoteConfigSourceConfigured.class)
-  @EnableConfigServer
+  @Import({
+    CompositeConfiguration.class,
+    ResourceRepositoryConfiguration.class,
+    ConfigServerEncryptionConfiguration.class
+  })
   static class RemoteConfigSourceConfiguration {
     @Bean
     ConfigFileService configFileService(

--- a/kork-config/src/main/resources/META-INF/spring.factories
+++ b/kork-config/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.configserver.autoconfig.ConfigFileServiceAutoConfiguration
+  com.netflix.spinnaker.kork.configserver.autoconfig.CloudConfigAutoConfiguration
+org.springframework.context.ApplicationListener=\
+  com.netflix.spinnaker.kork.configserver.CloudConfigApplicationListener

--- a/kork-config/src/test/java/com/netflix/spinnaker/kork/configserver/CloudConfigResourceServiceTest.java
+++ b/kork-config/src/test/java/com/netflix/spinnaker/kork/configserver/CloudConfigResourceServiceTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.environment.EnvironmentRepository;
+import org.springframework.cloud.config.server.resource.NoSuchResourceException;
+import org.springframework.cloud.config.server.resource.ResourceRepository;
+import org.springframework.core.io.ByteArrayResource;
+
+class CloudConfigResourceServiceTest {
+  private static final String TEST_FILE_NAME = "testfile";
+  private static final String TEST_FILE_PATH =
+      Paths.get(System.getProperty("java.io.tmpdir"), TEST_FILE_NAME).toString();
+  private static final String CLOUD_TEST_FILE_NAME = "configserver:" + TEST_FILE_NAME;
+  private static final String TEST_FILE_CONTENTS = "test file contents";
+
+  private ResourceRepository resourceRepository = mock(ResourceRepository.class);
+  private EnvironmentRepository environmentRepository = mock(EnvironmentRepository.class);
+
+  private CloudConfigResourceService resourceService =
+      new CloudConfigResourceService(resourceRepository, environmentRepository);
+
+  @AfterEach
+  void tearDown() throws IOException {
+    Files.deleteIfExists(Paths.get(TEST_FILE_PATH));
+  }
+
+  @Test
+  void getLocalPathWhenFileInConfigServer() {
+    expectFileInConfigServer();
+
+    String fileName = resourceService.getLocalPath(CLOUD_TEST_FILE_NAME);
+    assertThat(fileName).isEqualTo(TEST_FILE_PATH);
+  }
+
+  @Test
+  void getLocalPathWhenFileNotInConfigServer() {
+    expectFileNotInConfigServer();
+
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class, () -> resourceService.getLocalPath(CLOUD_TEST_FILE_NAME));
+    assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
+  }
+
+  @Test
+  void getLocalPathWhenConfigServerNotConfigured() {
+    resourceService = new CloudConfigResourceService();
+
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class, () -> resourceService.getLocalPath(CLOUD_TEST_FILE_NAME));
+    assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
+  }
+
+  private void expectFileInConfigServer() {
+    when(resourceRepository.findOne(anyString(), isNull(), isNull(), eq(TEST_FILE_NAME)))
+        .thenReturn(new ByteArrayResource(TEST_FILE_CONTENTS.getBytes()));
+    when(environmentRepository.findOne(anyString(), isNull(), isNull()))
+        .thenReturn(new Environment("application"));
+  }
+
+  private void expectFileNotInConfigServer() {
+    when(resourceRepository.findOne(anyString(), isNull(), isNull(), eq(TEST_FILE_NAME)))
+        .thenThrow(new NoSuchResourceException(TEST_FILE_NAME));
+  }
+}

--- a/kork-config/src/test/java/com/netflix/spinnaker/kork/configserver/ConfigFileServiceTest.java
+++ b/kork-config/src/test/java/com/netflix/spinnaker/kork/configserver/ConfigFileServiceTest.java
@@ -18,11 +18,6 @@ package com.netflix.spinnaker.kork.configserver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -30,30 +25,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.cloud.config.environment.Environment;
-import org.springframework.cloud.config.server.environment.EnvironmentRepository;
-import org.springframework.cloud.config.server.resource.NoSuchResourceException;
-import org.springframework.cloud.config.server.resource.ResourceRepository;
-import org.springframework.core.io.ByteArrayResource;
 
 class ConfigFileServiceTest {
   private static final String TEST_FILE_NAME = "testfile";
   private static final String TEST_FILE_PATH =
       Paths.get(System.getProperty("java.io.tmpdir"), TEST_FILE_NAME).toString();
-  private static final String CLOUD_TEST_FILE_NAME = "configserver:" + TEST_FILE_NAME;
   private static final String TEST_FILE_CONTENTS = "test file contents";
 
-  private ResourceRepository resourceRepository = mock(ResourceRepository.class);
-  private EnvironmentRepository environmentRepository = mock(EnvironmentRepository.class);
-
-  private ConfigFileService configFileService;
-
-  @BeforeEach
-  void setUp() {
-    configFileService = new ConfigFileService(resourceRepository, environmentRepository);
-  }
+  private ConfigFileService configFileService = new ConfigFileService();
 
   @AfterEach
   void tearDown() throws IOException {
@@ -76,34 +56,6 @@ class ConfigFileServiceTest {
   }
 
   @Test
-  void getLocalPathWhenFileInConfigServer() {
-    expectFileInConfigServer();
-
-    String fileName = configFileService.getLocalPath(CLOUD_TEST_FILE_NAME);
-    assertThat(fileName).isEqualTo(TEST_FILE_PATH);
-  }
-
-  @Test
-  void getLocalPathWhenFileNotInConfigServer() {
-    expectFileNotInConfigServer();
-
-    RuntimeException exception =
-        assertThrows(
-            RuntimeException.class, () -> configFileService.getLocalPath(CLOUD_TEST_FILE_NAME));
-    assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
-  }
-
-  @Test
-  void getLocalPathWhenConfigServerNotConfigured() {
-    configFileService = new ConfigFileService();
-
-    RuntimeException exception =
-        assertThrows(
-            RuntimeException.class, () -> configFileService.getLocalPath(CLOUD_TEST_FILE_NAME));
-    assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
-  }
-
-  @Test
   void getLocalPathWhenContentProvided() {
     String fileName = configFileService.getLocalPathForContents(TEST_FILE_CONTENTS, TEST_FILE_NAME);
     assertThat(fileName).isEqualTo(TEST_FILE_PATH);
@@ -117,24 +69,6 @@ class ConfigFileServiceTest {
     assertThat(contents).isEqualTo(TEST_FILE_CONTENTS);
   }
 
-  @Test
-  void getContentsWhenFileInConfigServer() {
-    expectFileInConfigServer();
-
-    String contents = configFileService.getContents(CLOUD_TEST_FILE_NAME);
-    assertThat(contents).isEqualTo(TEST_FILE_CONTENTS);
-  }
-
-  @Test
-  void getContentsWhenFileNotInConfigServer() {
-    expectFileNotInConfigServer();
-
-    RuntimeException exception =
-        assertThrows(
-            RuntimeException.class, () -> configFileService.getContents(CLOUD_TEST_FILE_NAME));
-    assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
-  }
-
   private void createExpectedFile() throws IOException {
     File file = new File(TEST_FILE_PATH);
     file.deleteOnExit();
@@ -142,17 +76,5 @@ class ConfigFileServiceTest {
     FileWriter fileWriter = new FileWriter(file);
     fileWriter.write(TEST_FILE_CONTENTS);
     fileWriter.close();
-  }
-
-  private void expectFileInConfigServer() {
-    when(resourceRepository.findOne(anyString(), isNull(), isNull(), eq(TEST_FILE_NAME)))
-        .thenReturn(new ByteArrayResource(TEST_FILE_CONTENTS.getBytes()));
-    when(environmentRepository.findOne(anyString(), isNull(), isNull()))
-        .thenReturn(new Environment("application"));
-  }
-
-  private void expectFileNotInConfigServer() {
-    when(resourceRepository.findOne(anyString(), isNull(), isNull(), eq(TEST_FILE_NAME)))
-        .thenThrow(new NoSuchResourceException(TEST_FILE_NAME));
   }
 }


### PR DESCRIPTION
The Spring Cloud Config Server integration provided by `kork-config` includes the ability to specify account credentials (e.g. Kubernetes account `kubeconfigfile` and Google account `json-path`) as files that are stored in a Config Server backend like git, using a `configserver:` qualifier. 

Previously code in services that accessed these file references in account properties needed to use a `ConfigFileService` bean provided by `kork-config` to resolve the file references, pulling the specified file from the Config Server backend if necessary. 

This was starting to get unwieldy and intrusive in services, especially in cases where the code using the account properties wasn't implemented as Spring beans that could get a `ConfigFileService` bean injected into it. This PR adds a Spring `PropertySource` wrapper that automatically de-references the `configserver:` file reference when a property is resolved. The result is that services will always get a absolute local file reference. 

`ConfigFileService` remains as a useful encapsulation of methods for dealing with local files. 