### PR TITLE
feat(plugins): Spring-backed plugin status provider

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/config/PluginsAutoConfiguration.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/config/PluginsAutoConfiguration.kt
@@ -18,10 +18,13 @@ package com.netflix.spinnaker.config
 import com.netflix.spinnaker.kork.plugins.ExtensionsInjector
 import com.netflix.spinnaker.kork.plugins.PluginBeanPostProcessor
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager
+import com.netflix.spinnaker.kork.plugins.SpringPluginStatusProvider
+import org.pf4j.PluginStatusProvider
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.support.GenericApplicationContext
+import org.springframework.core.env.Environment
 import java.nio.file.Paths
 
 /**
@@ -33,9 +36,10 @@ class PluginsAutoConfiguration {
 
   @Bean
   fun pluginManager(
+    pluginStatusProvider: PluginStatusProvider,
     properties: PluginsConfigurationProperties
   ): SpinnakerPluginManager =
-    SpinnakerPluginManager(Paths.get(properties.rootPath))
+    SpinnakerPluginManager(pluginStatusProvider, Paths.get(properties.rootPath))
 
   @Bean
   fun extensionsInjector(
@@ -50,4 +54,8 @@ class PluginsAutoConfiguration {
     extensionsInjector: ExtensionsInjector
   ) =
     PluginBeanPostProcessor(pluginManager, extensionsInjector)
+
+  @Bean
+  fun springPluginStatusProvider(environment: Environment): PluginStatusProvider =
+    SpringPluginStatusProvider(environment)
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -25,6 +25,7 @@ import org.pf4j.DefaultPluginManager
 import org.pf4j.ExtensionFactory
 import org.pf4j.PluginDescriptorFinder
 import org.pf4j.PluginLoader
+import org.pf4j.PluginStatusProvider
 import java.nio.file.Path
 
 /**
@@ -34,6 +35,7 @@ import java.nio.file.Path
  */
 @Beta
 class SpinnakerPluginManager(
+  private val statusProvider: PluginStatusProvider,
   pluginsRoot: Path
 ) : DefaultPluginManager(pluginsRoot) {
 
@@ -49,4 +51,7 @@ class SpinnakerPluginManager(
 
   override fun createPluginDescriptorFinder(): PluginDescriptorFinder =
     SpinnakerPluginDescriptorFinder()
+
+  override fun createPluginStatusProvider(): PluginStatusProvider =
+    statusProvider
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringPluginStatusProvider.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringPluginStatusProvider.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins
+
+import org.pf4j.PluginStatusProvider
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.core.env.Environment
+import org.springframework.core.env.MapPropertySource
+import kotlin.collections.set
+
+/**
+ * Backs plugin status by the Spring environment, instead of using text files.
+ */
+class SpringPluginStatusProvider(
+  private val environment: Environment
+) : PluginStatusProvider, ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  private val propertySourceBackingStore: MutableMap<String, Any> = mutableMapOf()
+  private val propertySource = MapPropertySource("plugins", propertySourceBackingStore)
+
+  override fun disablePlugin(pluginId: String) {
+    log.info("Disabling plugin: $pluginId")
+    propertySourceBackingStore[enabledPropertyName(pluginId)] = false
+  }
+
+  override fun isPluginDisabled(pluginId: String): Boolean =
+    !isEnabled(pluginId)
+
+  override fun enablePlugin(pluginId: String) {
+    log.info("Enabling plugin: $pluginId")
+    propertySourceBackingStore[enabledPropertyName(pluginId)] = true
+  }
+
+  override fun onApplicationEvent(event: ApplicationEnvironmentPreparedEvent) {
+    log.debug("Adding ${this.javaClass.simpleName} as new PropertySource")
+    event.environment.propertySources.addFirst(propertySource)
+  }
+
+  private fun isEnabled(pluginId: String): Boolean =
+    environment.getProperty(enabledPropertyName(pluginId))?.toBoolean() ?: false
+
+  private fun enabledPropertyName(pluginId: String): String =
+    "$ROOT_CONFIG.$pluginId.enabled"
+
+  companion object {
+    const val ROOT_CONFIG: String = "spinnaker.plugins"
+  }
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringPluginStatusProviderTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringPluginStatusProviderTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins
+
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.MapPropertySource
+import org.springframework.core.env.MutablePropertySources
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+
+class SpringPluginStatusProviderTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    test("provider attaches itself to environment") {
+      val propertySources: MutablePropertySources = mockk(relaxed = true)
+      every { environment.propertySources } returns propertySources
+
+      subject.onApplicationEvent(
+        ApplicationEnvironmentPreparedEvent(
+          mockk(relaxed = true),
+          arrayOf(),
+          environment
+        )
+      )
+
+      verify(exactly = 1) { propertySources.addFirst(any<MapPropertySource>()) }
+      confirmVerified(propertySources)
+    }
+
+    test("plugins default to disabled") {
+      every { environment.getProperty(any()) } returnsMany listOf(
+        "false",
+        "true",
+        "false"
+      )
+
+      expectThat(subject.isPluginDisabled("hello")).describedAs("initial state").isTrue()
+      subject.enablePlugin("hello")
+      expectThat(subject.isPluginDisabled("hello")).describedAs("enabled state").isFalse()
+      subject.disablePlugin("hello")
+      expectThat(subject.isPluginDisabled("hello")).describedAs("disabled state").isTrue()
+    }
+  }
+
+  private class Fixture {
+    val environment: ConfigurableEnvironment = mockk(relaxed = true)
+    val subject = SpringPluginStatusProvider(environment)
+  }
+}


### PR DESCRIPTION
This will likely need to change in the future to use Front50 as the ultimate source of these values, but this is an incremental improvement over default PF4J.