### PR TITLE
feat(core): Add resilience4j boot2 annotations api

### DIFF
--- a/kork-core/kork-core.gradle
+++ b/kork-core/kork-core.gradle
@@ -8,12 +8,15 @@ dependencies {
 
   api project(":kork-exceptions")
   api "org.springframework.boot:spring-boot-autoconfigure"
+  api "org.springframework.boot:spring-boot-starter-aop"
   api "org.springframework.boot:spring-boot-starter-actuator"
   api "com.netflix.eureka:eureka-client"
   api "com.netflix.spectator:spectator-api"
   api "com.google.code.findbugs:jsr305"
-  api "javax.inject:javax.inject:1"
+  api "io.github.resilience4j:resilience4j-annotations"
   api "io.github.resilience4j:resilience4j-retry"
+  api "io.github.resilience4j:resilience4j-spring-boot2"
+  api "javax.inject:javax.inject:1"
 
   implementation "com.netflix.netflix-commons:netflix-eventbus"
   implementation "com.netflix.archaius:archaius-core"

--- a/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt
+++ b/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt
@@ -36,7 +36,6 @@ import strikt.assertions.isEqualTo
 @RunWith(SpringRunner::class)
 @SpringBootTest(
   classes = [StartupTestApp::class],
-  webEnvironment = SpringBootTest.WebEnvironment.NONE,
   properties = [
     "sql.enabled=true",
     "sql.migration.jdbcUrl=jdbc:h2:mem:test",

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -116,6 +116,7 @@ dependencies {
     api("de.danielbechler:java-object-diff:0.95")
     api("de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.2.0")
     api("dev.minutest:minutest:1.7.0")
+    api("io.github.resilience4j:resilience4j-annotations:${versions.resilience4j}")
     api("io.github.resilience4j:resilience4j-circuitbreaker:${versions.resilience4j}")
     api("io.github.resilience4j:resilience4j-kotlin:${versions.resilience4j}")
     api("io.github.resilience4j:resilience4j-retry:${versions.resilience4j}")


### PR DESCRIPTION
Adds a nice Spring integration & annotations to the global project's dependency list: [Documentation](https://resilience4j.readme.io/docs/getting-started-3)

I was thinking we'd use `{service}-web/config/application.yml` to document all resilience configs within a service. It'd be an interesting exercise to additionally maintain any of Netflix's resilience4j config in OSS, keeping all configs in a `netflixResilience` spring profile.