### PR TITLE
fix(plugins): allow unsafe plugins to load

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
@@ -64,6 +64,7 @@ class ExtensionBeanDefinitionRegistryPostProcessor(
 
     log.debug("Creating plugin extensions")
     pluginManager.startedPlugins.forEach { plugin ->
+      if (plugin.isUnsafe()) return@forEach
       log.debug("Creating extensions for plugin '{}'", plugin.pluginId)
       pluginManager.getExtensionClassNames(plugin.pluginId).forEach {
         log.debug("Creating extension '{}' for plugin '{}'", it, plugin.pluginId)

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/loaders/UnsafePluginClassLoader.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/loaders/UnsafePluginClassLoader.kt
@@ -19,6 +19,7 @@ import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor
 import org.pf4j.PluginClassLoader
 import org.pf4j.PluginManager
 import java.net.URL
+import java.net.URLClassLoader
 import java.util.Enumeration
 
 /**
@@ -39,4 +40,10 @@ class UnsafePluginClassLoader(
   override fun loadClass(name: String?): Class<*> = parent.loadClass(name)
   override fun getResource(name: String?): URL? = parent.getResource(name)
   override fun getResources(name: String?): Enumeration<URL> = parent.getResources(name)
+
+  override fun addURL(url: URL?) {
+    val method = URLClassLoader::class.java.getDeclaredMethod("addURL", URL::class.java)
+    method.isAccessible = true
+    method.invoke(parent, url)
+  }
 }


### PR DESCRIPTION
Unsafe plugins were putting jars and classes in their own ClassLoader, and then loading Classes from the parent delegate (a different class loader). This obviously failed.
The easiest fix for this was to make UnsafePluginClassLoader addURL append to the same `parent` class loader. Since addURL is protected this was done using reflection, and there is an assumption that `parent` is a URLClassLoader. Not ideal at all, but it is "unsafe" mode right?
I looked at making UnsafePluginClassLoader being more careful about who it delegates to, but PF4J makes that difficult. There may be better ways to handle this at a higher level like overriding AbstractPluginManager.loadPlugin or making changes to PF4J so that using the parent class loader exclusively is an option (basically making unsafe mode an option in PF4J core).
Some other issues are that unsafe plugin extensions are seen as system extensions. This is tricky because AbstractPluginManager.whichPlugin looks plugins up by class loader. That means that unsafe plugin extensions must be configured like system extensions. It also means that ExtensionBeanDefinitionRegistryPostProcessor needs to ignore registering unsafe plugin extensions, since it already loads them as system extensions and it causes a Spring exception when loading them twice.
This is probably not the long term solution, but that would mean more extensive changes (perhaps to PF4J core). This at least allows unsafe plugins to load.