### PR TITLE
refactor(plugins): Remove enabled flag entirely

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/config/PluginsAutoConfiguration.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/config/PluginsAutoConfiguration.kt
@@ -35,7 +35,7 @@ class PluginsAutoConfiguration {
   fun pluginManager(
     properties: PluginsConfigurationProperties
   ): SpinnakerPluginManager =
-    SpinnakerPluginManager(properties.enabled, Paths.get(properties.rootPath))
+    SpinnakerPluginManager(Paths.get(properties.rootPath))
 
   @Bean
   fun extensionsInjector(

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/config/PluginsConfigurationProperties.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/config/PluginsConfigurationProperties.kt
@@ -25,11 +25,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("spinnaker.plugins")
 class PluginsConfigurationProperties {
   /**
-   * Whether or not plugins are enabled for a particular service.
-   */
-  var enabled: Boolean = false
-
-  /**
    * The root filepath to the directory containing all plugins.
    *
    * If an absolute path is not provided, the path will be calculated relative to the executable.

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/PluginBeanPostProcessor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/PluginBeanPostProcessor.kt
@@ -33,12 +33,10 @@ class PluginBeanPostProcessor(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override fun postProcessBeanDefinitionRegistry(registry: BeanDefinitionRegistry) {
-    if (pluginManager.enabled) {
-      log.debug("Preparing plugins")
-      val start = System.currentTimeMillis()
-      preparePlugins()
-      log.info("Finished preparing plugins in {}ms", System.currentTimeMillis() - start)
-    }
+    log.debug("Preparing plugins")
+    val start = System.currentTimeMillis()
+    preparePlugins()
+    log.info("Finished preparing plugins in {}ms", System.currentTimeMillis() - start)
   }
 
   private fun preparePlugins() {

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -25,31 +25,17 @@ import org.pf4j.DefaultPluginManager
 import org.pf4j.ExtensionFactory
 import org.pf4j.PluginDescriptorFinder
 import org.pf4j.PluginLoader
-import org.slf4j.LoggerFactory
 import java.nio.file.Path
 
 /**
  * The primary entry-point to the plugins system from a provider-side (services, libs, CLIs, and so-on).
  *
- * @param enabled Whether or not the PluginManager should do anything. While Plugins are an incubating
- * feature, this flag allows operators to disable the functionality, but keeps integrating services from
- * having to deal with `Optional<PluginManager>` autowiring.
  * @param pluginsRoot The root path to search for in-process plugin artifacts.
  */
 @Beta
 class SpinnakerPluginManager(
-  val enabled: Boolean,
   pluginsRoot: Path
 ) : DefaultPluginManager(pluginsRoot) {
-
-  private val log by lazy { LoggerFactory.getLogger(javaClass) }
-
-  override fun initialize() {
-    if (enabled) {
-      log.warn("Spinnaker Plugins enabled! This is a core incubating feature that may cause instability of the service")
-      super.initialize()
-    }
-  }
 
   override fun createExtensionFactory(): ExtensionFactory {
     return SpringExtensionFactory(this)

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactoryTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactoryTest.kt
@@ -17,7 +17,6 @@ package com.netflix.spinnaker.kork.plugins
 
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 
@@ -40,9 +39,5 @@ class SpringExtensionFactoryTest : JUnit5Minutests {
     val pluginManager: SpinnakerPluginManager = mockk(relaxed = true)
     val extensionInjector: ExtensionsInjector = mockk(relaxed = true)
     val subject = PluginBeanPostProcessor(pluginManager, extensionInjector)
-
-    init {
-      every { pluginManager.enabled } returns true
-    }
   }
 }


### PR DESCRIPTION
Even better, let's just not have an enabled flag on plugins. Everyone gets it: This will simplify the integration story.