### PR TITLE
refactor(artifacts): Deprecate Artifact constructors

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -21,15 +21,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 @JsonIgnoreProperties("kind")
 public class Artifact {
   @JsonProperty("type")
@@ -61,6 +57,37 @@ public class Artifact {
 
   @JsonProperty("uuid")
   private String uuid;
+
+  // Deprecated as consumers should be using a builder; in the future this constructor will be
+  // removed from the public API
+  @Deprecated
+  public Artifact(
+      String type,
+      boolean customKind,
+      String name,
+      String version,
+      String location,
+      String reference,
+      Map<String, Object> metadata,
+      String artifactAccount,
+      String provenance,
+      String uuid) {
+    this.type = type;
+    this.customKind = customKind;
+    this.name = name;
+    this.version = version;
+    this.location = location;
+    this.reference = reference;
+    this.metadata = metadata;
+    this.artifactAccount = artifactAccount;
+    this.provenance = provenance;
+    this.uuid = uuid;
+  }
+
+  // Deprecated as consumers should be using a builder; in the future this constructor will be
+  // removed from the public API
+  @Deprecated
+  public Artifact() {}
 
   // Add extra, unknown data to the metadata map:
   @JsonAnySetter

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -17,16 +17,12 @@
 package com.netflix.spinnaker.kork.artifacts.model;
 
 import java.util.regex.Pattern;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
 @Data
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class ExpectedArtifact {
   Artifact matchArtifact;
   boolean usePriorArtifact;
@@ -34,6 +30,29 @@ public class ExpectedArtifact {
   Artifact defaultArtifact;
   String id; // UUID to use this ExpectedArtifact by reference in Pipelines.
   Artifact boundArtifact;
+
+  // Deprecated as consumers should be using a builder; in the future this constructor will be
+  // removed from the public API
+  @Deprecated
+  public ExpectedArtifact(
+      Artifact matchArtifact,
+      boolean usePriorArtifact,
+      boolean useDefaultArtifact,
+      Artifact defaultArtifact,
+      String id,
+      Artifact boundArtifact) {
+    this.matchArtifact = matchArtifact;
+    this.usePriorArtifact = usePriorArtifact;
+    this.useDefaultArtifact = useDefaultArtifact;
+    this.defaultArtifact = defaultArtifact;
+    this.id = id;
+    this.boundArtifact = boundArtifact;
+  }
+
+  // Deprecated as consumers should be using a builder; in the future this constructor will be
+  // removed from the public API
+  @Deprecated
+  public ExpectedArtifact() {}
 
   /**
    * Decide if the "matchArtifact" matches the incoming artifact. Any fields not specified in the


### PR DESCRIPTION
This is the first step in addressing the discussion [here](https://github.com/spinnaker/igor/pull/535#discussion_r340260634).

The all-arg constructors for Artifact and ExpectedArtifact accept a lot of similarly-typed parameters; to encourage use of the Builder inside each of these classes, mark these constructors
deprecated with the goal of eventually removing them.

The no-arg constructors don't have a problem with too many parameters, but they do encourage a pattern of creating an empty object and then setting fields on it rather than creating a fully-formed object. (One day it would be great to make these classes immutable, which would force
use of the Builder.) For this reason, also deprecate the no-arg constructor.

Adding an annotation to a lombok-generated constructor is experimental (and depends on Java version) so to be safe, I've just explicitly defined the constructors for the purpose of adding the annotation.