### PR TITLE
feat(secrets): add encryptedFile syntax for secret files

### DIFF
--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/EncryptedSecret.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/EncryptedSecret.java
@@ -41,8 +41,11 @@ import lombok.Setter;
 public class EncryptedSecret {
 
   public static final String ENCRYPTED_STRING_PREFIX = "encrypted:";
+  public static final String ENCRYPTED_FILE_PREFIX = "encryptedFile:";
+  private static final String ENCRYPTED_TAG_REGEX = ".+(![a-zA-Z0-9]+:.+)+";
   private static final String ENCRYPTED_STRING_REGEX =
-      ENCRYPTED_STRING_PREFIX + ".+(![a-zA-Z0-9]+:.+)+";
+      ENCRYPTED_STRING_PREFIX + ENCRYPTED_TAG_REGEX;
+  private static final String ENCRYPTED_FILE_REGEX = ENCRYPTED_FILE_PREFIX + ENCRYPTED_TAG_REGEX;
 
   @Getter @Setter private String engineIdentifier;
 
@@ -89,16 +92,20 @@ public class EncryptedSecret {
    */
   public static boolean isEncryptedSecret(String secretConfig) {
     return secretConfig != null
-        && secretConfig.startsWith(ENCRYPTED_STRING_PREFIX)
+        && (matchesEncryptedStringSyntax(secretConfig) || matchesEncryptedFileSyntax(secretConfig));
+  }
+
+  public static boolean isEncryptedFile(String secretConfig) {
+    return secretConfig != null && matchesEncryptedFileSyntax(secretConfig);
+  }
+
+  private static boolean matchesEncryptedStringSyntax(String secretConfig) {
+    return secretConfig.startsWith(ENCRYPTED_STRING_PREFIX)
         && secretConfig.matches(ENCRYPTED_STRING_REGEX);
   }
 
-  /** @return formatted encrypted secret */
-  public String formatString() {
-    StringBuilder sb = new StringBuilder(ENCRYPTED_STRING_PREFIX).append(engineIdentifier);
-    for (String key : params.keySet()) {
-      sb.append('!').append(key).append(':').append(params.get(key));
-    }
-    return sb.toString();
+  private static boolean matchesEncryptedFileSyntax(String secretConfig) {
+    return secretConfig.toLowerCase().startsWith(ENCRYPTED_FILE_PREFIX.toLowerCase())
+        && secretConfig.matches(ENCRYPTED_FILE_REGEX);
   }
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretAwarePropertySource.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretAwarePropertySource.java
@@ -36,15 +36,25 @@ public class SecretAwarePropertySource extends EnumerablePropertySource<Enumerab
         throw new SecretException("No secret manager to decrypt value of " + name);
       }
       String lName = name.toLowerCase();
-      if (lName.endsWith("file") || lName.endsWith("path") || lName.endsWith("truststore")) {
-        return secretManager.decryptAsFile((String) o).toString();
-      } else if (lName.endsWith("keystore")) {
+      if (isSamlFile(lName)) {
         return "file:" + secretManager.decryptAsFile((String) o).toString();
+      } else if (isFile(lName) || EncryptedSecret.isEncryptedFile(lName)) {
+        return secretManager.decryptAsFile((String) o).toString();
       } else {
         return secretManager.decrypt((String) o);
       }
     }
     return o;
+  }
+
+  @Deprecated
+  private boolean isFile(String name) {
+    return name.endsWith("file") || name.endsWith("path") || name.endsWith("truststore");
+  }
+
+  @Deprecated
+  private boolean isSamlFile(String name) {
+    return name.endsWith("keystore") || name.endsWith("metadataurl");
   }
 
   @Override

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/EncryptedSecretTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/EncryptedSecretTest.java
@@ -30,6 +30,7 @@ public class EncryptedSecretTest {
   public void isEncryptedSecretShouldReturnFalse() {
     String secretConfig = "foo";
     assertEquals(false, EncryptedSecret.isEncryptedSecret(secretConfig));
+    assertEquals(false, EncryptedSecret.isEncryptedFile(secretConfig));
   }
 
   @Test
@@ -45,8 +46,22 @@ public class EncryptedSecretTest {
   }
 
   @Test
+  public void isEncryptedFileShouldReturnTrue() {
+    String secretConfig = "encryptedFile:aws-kms!foo:bar";
+    assertEquals(true, EncryptedSecret.isEncryptedSecret(secretConfig));
+    assertEquals(true, EncryptedSecret.isEncryptedFile(secretConfig));
+  }
+
+  @Test
   public void parseSecretConfigValue() {
     String secretConfig = "encrypted:s3!first:key!second:another-valu:e!3rd:yetAnothervalue";
+    EncryptedSecret encryptedSecret = EncryptedSecret.parse(secretConfig);
+    assertEquals("s3", encryptedSecret.getEngineIdentifier());
+  }
+
+  @Test
+  public void parseSecretFileConfigValue() {
+    String secretConfig = "encryptedFile:s3!first:key!second:another-valu:e!3rd:yetAnothervalue";
     EncryptedSecret encryptedSecret = EncryptedSecret.parse(secretConfig);
     assertEquals("s3", encryptedSecret.getEngineIdentifier());
   }
@@ -66,16 +81,13 @@ public class EncryptedSecretTest {
     assertEquals("bar", encryptedSecret.getParams().get("foo"));
     assertEquals("secret-param-1", encryptedSecret.getParams().get("key"));
     assertEquals("secret-param:2", encryptedSecret.getParams().get("Key"));
-  }
 
-  @Test
-  public void formatEncryptedSecret() {
-    String secretConfig =
-        "encrypted:aws-kms!foo:bar!key:value!config:value:with:colon!lastKey:secret-param_3";
-    EncryptedSecret encryptedSecret = new EncryptedSecret(secretConfig);
-    String formattedSecret = encryptedSecret.formatString();
-    EncryptedSecret encryptedSecretFromFormattedSecret = new EncryptedSecret(formattedSecret);
-    assertEquals(encryptedSecret, encryptedSecretFromFormattedSecret);
+    String secretFileConfig = "encryptedFile:aws-kms!foo:bar!key:secret-param-1!Key:secret-param:2";
+    EncryptedSecret encryptedSecretFile = new EncryptedSecret(secretConfig);
+    assertEquals("aws-kms", encryptedSecretFile.getEngineIdentifier());
+    assertEquals("bar", encryptedSecretFile.getParams().get("foo"));
+    assertEquals("secret-param-1", encryptedSecretFile.getParams().get("key"));
+    assertEquals("secret-param:2", encryptedSecretFile.getParams().get("Key"));
   }
 
   @Test


### PR DESCRIPTION
This replaces the less-than-ideal logic around determining if an encrypted secret is a saml file, a regular file or string value. Now, users should use the `encryptedFile:s3!...` syntax for secret files and `encrypted:s3!...` for secret strings. The logic for prepending saml files with "file:" after decrypting moves into gate with this PR: https://github.com/spinnaker/gate/pull/919

This proposes to keep both sets of logic in place for version 1.16/1.17, but mark the old logic as deprecated and remove it fully in version 1.17/1.18?

