### PR TITLE
feat(config): Add and prefer config files in ~/.config/spinnaker

### DIFF
--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/boot/DefaultPropertiesBuilder.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/boot/DefaultPropertiesBuilder.java
@@ -29,7 +29,7 @@ public class DefaultPropertiesBuilder {
     defaults.put("netflix.account", "${netflix.environment}");
     defaults.put("netflix.stack", "test");
     defaults.put("spring.config.name", "spinnaker,${spring.application.name}");
-    defaults.put("spring.config.additional-location", "${user.home}/.spinnaker/");
+    defaults.put("spring.config.additional-location", "${user.home}/.config/spinnaker,${user.home}/.spinnaker/");
     defaults.put("spring.profiles.active", "${netflix.environment},local");
     // add the Spring Cloud Config "composite" profile to default to a configuration
     // source that won't prevent app startup if custom configuration is not provided


### PR DESCRIPTION
The [XDG Base Directory spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html) suggests putting application config under `~/.config/<app_name>`, as the older `~/.<app_name>/` config dir clutters up the `$HOME` dir. A bunch of other modern applications already do this.

A follow up PR against Halyard would be needed to start putting files in this new directory.