### PR TITLE
fix(vuln): upgrade jackson for CVE remediation

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -50,7 +50,7 @@ dependencies {
   api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.3.0"))
   api(platform("org.jetbrains.kotlin:kotlin-bom:1.3.50"))
   api(platform("org.junit:junit-bom:5.5.1"))
-  api(platform("com.fasterxml.jackson:jackson-bom:2.9.9"))
+  api(platform("com.fasterxml.jackson:jackson-bom:2.9.9.20190807"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))


### PR DESCRIPTION
the updated bom bumps jackson-databind from 2.9.9 -> 2.9.9.3

see https://github.com/FasterXML/jackson-databind/issues/2387