### PR TITLE
feat(sql): Support for multiple SQL data sources

### DIFF
--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -74,7 +74,7 @@ class DefaultSqlConfiguration {
     SpringLiquibaseProxy(properties.migration)
 
   @Bean
-  @ConditionalOnProperty("sql.secondaryMigration.jdbcUrl")
+  @ConditionalOnProperty("sql.secondary-migration.jdbc-url")
   fun secondaryLiquibase(properties: SqlProperties): SpringLiquibase =
     SpringLiquibaseProxy(properties.secondaryMigration!!)
 

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -76,7 +76,7 @@ class DefaultSqlConfiguration {
   @Bean
   @ConditionalOnProperty("sql.secondary-migration.jdbc-url")
   fun secondaryLiquibase(properties: SqlProperties): SpringLiquibase =
-    SpringLiquibaseProxy(properties.secondaryMigration!!)
+    SpringLiquibaseProxy(properties.secondaryMigration)
 
   @DependsOn("liquibase")
   @Bean

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -43,6 +43,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.DependsOn
 import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Conditional
 import org.springframework.jdbc.datasource.DataSourceTransactionManager
 import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy
 import sun.net.InetAddressCachePolicy
@@ -71,6 +72,11 @@ class DefaultSqlConfiguration {
   @ConditionalOnMissingBean(SpringLiquibase::class)
   fun liquibase(properties: SqlProperties): SpringLiquibase =
     SpringLiquibaseProxy(properties.migration)
+
+  @Bean
+  @ConditionalOnProperty("sql.secondaryMigration.jdbcUrl")
+  fun secondaryLiquibase(properties: SqlProperties): SpringLiquibase =
+    SpringLiquibaseProxy(properties.secondaryMigration!!)
 
   @DependsOn("liquibase")
   @Bean
@@ -165,6 +171,22 @@ class DefaultSqlConfiguration {
   @ConditionalOnMissingBean(DSLContext::class)
   fun jooq(jooqConfiguration: DefaultConfiguration): DSLContext =
     DefaultDSLContext(jooqConfiguration)
+
+  @Bean(destroyMethod = "close")
+  @Conditional(SecondaryPoolDialectCondition::class)
+  fun secondaryJooq(connectionProvider: DataSourceConnectionProvider, sqlProperties: SqlProperties): DSLContext {
+    val secondaryPool: ConnectionPoolProperties = sqlProperties.connectionPools.filter { !it.value.default }.values.first()
+    val secondaryJooqConfig: DefaultConfiguration = DefaultConfiguration().apply {
+      set(*DefaultExecuteListenerProvider.providers(
+        JooqToSpringExceptionTransformer(),
+        JooqSqlCommentAppender(),
+        JooqSlowQueryLogger()
+      ))
+      set(connectionProvider)
+      setSQLDialect(secondaryPool.dialect)
+    }
+    return DefaultDSLContext(secondaryJooqConfig)
+  }
 
   @Bean
   fun sqlHealthProvider(

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SecondaryPoolDialectCondition.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SecondaryPoolDialectCondition.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.sql.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.core.type.AnnotatedTypeMetadata
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName
+import org.springframework.boot.context.properties.bind.Bindable
+import org.springframework.boot.context.properties.bind.Binder
+
+class SecondaryPoolDialectCondition : SpringBootCondition() {
+
+  override fun getMatchOutcome(context: ConditionContext?, metadata: AnnotatedTypeMetadata?): ConditionOutcome {
+    return ConditionOutcome(hasDifferentDialect(context), "SQL Dialect check did not pass")
+  }
+
+  fun hasDifferentDialect(context: ConditionContext?): Boolean {
+    val sqlProperties: SqlProperties = Binder.get(context?.environment)
+      .bind(ConfigurationPropertyName.of("sql"), Bindable.of(SqlProperties::class.java))
+      .orElse(SqlProperties())
+
+    if (sqlProperties.connectionPools.size <= 1 || sqlProperties.connectionPools.size > 2) {
+      return false
+    }
+
+    val defaultPool: ConnectionPoolProperties = sqlProperties.connectionPools.filter { it.value.default }.values.first()
+    val secondaryPool: ConnectionPoolProperties = sqlProperties.connectionPools.filter { !it.value.default }.values.first()
+
+    return defaultPool.dialect != secondaryPool.dialect
+  }
+}

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlProperties.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlProperties.kt
@@ -20,7 +20,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("sql")
 data class SqlProperties(
   var migration: SqlMigrationProperties = SqlMigrationProperties(),
-  var secondaryMigration: SqlMigrationProperties? = null,
+  var secondaryMigration: SqlMigrationProperties = SqlMigrationProperties(),
   var connectionPools: MutableMap<String, ConnectionPoolProperties> = mutableMapOf(),
   var retries: SqlRetryProperties = SqlRetryProperties(),
 

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlProperties.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlProperties.kt
@@ -20,6 +20,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("sql")
 data class SqlProperties(
   var migration: SqlMigrationProperties = SqlMigrationProperties(),
+  var secondaryMigration: SqlMigrationProperties? = null,
   var connectionPools: MutableMap<String, ConnectionPoolProperties> = mutableMapOf(),
   var retries: SqlRetryProperties = SqlRetryProperties(),
 

--- a/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SqlConfigurationTests.kt
+++ b/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SqlConfigurationTests.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,67 +13,50 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.netflix.spinnaker.kork.sql
 
 import com.netflix.spinnaker.kork.PlatformComponents
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
-import com.netflix.spinnaker.kork.sql.health.SqlHealthIndicator
+import com.netflix.spinnaker.kork.sql.config.SqlProperties
 import org.jooq.DSLContext
-import org.jooq.impl.DSL.field
-import org.jooq.impl.DSL.table
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.getBeansOfType
-import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import strikt.api.expectThat
-import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 
 @RunWith(SpringRunner::class)
+@ActiveProfiles("test")
 @SpringBootTest(
-  classes = [StartupTestApp::class],
-  properties = [
-    "sql.enabled=true",
-    "sql.migration.jdbcUrl=jdbc:h2:mem:test",
-    "sql.migration.dialect=H2",
-    "sql.connectionPool.jdbcUrl=jdbc:h2:mem:test",
-    "sql.connectionPool.dialect=H2"
-  ]
+  classes = [SqlConfigTestApp::class]
 )
-internal class SpringStartupTests {
-
-  @Autowired
-  lateinit var dbHealthIndicator: HealthIndicator
-
-  @Autowired
-  lateinit var jooq: DSLContext
+internal class SqlConfigurationTests {
 
   @Autowired
   lateinit var applicationContext: ApplicationContext
 
+  @Autowired
+  lateinit var sqlProperties: SqlProperties
+
   @Test
-  fun `uses SqlHealthIndicator`() {
-    expectThat(dbHealthIndicator).isA<SqlHealthIndicator>()
-
-    expectThat(
-      jooq
-        .insertInto(table("healthcheck"), listOf(field("id")))
-        .values(true).execute()
-    ).isEqualTo(1)
-
-    expectThat(applicationContext.getBeansOfType(DSLContext::class.java).size).isEqualTo(1)
+  fun `should have 2 JOOQ configured for both H2 & MYSQL pool`() {
+    expectThat(applicationContext.getBeansOfType(DSLContext::class.java).size).isEqualTo(2)
+    expectThat(sqlProperties.connectionPools.size).isEqualTo(2)
     expectThat(applicationContext.getBean("jooq")).isNotNull()
+    expectThat(applicationContext.getBean("secondaryJooq")).isNotNull()
     expectThat(applicationContext.getBean("liquibase")).isNotNull()
+    expectThat(applicationContext.getBean("secondaryLiquibase")).isNotNull()
   }
 }
 
 @SpringBootApplication
 @Import(PlatformComponents::class, DefaultSqlConfiguration::class)
-internal class StartupTestApp
+internal class SqlConfigTestApp

--- a/kork-sql/src/test/resources/application-test.yml
+++ b/kork-sql/src/test/resources/application-test.yml
@@ -1,11 +1,15 @@
 spring:
-  profiles:
-    active: test
+  profiles: test
+
+sql:
+  enabled: false
+
+---
+spring:
+  profiles: twodialects
+
 sql:
   enabled: true
-  secondary:
-    enabled: true
-    pool-name: secondary
   connectionPools:
     default:
       jdbcUrl: "jdbc:h2:mem:test"
@@ -23,6 +27,28 @@ sql:
     user:
     password:
   secondaryMigration:
+    jdbcUrl: "jdbc:h2:mem:test"
+    user:
+    password:
+---
+
+spring:
+  profiles: singledialect
+
+sql:
+  enabled: true
+  connectionPools:
+    default:
+      jdbcUrl: "jdbc:h2:mem:test"
+      default: true
+      user:
+      password:
+    secondary:
+      enabled: true
+      jdbcUrl: "jdbc:h2:mem:test"
+      user:
+      password:
+  migration:
     jdbcUrl: "jdbc:h2:mem:test"
     user:
     password:

--- a/kork-sql/src/test/resources/application-test.yml
+++ b/kork-sql/src/test/resources/application-test.yml
@@ -1,0 +1,28 @@
+spring:
+  profiles:
+    active: test
+sql:
+  enabled: true
+  secondary:
+    enabled: true
+    pool-name: secondary
+  connectionPools:
+    default:
+      jdbcUrl: "jdbc:h2:mem:test"
+      default: true
+      user:
+      password:
+    secondary:
+      enabled: true
+      jdbcUrl: "jdbc:h2:mem:test"
+      dialect: H2
+      user:
+      password:
+  migration:
+    jdbcUrl: "jdbc:h2:mem:test"
+    user:
+    password:
+  secondaryMigration:
+    jdbcUrl: "jdbc:h2:mem:test"
+    user:
+    password:


### PR DESCRIPTION
- Conditionally add secondary liquibase target if configured.
- Conditionally add secondary JOOQ (DSLContext) to target a different dialect than the primary source. If two connection pools exist and they both are of same dialect we will not create secondary JOOQ bean. (eg: application having 2 pools against the same datasource will not need a secondary JOOQ)
- Configuration is backward compatible for the most part. Applications will need to wire up the JOOQ and pool as applicable on the app side of things.
- Tests exercise taking in the new sql config and verifies the bean existence as expected.