### PR TITLE
fix(plugins): plugin enable config did not use namespace

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginDescriptor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginDescriptor.kt
@@ -26,5 +26,14 @@ import org.pf4j.PluginDescriptor
 class SpinnakerPluginDescriptor(
   private val baseDescriptor: PluginDescriptor,
   val namespace: String,
-  val unsafe: Boolean = false
-) : PluginDescriptor by baseDescriptor
+  val unsafe: Boolean = false,
+  val pluginName: String = baseDescriptor.pluginId
+) : PluginDescriptor by baseDescriptor {
+  override fun getPluginId(): String {
+    if (namespace == "undefined") {
+      return baseDescriptor.pluginId
+    } else {
+      return "$namespace.${baseDescriptor.pluginId}"
+    }
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactory.kt
@@ -170,7 +170,7 @@ class SpringExtensionFactory(
   }
 
   private fun PluginWrapper.getCoordinates(): PluginCoordinates =
-    (descriptor as SpinnakerPluginDescriptor).let { PluginCoordinates(it.namespace, it.pluginId) }
+    (descriptor as SpinnakerPluginDescriptor).let { PluginCoordinates(it.namespace, it.pluginName) }
 
   private inner class PluginCoordinates(
     val namespace: String,

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolver.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolver.kt
@@ -60,12 +60,14 @@ class SpringEnvironmentExtensionConfigResolver(
     val pointer = when (coordinates) {
       is PluginConfigCoordinates ->
         listOf(
-          coordinates.pluginNamespace,
+          if (coordinates.pluginNamespace == "undefined") null else coordinates.pluginNamespace,
           coordinates.pluginId,
           "extensions",
           coordinates.extensionNamespace,
           coordinates.extensionId
-        ).let { "/spinnaker/plugins/${it.joinToString("/")}/config" }
+        ).filter { it != null }.let {
+          "/spinnaker/plugins/${it.joinToString("/")}/config"
+        }
       is SystemExtensionConfigCoordinates ->
         "/spinnaker/extensions/${coordinates.extensionNamespace}/${coordinates.extensionId}/config"
     }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerManifestPluginDescriptorFinderTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerManifestPluginDescriptorFinderTest.kt
@@ -45,7 +45,8 @@ class SpinnakerManifestPluginDescriptorFinderTest : JUnit5Minutests {
       expectThat(descriptorFinder.find(pluginsPath.resolve("test-plugin-1")))
         .isA<SpinnakerPluginDescriptor>()
         .and {
-          get { pluginId }.isEqualTo("test-plugin-1")
+          get { pluginId }.isEqualTo("pf4j.test-plugin-1")
+          get { pluginName }.isEqualTo("test-plugin-1")
           get { unsafe }.isTrue()
         }
     }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerPropertiesPluginDescriptorFinderTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerPropertiesPluginDescriptorFinderTest.kt
@@ -47,7 +47,8 @@ class SpinnakerPropertiesPluginDescriptorFinderTest : JUnit5Minutests {
       expectThat(descriptorFinder.find(pluginsPath.resolve("test-plugin-1")))
         .isA<SpinnakerPluginDescriptor>()
         .and {
-          get { pluginId }.isEqualTo("test-plugin-1")
+          get { pluginId }.isEqualTo("pf4j.test-plugin-1")
+          get { pluginName }.isEqualTo("test-plugin-1")
           get { unsafe }.isTrue()
         }
     }


### PR DESCRIPTION
My example plugin (https://github.com/claymccoy/pf4jStagePlugin) has a namespace. In order for it to load in orca the config must have the namespace in the config path, but it can't be in the enabled path.
```
spinnaker:
  plugins:
    RandomWaitPlugin:
      enabled: true
    Armory.RandomWaitPlugin:
      extensions:
        armory.randomWaitStage:
          enabled: true
          config:
            defaultMaxWaitTime: 60
```
This change unifies the path to be \<namespace\>.\<plugin name\>.
Since PF4J uses the pluginId, I've had to override our SpinnakerPluginDescriptor to use \<namespace\>.\<plugin name\> as the pluginId. There are still places that require just the plugin name without the namespace, so I've added an attribute pluginName to distinguish that.
I think that plugin namespace should probably be required, but I've made it optional for now. I noticed that https://github.com/robzienert/spinnaker-plugin-helloworld/blob/master/helloworld-orca/helloworld-orca.gradle does not have a plugin namespace.