### PR TITLE
feat(plugins): adds a plugin generation testing tool and tests SpinnakerDefaultPluginLoader

### DIFF
--- a/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/api/TestExtension.java
+++ b/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/api/TestExtension.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins.testplugin.api;
+
+import org.pf4j.ExtensionPoint;
+
+/** A simple ExtensionPoint for unit/integration testing. */
+public interface TestExtension extends ExtensionPoint {
+  String getTestValue();
+}

--- a/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/unsafe/UnsafeTestExtension.java
+++ b/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/unsafe/UnsafeTestExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins.testplugin.unsafe;
+
+import com.netflix.spinnaker.kork.plugins.SpinnakerExtension;
+import com.netflix.spinnaker.kork.plugins.testplugin.api.TestExtension;
+import org.pf4j.Extension;
+
+/** An unsafe (in codebase) implementation of TestExtension. */
+@Extension
+@SpinnakerExtension(namespace = "spinnaker", id = "unsafe-test-extension")
+public class UnsafeTestExtension implements TestExtension {
+  @Override
+  public String getTestValue() {
+    return getClass().getSimpleName();
+  }
+}

--- a/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/unsafe/UnsafeTestPlugin.java
+++ b/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/unsafe/UnsafeTestPlugin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins.testplugin.unsafe;
+
+import org.pf4j.Plugin;
+import org.pf4j.PluginWrapper;
+
+/** An unsafe (in-codebase) Plugin for UnsafeTestExtension. */
+public class UnsafeTestPlugin extends Plugin {
+  public UnsafeTestPlugin(PluginWrapper wrapper) {
+    super(wrapper);
+  }
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/loaders/SpinnakerDefaultPluginLoaderTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/loaders/SpinnakerDefaultPluginLoaderTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins.loaders
+
+import com.netflix.spinnaker.kork.plugins.finders.SpinnakerPropertiesPluginDescriptorFinder
+import com.netflix.spinnaker.kork.plugins.testplugin.TestPluginBuilder
+import com.netflix.spinnaker.kork.plugins.testplugin.api.TestExtension
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.mockk
+import org.pf4j.PluginClassLoader
+import org.pf4j.PluginDescriptor
+import org.pf4j.PluginManager
+import strikt.api.expectThat
+import strikt.assertions.isTrue
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class SpinnakerDefaultPluginLoaderTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    test("plugin directory is applicable") {
+      expectThat(subject.isApplicable(unsafePluginPath)).isTrue()
+    }
+
+    test("loads the plugin class") {
+      val classpath = subject.loadPlugin(unsafePluginPath, unsafePluginDescriptor)
+      expectThat(classpath).isA<UnsafePluginClassLoader>()
+      expectThat(classpath.loadClass(unsafePluginDescriptor.pluginClass).name).isEqualTo(unsafePluginDescriptor.pluginClass)
+    }
+
+    test("generated plugin directory is applicable") {
+      expectThat(subject.isApplicable(generatedPluginPath)).isTrue()
+    }
+
+    test("loads the generated plugin") {
+      val classpath = subject.loadPlugin(generatedPluginPath, generatedPluginDescriptor)
+      expectThat(classpath).isA<PluginClassLoader>()
+      val pluginClass = classpath.loadClass(generatedPluginDescriptor.pluginClass)
+      expectThat(pluginClass.name).isEqualTo(generatedPluginDescriptor.pluginClass)
+      val extensionClassName = "${pluginClass.`package`.name}.${generatedPluginName}TestExtension"
+      val extensionClass = classpath.loadClass(extensionClassName)
+      expectThat(TestExtension::class.java.isAssignableFrom(extensionClass)).isTrue()
+      val extension = extensionClass.newInstance() as TestExtension
+      expectThat(extension.testValue).isEqualTo(extensionClass.simpleName)
+    }
+  }
+
+  private inner class Fixture {
+    val unsafePluginPath: Path = Paths.get(javaClass.getResource("/unsafe-testplugin/plugin.properties").toURI()).parent
+    val unsafePluginDescriptor: PluginDescriptor = SpinnakerPropertiesPluginDescriptorFinder().find(unsafePluginPath)
+    val pluginManager: PluginManager = mockk(relaxed = true)
+    val subject = SpinnakerDefaultPluginLoader(pluginManager)
+  }
+
+  companion object {
+    val generatedPluginName = "SpinnakerDefaultPluginLoaderTest"
+    val generatedPluginPath: Path = Files.createTempDirectory("generatedplugin").also {
+      TestPluginBuilder(pluginPath = it, name = generatedPluginName).build()
+    }
+    val generatedPluginDescriptor: PluginDescriptor = SpinnakerPropertiesPluginDescriptorFinder().find(generatedPluginPath)
+  }
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilder.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilder.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins.testplugin
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.tools.DiagnosticCollector
+import javax.tools.JavaCompiler
+import javax.tools.JavaFileObject
+import javax.tools.StandardLocation
+import javax.tools.ToolProvider
+
+/**
+ * Generates new java source and compiles it to dynamically create a Plugin that is not in the current classpath.
+ *
+ * The generated Plugin is an expanded directory type plugin with a properties file plugin descriptor. It
+ * has an Extension implementing {@code TestExtension}
+ *
+ * @see com.netflix.spinnaker.kork.plugins.testplugin.api.TestExtension
+ *
+ */
+class TestPluginBuilder(
+  /**
+   * The directory in which to create a plugin.
+   */
+  val pluginPath: Path,
+
+  /**
+   * The package name for the generated Plugin and Extension.
+   */
+  val packageName: String = "com.netflix.spinnaker.kork.plugins.testplugin.generated",
+
+  /**
+   * The name of the generated plugin and extension.
+   * The plugin will be ${name}TestPlugin and the Extension ${name}TestExtension.
+   */
+  val name: String = "Generated"
+) {
+
+  fun build() {
+    val generated = generateSources()
+    val classesDir = preparePluginDestination()
+    writePluginProperties()
+    val compilerSetup = setupCompiler(classesDir, generated)
+    if (!compilerSetup.task.call()) {
+      val message = compilerSetup.diagnostics.diagnostics.joinToString(separator = System.lineSeparator()) {
+        "${it.kind} in ${it.source} on line ${it.lineNumber} at ${it.columnNumber}: ${it.getMessage(null)}"
+      }
+      throw IllegalStateException("generation failed: ${System.lineSeparator()}$message")
+    }
+  }
+
+  private data class GenerateResult(
+    val rootDir: File,
+    val pluginFile: File,
+    val extensionFile: File
+  )
+
+  private fun generateSources(): GenerateResult {
+    val tempDir = Files.createTempDirectory("plugincodegen")
+    val packageDir = tempDir.resolve(packageName.replace('.', '/'))
+    packageDir.toFile().mkdirs()
+    val pluginFile = packageDir.resolve("${name}TestPlugin.java")
+    pluginFile.toFile().writeText(pluginSrc)
+    val extensionFile = packageDir.resolve("${name}TestExtension.java")
+    extensionFile.toFile().writeText(extensionSrc)
+
+    fun cleanupTemp(dir: File) {
+      dir.deleteOnExit()
+      dir.listFiles()?.forEach {
+        if (it.isDirectory) {
+          cleanupTemp(it)
+        } else {
+          it.deleteOnExit()
+        }
+      }
+    }
+
+    cleanupTemp(tempDir.toFile())
+    return GenerateResult(
+      rootDir = tempDir.toFile(),
+      pluginFile = pluginFile.toFile(),
+      extensionFile = extensionFile.toFile())
+  }
+
+  private fun systemClasspath(): Iterable<File> =
+    System.getProperty("java.class.path").split(System.getProperty("path.separator")).map { File(it) }
+
+  private fun preparePluginDestination(): File {
+    pluginPath.toFile().deleteRecursively()
+    val classOutput = pluginPath.resolve("classes").toFile()
+    classOutput.mkdirs()
+    return classOutput
+  }
+
+  private fun writePluginProperties(): Unit =
+    pluginPath.resolve("plugin.properties").toFile().writeText(pluginProperties)
+
+  private data class CompilerSetup(
+    val task: JavaCompiler.CompilationTask,
+    val diagnostics: DiagnosticCollector<JavaFileObject>
+  )
+
+  private fun setupCompiler(classesDir: File, generated: GenerateResult): CompilerSetup {
+    val compiler = ToolProvider.getSystemJavaCompiler()
+    val diag = DiagnosticCollector<JavaFileObject>()
+    val sfm = compiler.getStandardFileManager(diag, null, Charsets.UTF_8)
+    sfm.setLocation(StandardLocation.CLASS_OUTPUT, listOf(classesDir))
+    sfm.setLocation(StandardLocation.SOURCE_PATH, listOf(generated.rootDir))
+    sfm.setLocation(StandardLocation.CLASS_PATH, systemClasspath())
+    val javaFiles = sfm.getJavaFileObjects(generated.pluginFile, generated.extensionFile)
+    return CompilerSetup(
+      task = compiler.getTask(null, sfm, diag, null, null, javaFiles),
+      diagnostics = diag)
+  }
+
+  private val pluginSrc =
+    """
+    package $packageName;
+
+    import org.pf4j.Plugin;
+    import org.pf4j.PluginWrapper;
+
+    public class ${name}TestPlugin extends Plugin {
+      public ${name}TestPlugin(PluginWrapper wrapper) {
+        super(wrapper);
+      }
+    }
+    """.trimIndent()
+
+  private val extensionSrc =
+    """
+    package $packageName;
+
+    import com.netflix.spinnaker.kork.plugins.SpinnakerExtension;
+    import com.netflix.spinnaker.kork.plugins.testplugin.api.TestExtension;
+    import org.pf4j.Extension;
+
+    @Extension
+    @SpinnakerExtension(namespace = "spinnaker", id = "${name.toLowerCase()}-test-extension")
+    public class ${name}TestExtension implements TestExtension {
+      @Override
+      public String getTestValue() {
+        return getClass().getSimpleName();
+      }
+    }
+    """.trimIndent()
+
+  private val pluginProperties =
+    """
+    plugin.id=spinnaker/${name.toLowerCase()}testplugin
+    plugin.description=A generated TestPlugin named $name
+    plugin.class=$packageName.${name}TestPlugin
+    plugin.version=0.0.1
+    plugin.provider=Spinnaker
+    plugin.dependencies=
+    plugin.requires=*
+    plugin.license=Apache 2.0
+    plugin.unsafe=false
+    plugin.namespace=spinnaker
+    """.trimIndent()
+}

--- a/kork-plugins/src/test/resources/unsafe-testplugin/plugin.properties
+++ b/kork-plugins/src/test/resources/unsafe-testplugin/plugin.properties
@@ -1,0 +1,25 @@
+#
+# Copyright 2019 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+plugin.id=spinnaker/unsafetestplugin
+plugin.description=An unsafe test Plugin
+plugin.class=com.netflix.spinnaker.kork.plugins.testplugin.unsafe.UnsafeTestPlugin
+plugin.version=0.0.1
+plugin.provider=Spinnaker
+plugin.dependencies=
+plugin.requires=*
+plugin.license=Apache 2.0
+plugin.unsafe=true
+plugin.namespace=spinnaker


### PR DESCRIPTION
TestPluginBuilder will generate java source and compile to create a standalone plugin directory
suitable for referencing as a plugin to install. Useful for testing to have the ability to
create a plugin that is not already in the test classpath.