### PR TITLE
feat(expressions): allow java.net.URLEncoder class in pipeline expressions

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/InstantiationTypeRestrictor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/InstantiationTypeRestrictor.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.kork.expressions.whitelisting;
 
+import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -40,7 +41,8 @@ public class InstantiationTypeRestrictor {
                   Boolean.class,
                   LocalDate.class,
                   Instant.class,
-                  ChronoUnit.class)));
+                  ChronoUnit.class,
+                  URL.class)));
 
   boolean supports(Class<?> type) {
     return allowedTypes.contains(type);

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/InstantiationTypeRestrictor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/whitelisting/InstantiationTypeRestrictor.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.kork.expressions.whitelisting;
 
-import java.net.URL;
+import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -42,7 +42,7 @@ public class InstantiationTypeRestrictor {
                   LocalDate.class,
                   Instant.class,
                   ChronoUnit.class,
-                  URL.class)));
+                  URLEncoder.class)));
 
   boolean supports(Class<?> type) {
     return allowedTypes.contains(type);


### PR DESCRIPTION
This allows us to do URL encoding in pipeline expressions