### PR TITLE
chore(aws): Bump aws sdk

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -20,7 +20,7 @@ publishing {
 
 ext {
   versions = [
-    aws            : "1.11.622",
+    aws            : "1.11.656",
     bouncycastle   : "1.61",
     groovy         : "2.5.7", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
     hystrix        : "1.4.21",


### PR DESCRIPTION
Pick up new ECS task definition fields.

Updating to match [Netflix/AWSObjectMapper](https://github.com/Netflix/AWSObjectMapper/blob/master/build.gradle#L44)