### PR TITLE
feat(expressions): Add plumbing to support function auto-complete

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionTransform.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionTransform.java
@@ -73,6 +73,9 @@ public class ExpressionTransform {
   /**
    * Helper to escape a simple expression string Used to extract a simple expression when parsing
    * fails
+   *
+   * @param expression Expression to escape
+   * @return escaped expression string
    */
   public static String escapeSimpleExpression(String expression) {
     String escaped = null;
@@ -88,6 +91,9 @@ public class ExpressionTransform {
    * Traverses and attempts to evaluate expressions Failures can either be INFO (for a simple
    * unresolved expression) or ERROR when an exception is thrown
    *
+   * @param source Source object to apply SpEL transformations to
+   * @param evaluationContext Context used during evaluation of source object
+   * @param summary Summary of evaluation after all transformations are applied
    * @return the transformed source object
    */
   public Map<String, Object> transformMap(

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
@@ -102,6 +102,10 @@ public class ExpressionsSupport {
     }
   }
 
+  public List<ExpressionFunctionProvider> getExpressionFunctionProviders() {
+    return expressionFunctionProviders;
+  }
+
   private static void registerFunction(
       StandardEvaluationContext context,
       String registrationName,
@@ -210,6 +214,7 @@ public class ExpressionsSupport {
       return new Functions(
           new FunctionDefinition(
               "toJson",
+              "Converts an object to JSON string",
               new FunctionParameter(
                   Object.class, "value", "An Object to marshall to a JSON String")));
     }
@@ -287,23 +292,29 @@ public class ExpressionsSupport {
       return new Functions(
           new FunctionDefinition(
               "toInt",
+              "Converts a string to integer",
               new FunctionParameter(String.class, "value", "A String value to convert to an int")),
           new FunctionDefinition(
               "toFloat",
+              "Converts a string to float",
               new FunctionParameter(String.class, "value", "A String value to convert to a float")),
           new FunctionDefinition(
               "toBoolean",
+              "Converts a string value to boolean",
               new FunctionParameter(
                   String.class, "value", "A String value to convert to a boolean")),
           new FunctionDefinition(
               "toBase64",
+              "Encodes a string to base64 string",
               new FunctionParameter(String.class, "value", "A String value to base64 encode")),
           new FunctionDefinition(
               "fromBase64",
+              "Decodes a base64 string",
               new FunctionParameter(
                   String.class, "value", "A base64-encoded String value to decode")),
           new FunctionDefinition(
               "alphanumerical",
+              "Removes all non-alphanumeric characters from a string",
               new FunctionParameter(
                   String.class,
                   "value",

--- a/kork-expressions/src/main/kotlin/com/netflix/spinnaker/kork/expressions/ExpressionFunctionProvider.kt
+++ b/kork-expressions/src/main/kotlin/com/netflix/spinnaker/kork/expressions/ExpressionFunctionProvider.kt
@@ -83,10 +83,15 @@ interface ExpressionFunctionProvider : ExtensionPoint {
    */
   data class FunctionDefinition(
     val name: String,
+    val description: String,
     val parameters: List<FunctionParameter>
   ) {
+    @Deprecated("Please use the overload with description", replaceWith = ReplaceWith("FunctionDefinition(name, \"\", functionParameters)"))
     constructor(name: String, vararg functionParameters: FunctionParameter) :
-      this(name, listOf(*functionParameters))
+      this(name, "", listOf(*functionParameters))
+
+    constructor(name: String, description: String, vararg functionParameters: FunctionParameter) :
+      this(name, description, listOf(*functionParameters))
   }
 
   /**


### PR DESCRIPTION
We would like to add SpEL function auto-complete ability to `deck` for better useability.
This requires that we can describe functions nicely and enum them from orca

* Add function description to `FunctionDefinition`
* Add ability to get all registered `FunctionProviders`

(also minor java doc fixups to remove compiler warnings)