### PR TITLE
fix(plugins): fix SpinnakerPluginManager initialization

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/kork/plugins/spring/PluginLoader.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/kork/plugins/spring/PluginLoader.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * initialization, plugins are able to be autowired. The PluginLoader config file's location is
  * configurable itself, via an environment variable.
  *
- * @deprecated Should use `SpringPluginManager` instead. See `PluginsAutoConfiguration`.
+ * @deprecated Should use `SpinnakerPluginManager` instead. See `PluginsAutoConfiguration`.
  */
 @Deprecated
 @Beta

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactory.kt
@@ -19,6 +19,7 @@ import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import com.netflix.spinnaker.kork.plugins.api.spring.SpringPlugin
 import com.netflix.spinnaker.kork.plugins.config.ConfigCoordinates
+import com.netflix.spinnaker.kork.plugins.config.ConfigResolver
 import com.netflix.spinnaker.kork.plugins.config.PluginConfigCoordinates
 import com.netflix.spinnaker.kork.plugins.config.SystemExtensionConfigCoordinates
 import org.pf4j.ExtensionFactory
@@ -34,7 +35,8 @@ import java.lang.reflect.InvocationTargetException
  * TODO(rz): Support creation of unsafe plugins
  */
 class SpringExtensionFactory(
-  private val pluginManager: SpinnakerPluginManager
+  private val pluginManager: SpinnakerPluginManager,
+  private val configResolver: ConfigResolver
 ) : ExtensionFactory {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -116,7 +118,7 @@ class SpringExtensionFactory(
             it.resolve()
             it.getGeneric(0).rawClass
           }
-          ?.let { pluginManager.configResolver.resolve(coordinates, it) }
+          ?.let { configResolver.resolve(coordinates, it) }
           ?.also {
             try {
               val method = extension.javaClass.getDeclaredMethod("setConfiguration", it.javaClass)

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSystemTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSystemTest.kt
@@ -18,6 +18,9 @@ package com.netflix.spinnaker.kork.plugins
 import com.netflix.spinnaker.config.PluginsAutoConfiguration
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import org.pf4j.DefaultPluginDescriptor
+import org.pf4j.PluginState
+import org.pf4j.PluginWrapper
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
@@ -40,6 +43,30 @@ class PluginSystemTest : JUnit5Minutests {
           that(ctx.getBean("pluginManager")).isA<SpinnakerPluginManager>()
           that(ctx.getBean("pluginBeanPostProcessor")).isA<ExtensionBeanDefinitionRegistryPostProcessor>()
         }
+      }
+    }
+
+    test("SpinnakerPluginManager is initialized properly and usable") {
+      run { ctx: AssertableApplicationContext ->
+        val pluginManager = ctx.getBean("pluginManager") as SpinnakerPluginManager
+        val testPluginWrapper = PluginWrapper(
+          pluginManager,
+          DefaultPluginDescriptor(
+            "TestPlugin",
+            "desc",
+            "TestPlugin.java",
+            "1.0.0",
+            "",
+            "Armory",
+            "Apache"
+          ),
+          null,
+          null
+        )
+        testPluginWrapper.pluginState = PluginState.DISABLED
+        pluginManager.setPlugins(listOf(testPluginWrapper))
+
+        pluginManager.enablePlugin("TestPlugin")
       }
     }
   }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins
+
+import com.netflix.spinnaker.kork.plugins.config.ConfigCoordinates
+import com.netflix.spinnaker.kork.plugins.config.ConfigResolver
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.pf4j.DefaultPluginDescriptor
+import org.pf4j.PluginState
+import org.pf4j.PluginStatusProvider
+import org.pf4j.PluginWrapper
+import strikt.api.expectThat
+import strikt.assertions.isTrue
+import java.nio.file.Paths
+
+class SpinnakerPluginManagerTest : JUnit5Minutests {
+
+  fun tests() = rootContext {
+
+    test("SpinnakerPluginManager is initialized properly and usable") {
+      val pluginManager = SpinnakerPluginManager(FakePluginStatusProvider(), FakeConfigResolver(), Paths.get("plugins"))
+      val testPluginWrapper = PluginWrapper(
+        pluginManager,
+        DefaultPluginDescriptor(
+          "TestPlugin",
+          "desc",
+          "TestPlugin.java",
+          "1.0.0",
+          "",
+          "Armory",
+          "Apache"
+        ),
+        null,
+        null
+      )
+      testPluginWrapper.pluginState = PluginState.DISABLED
+      pluginManager.setPlugins(listOf(testPluginWrapper))
+
+      expectThat(pluginManager.enablePlugin("TestPlugin")).isTrue()
+    }
+  }
+}
+
+class FakePluginStatusProvider : PluginStatusProvider {
+  override fun disablePlugin(pluginId: String?) {}
+  override fun isPluginDisabled(pluginId: String?) = false
+  override fun enablePlugin(pluginId: String?) {}
+}
+
+class FakeConfigResolver : ConfigResolver {
+  override fun <T> resolve(coordinates: ConfigCoordinates, expectedType: Class<T>) = expectedType.newInstance()
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactoryTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactoryTest.kt
@@ -89,12 +89,8 @@ class SpringExtensionFactoryTest : JUnit5Minutests {
   private inner class Fixture {
     val configResolver: ConfigResolver = mockk(relaxed = true)
     val pluginManager: SpinnakerPluginManager = mockk(relaxed = true)
-    val subject = SpringExtensionFactory(pluginManager)
+    val subject = SpringExtensionFactory(pluginManager, configResolver)
     val pluginWrapper: PluginWrapper = mockk(relaxed = true)
-
-    init {
-      every { pluginManager.configResolver } returns configResolver
-    }
   }
 
   private fun createPluginDescriptor(namespace: String, pluginId: String): SpinnakerPluginDescriptor {


### PR DESCRIPTION
Plugins didn't actually load. AbstractPluginManager conflates instantiation and initialization. The SpinnakerPluginManager pluginStatusProvider was delegating to null (even with the proxy in place) and load plugins, enabling and disabling failed with NPEs. The most straight forward way to fix it was to circumvent the create* methods and just initialize the protected members direct that are passing into SpinnakerPluginManager. There are tests that show the problem and fail without the changes.