### PR TITLE
fix(resolvedEnv): unless explicitly configured, use Sanitizer defaults.

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/ResolvedEnvironmentConfigurationProperties.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/ResolvedEnvironmentConfigurationProperties.java
@@ -15,14 +15,13 @@
  */
 package com.netflix.spinnaker.config;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "endpoints.resolved-env")
 public class ResolvedEnvironmentConfigurationProperties {
 
-  List<String> keysToSanitize = new ArrayList<>();
+  List<String> keysToSanitize = null;
 
   public List<String> getKeysToSanitize() {
     return keysToSanitize;

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/endpoint/ResolvedEnvironmentEndpoint.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/endpoint/ResolvedEnvironmentEndpoint.java
@@ -18,11 +18,9 @@ package com.netflix.spinnaker.endpoint;
 import static java.lang.String.format;
 
 import com.netflix.spinnaker.config.ResolvedEnvironmentConfigurationProperties;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.Sanitizer;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
@@ -36,10 +34,13 @@ public class ResolvedEnvironmentEndpoint {
   private final Sanitizer sanitizer = new Sanitizer();
   private final Environment environment;
 
+  @Autowired
   public ResolvedEnvironmentEndpoint(
       Environment environment, ResolvedEnvironmentConfigurationProperties properties) {
     this.environment = environment;
-    sanitizer.setKeysToSanitize(properties.getKeysToSanitize().toArray(new String[0]));
+    Optional.ofNullable(properties.getKeysToSanitize())
+        .map(p -> p.toArray(new String[0]))
+        .ifPresent(sanitizer::setKeysToSanitize);
   }
 
   @ReadOperation
@@ -62,7 +63,7 @@ public class ResolvedEnvironmentEndpoint {
     SortedSet<String> result = new TreeSet<>();
     MutablePropertySources sources;
 
-    if (environment != null && environment instanceof ConfigurableEnvironment) {
+    if (environment instanceof ConfigurableEnvironment) {
       sources = ((ConfigurableEnvironment) environment).getPropertySources();
     } else {
       sources = new StandardEnvironment().getPropertySources();


### PR DESCRIPTION
This was a regression from the boot2 upgrade where, now that there is a
ConfigurationProperties class for keysToSanitize, we are by default saying
do not sanitize anything.  This changes the default behaviour to use the
Sanitizer's default set of keywords to sanitize with.

While this is technically a breaking change, I think the expectation of
anyone using this would be that they don't have to supply configuration
to get a reasonable default level of resolvedEnv sanitiation, and anyone
who has supplied a custom value for this property will continue to work
as expected.