### PR TITLE
feat(exceptions): chain style accessor for SpinnakerException retryable

### DIFF
--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/SpinnakerException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/SpinnakerException.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.kork.exceptions;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 
 /** A root-level marker interface for all exceptions to be thrown by Spinnaker code. */
 @Getter
@@ -38,7 +39,10 @@ public class SpinnakerException extends RuntimeException implements HasAdditiona
    * <p>If the result is NULL, the exception's retry characteristics are undefined and thus retries
    * on the original logic that caused the exception may have undefined behavior.
    */
-  @Setter @Nullable private Boolean retryable;
+  @Setter
+  @Nullable
+  @Accessors(chain = true)
+  private Boolean retryable;
 
   public SpinnakerException() {}
 


### PR DESCRIPTION
Allows for `throw new SpinnakerException("some constructor args").setRetryable(true)`