### PR TITLE
chore(dependencies): Upgrade Spring Boot to 2.2

### DIFF
--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientDelegate.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteClientDelegate.java
@@ -24,7 +24,13 @@ import com.netflix.spinnaker.kork.jedis.RedisScanResult;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import redis.clients.jedis.*;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.Transaction;
+import redis.clients.jedis.commands.BinaryJedisCommands;
+import redis.clients.jedis.commands.JedisCommands;
+import redis.clients.jedis.commands.MultiKeyCommands;
+import redis.clients.jedis.commands.RedisPipeline;
+import redis.clients.jedis.commands.ScriptingCommands;
 import redis.clients.jedis.exceptions.JedisException;
 
 public class DynomiteClientDelegate implements RedisClientDelegate {

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteDriverProperties.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/DynomiteDriverProperties.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.kork.dynomite;
 
+import static com.netflix.dyno.connectionpool.Host.DEFAULT_DATASTORE_PORT;
 import static com.netflix.dyno.connectionpool.Host.DEFAULT_PORT;
 import static com.netflix.dyno.connectionpool.Host.Status;
 
@@ -49,10 +50,13 @@ public class DynomiteDriverProperties {
                     it.hostname,
                     it.ipAddress,
                     it.port,
+                    it.securePort,
+                    it.datastorePort,
                     it.rack,
                     it.datacenter,
                     it.status,
-                    it.hashtag))
+                    it.hashtag,
+                    it.password))
         .collect(Collectors.toList());
   }
 
@@ -69,10 +73,13 @@ public class DynomiteDriverProperties {
     public String hostname;
     public String ipAddress;
     public int port = DEFAULT_PORT;
+    public int securePort = DEFAULT_PORT;
+    public int datastorePort = DEFAULT_DATASTORE_PORT;
     public Status status = Status.Up;
     public String rack = LOCAL_RACK;
     public String datacenter = LOCAL_DATACENTER;
     public Long token = 1000000L;
     public String hashtag = "{}";
+    public String password;
   }
 }

--- a/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/LocalRedisDynomiteClient.java
+++ b/kork-dynomite/src/main/java/com/netflix/spinnaker/kork/dynomite/LocalRedisDynomiteClient.java
@@ -37,7 +37,18 @@ public class LocalRedisDynomiteClient {
         StringUtils.isBlank(System.getenv("EC2_REGION")) ? "local" : System.getenv("EC2_REGION");
     HostSupplier localHostSupplier =
         new HostSupplier() {
-          final Host hostSupplierHost = new Host("localhost", rack, Host.Status.Up);
+          final Host hostSupplierHost =
+              new Host(
+                  "localhost",
+                  null,
+                  port,
+                  port,
+                  Host.DEFAULT_DATASTORE_PORT,
+                  rack,
+                  null,
+                  Host.Status.Up,
+                  null,
+                  null);
 
           @Override
           public List<Host> getHosts() {
@@ -47,7 +58,18 @@ public class LocalRedisDynomiteClient {
 
     TokenMapSupplier tokenMapSupplier =
         new TokenMapSupplier() {
-          final Host tokenHost = new Host("localhost", port, rack, Host.Status.Up);
+          final Host tokenHost =
+              new Host(
+                  "localhost",
+                  null,
+                  port,
+                  port,
+                  Host.DEFAULT_DATASTORE_PORT,
+                  rack,
+                  null,
+                  Host.Status.Up,
+                  null,
+                  null);
           final HostToken localHostToken = new HostToken(100000L, tokenHost);
 
           @Override

--- a/kork-jedis-test/src/main/java/com/netflix/spinnaker/kork/jedis/EmbeddedRedis.java
+++ b/kork-jedis-test/src/main/java/com/netflix/spinnaker/kork/jedis/EmbeddedRedis.java
@@ -6,7 +6,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
-import redis.clients.util.Pool;
+import redis.clients.jedis.util.Pool;
 import redis.embedded.RedisServer;
 
 public class EmbeddedRedis {

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisClientDelegate.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisClientDelegate.java
@@ -18,8 +18,17 @@ package com.netflix.spinnaker.kork.jedis;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import redis.clients.jedis.*;
-import redis.clients.util.Pool;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+import redis.clients.jedis.Transaction;
+import redis.clients.jedis.commands.BinaryJedisCommands;
+import redis.clients.jedis.commands.JedisCommands;
+import redis.clients.jedis.commands.MultiKeyCommands;
+import redis.clients.jedis.commands.RedisPipeline;
+import redis.clients.jedis.commands.ScriptingCommands;
+import redis.clients.jedis.util.Pool;
 
 public class JedisClientDelegate implements RedisClientDelegate {
 
@@ -175,7 +184,7 @@ public class JedisClientDelegate implements RedisClientDelegate {
         final List<String> results = result.getResult();
         f.accept(() -> results);
 
-        cursor = result.getStringCursor();
+        cursor = result.getCursor();
       } while (!"0".equals(cursor));
     }
   }

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisHealthIndicatorFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisHealthIndicatorFactory.java
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import redis.clients.jedis.Jedis;
-import redis.clients.util.Pool;
+import redis.clients.jedis.util.Pool;
 
 @SuppressWarnings("unchecked")
 public class JedisHealthIndicatorFactory {

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
@@ -25,7 +25,7 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.Protocol;
-import redis.clients.util.Pool;
+import redis.clients.jedis.util.Pool;
 
 public class JedisPoolFactory {
 

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientDelegate.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientDelegate.java
@@ -17,7 +17,13 @@ package com.netflix.spinnaker.kork.jedis;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
-import redis.clients.jedis.*;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.Transaction;
+import redis.clients.jedis.commands.BinaryJedisCommands;
+import redis.clients.jedis.commands.JedisCommands;
+import redis.clients.jedis.commands.MultiKeyCommands;
+import redis.clients.jedis.commands.RedisPipeline;
+import redis.clients.jedis.commands.ScriptingCommands;
 
 /**
  * Offers a functional interface over either a vanilla Jedis or Dynomite client.

--- a/kork-jedis/src/test/groovy/com/netflix/spinnaker/kork/jedis/locking/RedisLockManagerSpec.groovy
+++ b/kork-jedis/src/test/groovy/com/netflix/spinnaker/kork/jedis/locking/RedisLockManagerSpec.groovy
@@ -23,8 +23,7 @@ import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.lock.RedisLockManager
 import com.netflix.spinnaker.kork.lock.BaseLockManagerSpec
-import com.netflix.spinnaker.kork.lock.LockManager
-import redis.clients.jedis.JedisCommands
+import redis.clients.jedis.commands.JedisCommands
 import redis.clients.jedis.JedisPool
 import spock.lang.Shared
 

--- a/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
+++ b/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
@@ -27,6 +27,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Comparator;
 import liquibase.ContextExpression;
+import liquibase.LabelExpression;
 import liquibase.Liquibase;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
@@ -162,7 +163,9 @@ public class SqlTestUtil {
           false,
           Comparator.comparing(String::toString),
           new ClassLoaderResourceAccessor(),
-          new ContextExpression());
+          new ContextExpression(),
+          new LabelExpression(),
+          false);
 
       migrate =
           new Liquibase(

--- a/kork-sql/kork-sql.gradle
+++ b/kork-sql/kork-sql.gradle
@@ -8,7 +8,7 @@ dependencies {
   api project(":kork-security")
   api "org.springframework:spring-jdbc"
   api "org.springframework:spring-tx"
-  api("org.jooq:jooq:3.11.6")
+  api "org.jooq:jooq"
   api "org.liquibase:liquibase-core"
   api "com.zaxxer:HikariCP"
 

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -34,7 +34,7 @@ ext {
     retrofit2      : "2.6.2",
     spectator      : "0.75.0",
     spek           : "1.2.1",
-    springBoot     : "2.1.7.RELEASE",
+    springBoot     : "2.2.1.RELEASE",
     springCloud    : "Greenwich.SR2",
     swagger        : "2.9.2"
   ]
@@ -82,7 +82,7 @@ dependencies {
     api("com.natpryce:hamkrest:1.4.2.2")
     api("com.netflix.archaius:archaius-core:0.7.5")
     api("com.netflix.awsobjectmapper:awsobjectmapper:${versions.aws}")
-    api("com.netflix.dyno:dyno-jedis:1.6.4")
+    api("com.netflix.dyno:dyno-jedis:1.7.2")
     api("com.netflix.eureka:eureka-client:1.9.2")
     api("com.netflix.frigga:frigga:0.20.0")
     api("com.netflix.hystrix:hystrix-core:${versions.hystrix}")

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -34,7 +34,7 @@ ext {
     retrofit2      : "2.6.2",
     spectator      : "0.75.0",
     spek           : "1.2.1",
-    springBoot     : "2.2.1.RELEASE",
+    springBoot     : "2.2.2.RELEASE",
     springCloud    : "Greenwich.SR2",
     swagger        : "2.9.2"
   ]


### PR DESCRIPTION
**DO NOT MERGE**

This PR should not be merged until services that use kork-managed dependencies are ready to upgrade. 

Upgrade Spring Boot from 2.1.7 to 2.2.2. The Boot upgrade requires no code changes, but brings in newer versions of some Boot-managed dependencies that do require code changes. 

Jedis upgrade to `redis.clients:jedis:3.1.0`

* Packaging changes (especially `XxxCommand` classes)
* Various backward-incompatible API changes
* Previously deprecated methods removed

The Jedis upgrade necessitates an upgrade to `com.netflix.dyno:dyno-jedis:1.7.2`

* Compatibility with Jedis 3.1.x
* Various backward-incompatible API changes

Liquibase upgrade to `org.liquibase:liquibase-core:3.8.0`

* One backward-incompatible API change
