### PR TITLE
fix(config): support configserver files

### DIFF
--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigFileService.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigFileService.java
@@ -30,10 +30,17 @@ import org.apache.commons.lang3.StringUtils;
 @Slf4j
 public class ConfigFileService {
   private static final String CLASSPATH_FILE_PREFIX = "classpath:";
+  private final CloudConfigResourceService cloudConfigResourceService;
 
-  public ConfigFileService() {}
+  public ConfigFileService(CloudConfigResourceService cloudConfigResourceService) {
+    this.cloudConfigResourceService = cloudConfigResourceService;
+  }
 
   public String getLocalPath(String path) {
+    if (CloudConfigResourceService.isCloudConfigResource(path)
+        && cloudConfigResourceService != null) {
+      path = cloudConfigResourceService.getLocalPath(path);
+    }
     verifyLocalPath(path);
     return path;
   }
@@ -51,8 +58,7 @@ public class ConfigFileService {
       if (isClasspathResource(path)) {
         return retrieveFromClasspath(path);
       }
-
-      return retrieveFromLocalPath(path);
+      return retrieveFromLocalPath(getLocalPath(path));
     }
 
     return null;

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/CloudConfigAutoConfiguration.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/CloudConfigAutoConfiguration.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.kork.configserver.autoconfig;
 
 import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
 import com.netflix.spinnaker.kork.configserver.ConfigFileService;
+import java.util.Optional;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.config.server.bootstrap.ConfigServerBootstrapConfiguration;
@@ -36,8 +37,9 @@ import org.springframework.context.annotation.Import;
 @AutoConfigureAfter({ConfigServerAutoConfiguration.class, ConfigServerBootstrapConfiguration.class})
 public class CloudConfigAutoConfiguration {
   @Bean
-  ConfigFileService configFileService() {
-    return new ConfigFileService();
+  ConfigFileService configFileService(
+      Optional<CloudConfigResourceService> cloudConfigResourceService) {
+    return new ConfigFileService(cloudConfigResourceService.get());
   }
 
   @Configuration

--- a/kork-config/src/test/java/com/netflix/spinnaker/kork/configserver/ConfigFileServiceTest.java
+++ b/kork-config/src/test/java/com/netflix/spinnaker/kork/configserver/ConfigFileServiceTest.java
@@ -33,7 +33,7 @@ class ConfigFileServiceTest {
       Paths.get(System.getProperty("java.io.tmpdir"), TEST_FILE_NAME).toString();
   private static final String TEST_FILE_CONTENTS = "test file contents";
 
-  private ConfigFileService configFileService = new ConfigFileService();
+  private ConfigFileService configFileService = new ConfigFileService(null);
 
   @AfterEach
   void tearDown() throws IOException {


### PR DESCRIPTION
This enables support for `configserver:` prefixed files transparently for services already using ConfigFileService.

It fixes the issue in Clouddriver of changes not being detected when referencing `kubeconfigFile` with `configserver` from a Cloud config server loaded config.