### PR TITLE
chore(dependency): Bump pf4j to 3.2.0

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -143,7 +143,7 @@ dependencies {
     api("org.jetbrains.spek:spek-subject-extension:${versions.spek}")
     api("org.jooq:jooq:3.12.3")
     api("org.objenesis:objenesis:2.5.1")
-    api("org.pf4j:pf4j:3.1.0")
+    api("org.pf4j:pf4j:3.2.0")
     api("org.springframework.boot:spring-boot-configuration-processor:${versions.springBoot}")
     api("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:2.1.5.RELEASE")
     api("org.springframework.security.extensions:spring-security-saml-dsl-core:1.0.5.RELEASE")


### PR DESCRIPTION
With this version bump, we can remove `@Extension` from plugin extensions and instead just use `@SpinnakerExtension`.