### PR TITLE
feat(plugins): Remote plugin download capabilities

### DIFF
--- a/kork-plugins/kork-plugins.gradle
+++ b/kork-plugins/kork-plugins.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation project(":kork-plugins-spring-api")
 
   implementation "org.pf4j:pf4j"
+  implementation "org.pf4j:pf4j-update"
 
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation("com.google.guava:guava")

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -15,13 +15,27 @@
  */
 package com.netflix.spinnaker.config;
 
+import static java.lang.String.format;
+
 import com.netflix.spinnaker.kork.plugins.ExtensionBeanDefinitionRegistryPostProcessor;
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager;
 import com.netflix.spinnaker.kork.plugins.SpringPluginStatusProvider;
 import com.netflix.spinnaker.kork.plugins.config.ConfigResolver;
 import com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentExtensionConfigResolver;
+import com.netflix.spinnaker.kork.plugins.update.PluginUpdateService;
+import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.pf4j.PluginStatusProvider;
+import org.pf4j.update.DefaultUpdateRepository;
+import org.pf4j.update.UpdateManager;
+import org.pf4j.update.UpdateRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
@@ -33,6 +47,8 @@ import org.springframework.core.env.Environment;
 @Configuration
 @EnableConfigurationProperties(PluginsConfigurationProperties.class)
 public class PluginsAutoConfiguration {
+
+  private static final Logger log = LoggerFactory.getLogger(PluginsAutoConfiguration.class);
 
   @Bean
   public static PluginStatusProvider pluginStatusProvider(Environment environment) {
@@ -61,9 +77,38 @@ public class PluginsAutoConfiguration {
   }
 
   @Bean
+  public static UpdateManager pluginUpdateManager(
+      SpinnakerPluginManager pluginManager, PluginsConfigurationProperties properties) {
+    // TODO(rz): If no repositories, should we setup something to default to?
+    List<UpdateRepository> repositories =
+        properties.repositories.entrySet().stream()
+            .map(
+                entry -> {
+                  try {
+                    return new DefaultUpdateRepository(
+                        entry.getKey(), new URL(entry.getValue().url));
+                  } catch (MalformedURLException e) {
+                    throw new BeanCreationException(
+                        format("Plugin repository '%s' has malformed URL", entry.getKey()), e);
+                  }
+                })
+            .collect(Collectors.toList());
+
+    return new SpinnakerUpdateManager(pluginManager, repositories);
+  }
+
+  @Bean
+  public static PluginUpdateService pluginUpdateManagerAgent(
+      UpdateManager updateManager, SpinnakerPluginManager pluginManager) {
+    return new PluginUpdateService(updateManager, pluginManager);
+  }
+
+  @Bean
   public static ExtensionBeanDefinitionRegistryPostProcessor pluginBeanPostProcessor(
-      SpinnakerPluginManager pluginManager, ApplicationEventPublisher applicationEventPublisher) {
+      SpinnakerPluginManager pluginManager,
+      PluginUpdateService updateManagerService,
+      ApplicationEventPublisher applicationEventPublisher) {
     return new ExtensionBeanDefinitionRegistryPostProcessor(
-        pluginManager, applicationEventPublisher);
+        pluginManager, updateManagerService, applicationEventPublisher);
   }
 }

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.config;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -48,5 +50,11 @@ public class PluginsConfigurationProperties {
 
   public void setRootPath(String rootPath) {
     this.rootPath = rootPath;
+  }
+
+  public Map<String, PluginRepositoryProperties> repositories = new HashMap<>();
+
+  public static class PluginRepositoryProperties {
+    public String url;
   }
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.kork.plugins
 
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import com.netflix.spinnaker.kork.plugins.events.ExtensionLoaded
+import com.netflix.spinnaker.kork.plugins.update.PluginUpdateService
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.beans.factory.support.BeanDefinitionRegistry
@@ -30,6 +31,7 @@ import org.springframework.context.ApplicationEventPublisher
  */
 class ExtensionBeanDefinitionRegistryPostProcessor(
   private val pluginManager: SpinnakerPluginManager,
+  private val updateManagerService: PluginUpdateService,
   private val applicationEventPublisher: ApplicationEventPublisher
 ) : BeanDefinitionRegistryPostProcessor {
 
@@ -39,7 +41,9 @@ class ExtensionBeanDefinitionRegistryPostProcessor(
     val start = System.currentTimeMillis()
     log.debug("Preparing plugins")
     pluginManager.loadPlugins()
+    updateManagerService.checkForUpdates()
     pluginManager.startPlugins()
+
     log.debug("Finished preparing plugins in {}ms", System.currentTimeMillis() - start)
   }
 

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateService.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateService.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.update
+
+import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager
+import org.pf4j.update.UpdateManager
+import org.slf4j.LoggerFactory
+
+/**
+ * The [PluginUpdateService] is responsible for sourcing plugin updates from a plugin repository on startup.
+ *
+ * The current behavior is that the latest plugin release (according to semver) will always be selected as the
+ * most desirable plugin.
+ *
+ * All plugins that are returned by the repository will be downloaded and installed.
+ *
+ * While it's possible that this could be used after the application has started up, there is no guarantee that the
+ * extensions a plugin exposes will be correctly refreshed within the Spring context at this point. Therefore, it is
+ * strongly advised that if a plugin update needs to occur, the service should be redeployed. If live updates are
+ * desired in the future, we'll need to proxy extensions so that the real implementing object is delegated to, allowing
+ * Spring injection to continue working.
+ *
+ * TODO(rz): Look to a local config or front50 (depending on spinnaker setup) to determine if there are specific
+ *  plugin versions to use. We may not want the most recent release of a plugin.
+ * TODO(rz): The front50 integration will need to be smart enough to understand what service is asking for plugins
+ *  from the repository, and return only the plugins that are supposed to be installed on that service.
+ */
+class PluginUpdateService(
+  internal val updateManager: UpdateManager,
+  internal val pluginManager: SpinnakerPluginManager
+) {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  fun checkForUpdates() {
+    updateExistingPlugins()
+    installNewPlugins()
+  }
+
+  internal fun updateExistingPlugins() {
+    if (!updateManager.hasUpdates()) {
+      log.debug("No plugin updates found")
+      return
+    }
+
+    val updates = updateManager.updates
+    log.debug("Found {} plugin updates", updates.size)
+
+    updates.forEach { plugin ->
+      log.debug("Found update for plugin '{}'", plugin.id)
+
+      val lastRelease = updateManager.getLastPluginRelease(plugin.id)
+      val installedVersion = pluginManager.getPlugin(plugin.id).descriptor.version
+
+      log.debug("Update plugin '{}' from version {} to {}", plugin.id, installedVersion, lastRelease.version)
+
+      val updated = updateManager.updatePlugin(plugin.id, lastRelease.version)
+      if (updated) {
+        log.debug("Updated plugin '{}'", plugin.id)
+      } else {
+        log.error("Failed updating plugin '{}'", plugin.id)
+      }
+    }
+  }
+
+  internal fun installNewPlugins() {
+    if (!updateManager.hasAvailablePlugins()) {
+      log.debug("No new plugins found to install")
+      return
+    }
+
+    val availablePlugins = updateManager.availablePlugins
+    log.info("Found {} available plugins", availablePlugins.size)
+
+    availablePlugins.forEach { plugin ->
+      log.debug("Found new plugin '{}'", plugin.id)
+
+      val lastRelease = updateManager.getLastPluginRelease(plugin.id)
+      log.debug("Installing plugin '{}' with version {}", plugin.id, lastRelease.version)
+
+      val installed = updateManager.installPlugin(plugin.id, lastRelease.version)
+      if (installed) {
+        log.debug("Installed plugin '{}'", plugin.id)
+      } else {
+        log.error("Failed installing plugin '{}'", plugin.id)
+      }
+    }
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.update
+
+import org.pf4j.PluginManager
+import org.pf4j.update.UpdateManager
+import org.pf4j.update.UpdateRepository
+
+/**
+ * TODO(rz): Update [hasPluginUpdate] such that it understands the latest plugin is not always the one desired
+ */
+class SpinnakerUpdateManager(
+  pluginManager: PluginManager,
+  repositories: List<UpdateRepository>
+) : UpdateManager(pluginManager, repositories)

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.kork.plugins
 
 import com.netflix.spinnaker.kork.plugins.events.ExtensionLoaded
+import com.netflix.spinnaker.kork.plugins.update.PluginUpdateService
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
@@ -97,12 +98,13 @@ class ExtensionBeanDefinitionRegistryPostProcessorTest : JUnit5Minutests {
 
   private class Fixture {
     val pluginManager: SpinnakerPluginManager = mockk(relaxed = true)
+    val updateService: PluginUpdateService = mockk(relaxed = true)
     val pluginWrapper: PluginWrapper = mockk(relaxed = true)
     val extensionFactory: ExtensionFactory = mockk(relaxed = true)
     val applicationEventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
     val pluginDescriptor: SpinnakerPluginDescriptor = mockk(relaxed = true)
 
-    val subject = ExtensionBeanDefinitionRegistryPostProcessor(pluginManager, applicationEventPublisher)
+    val subject = ExtensionBeanDefinitionRegistryPostProcessor(pluginManager, updateService, applicationEventPublisher)
 
     init {
       every { extensionFactory.create(eq(FooExtension::class.java)) } returns FooExtension()

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilder.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilder.kt
@@ -49,8 +49,28 @@ class TestPluginBuilder(
    * The name of the generated plugin and extension.
    * The plugin will be ${name}TestPlugin and the Extension ${name}TestExtension.
    */
-  val name: String = "Generated"
+  val name: String = "Generated",
+
+  /**
+   * The version of the generated plugin.
+   */
+  val version: String = "0.0.1"
 ) {
+
+  /**
+   * The canonical Plugin class name.
+   */
+  val canonicalPluginClass = "$packageName.${name}TestPlugin"
+
+  /**
+   * The canonical Extension class name.
+   */
+  val canonicalExtensionClass = "$packageName.${name}TestExtension"
+
+  /**
+   * The fully resolved plugin ID.
+   */
+  val pluginId = "spinnaker.${name.toLowerCase()}testplugin"
 
   fun build() {
     val generated = generateSources()
@@ -163,10 +183,10 @@ class TestPluginBuilder(
 
   private val pluginProperties =
     """
-    plugin.id=spinnaker/${name.toLowerCase()}testplugin
+    plugin.id=$pluginId
     plugin.description=A generated TestPlugin named $name
-    plugin.class=$packageName.${name}TestPlugin
-    plugin.version=0.0.1
+    plugin.class=$canonicalPluginClass
+    plugin.version=$version
     plugin.provider=Spinnaker
     plugin.dependencies=
     plugin.requires=*

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateServiceTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateServiceTest.kt
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.update
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager
+import com.netflix.spinnaker.kork.plugins.internal.PluginZip
+import com.netflix.spinnaker.kork.plugins.testplugin.TestPluginBuilder
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.mockk
+import org.pf4j.DefaultPluginStatusProvider
+import org.pf4j.PluginState
+import org.pf4j.update.DefaultUpdateRepository
+import org.pf4j.update.PluginInfo
+import org.pf4j.update.UpdateManager
+import strikt.api.expect
+import strikt.api.expectThat
+import strikt.assertions.hasSize
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.time.Instant
+import java.util.Date
+
+class PluginUpdateServiceTest : JUnit5Minutests {
+
+  fun tests() = rootContext<PluginUpdateService> {
+    val paths = setupTestPluginInfra()
+
+    fixture {
+      val pluginManager = SpinnakerPluginManager(DefaultPluginStatusProvider(paths.plugins), mockk(), paths.plugins)
+      PluginUpdateService(
+        SpinnakerUpdateManager(
+          pluginManager,
+          listOf(DefaultUpdateRepository("testing", paths.repository.toUri().toURL()))
+        ),
+        pluginManager
+      )
+    }
+
+    after { reset(paths) }
+
+    context("no plugins installed locally") {
+      before {
+        changeRepository(updateManager, paths.repository, listOf(
+          createPlugin(paths.repository)
+        ))
+      }
+
+      test("no plugins loaded") {
+        pluginManager.loadPlugins()
+        expectThat(pluginManager.plugins).hasSize(0)
+      }
+
+      test("install new plugins") {
+        installNewPlugins()
+
+        expect {
+          that(pluginManager.plugins).hasSize(1)
+          that(pluginManager.getPlugin("spinnaker.generatedtestplugin"))
+            .get { pluginState }.isEqualTo(PluginState.STARTED)
+        }
+      }
+    }
+
+    context("local plugins are out-of-date") {
+      before {
+        addToLocalPlugins(createPlugin(paths.repository, "0.0.1"), paths).id
+        changeRepository(updateManager, paths.repository, listOf(
+          createPlugin(paths.repository, "0.0.2")
+        ))
+      }
+
+      test("old plugins are loaded") {
+        expect {
+          pluginManager.loadPlugins()
+
+          that(pluginManager.plugins)
+            .describedAs("initial loaded plugins")
+            .hasSize(1)
+          that(pluginManager.getPlugin("spinnaker.generatedtestplugin").descriptor.version)
+            .describedAs("loaded plugin version")
+            .isEqualTo("0.0.1")
+          that(updateManager.hasPluginUpdate("spinnaker.generatedtestplugin"))
+            .describedAs("loaded plugin update status")
+            .isTrue()
+        }
+      }
+
+      test("out-of-date plugins are updated") {
+        expect {
+          pluginManager.loadPlugins()
+
+          updateExistingPlugins()
+
+          that(updateManager.hasPluginUpdate("spinnaker.generatedtestplugin"))
+            .describedAs("plugin update status")
+            .isFalse()
+          that(pluginManager.plugins).hasSize(1)
+          that(pluginManager.getPlugin("spinnaker.generatedtestplugin").descriptor.version)
+            .describedAs("updated plugin version")
+            .isEqualTo("0.0.2")
+        }
+      }
+    }
+
+    context("all local plugins are up-to-date") {
+      before {
+        changeRepository(updateManager, paths.repository, listOf(
+          addToLocalPlugins(createPlugin(paths.repository), paths)
+        ))
+      }
+
+      test("no updates are performed") {
+        expect {
+          pluginManager.loadPlugins()
+
+          that(pluginManager.plugins)
+            .describedAs("loaded plugins")
+            .hasSize(1)
+          that(pluginManager.getPlugin("spinnaker.generatedtestplugin").descriptor.version)
+            .describedAs("loaded plugin version")
+            .isEqualTo("0.0.1")
+          that(updateManager.hasPluginUpdate("spinnaker.generatedtestplugin"))
+            .describedAs("loaded plugin has update")
+            .isFalse()
+
+          updateExistingPlugins()
+
+          that(pluginManager.getPlugin("spinnaker.generatedtestplugin").descriptor.version)
+            .describedAs("updated plugin version")
+            .isEqualTo("0.0.1")
+        }
+      }
+    }
+  }
+
+  private fun reset(paths: TestPaths) {
+    fun Path.recreate() {
+      toFile().deleteRecursively()
+      toFile().mkdir()
+    }
+    paths.repository.recreate()
+    paths.plugins.recreate()
+  }
+
+  /**
+   * Alters the repository without creating a new UpdateRepository within the Fixture.
+   */
+  private fun changeRepository(updateManager: UpdateManager, repositoryPath: Path, plugins: List<PluginInfo>) {
+    repositoryPath.resolve("plugins.json").toFile().writeText(ObjectMapper().writeValueAsString(plugins))
+    updateManager.repositories.first().refresh()
+  }
+
+  /**
+   * Copies a created plugin from the repository to the local `plugins` directory.
+   */
+  private fun addToLocalPlugins(pluginInfo: PluginInfo, paths: TestPaths): PluginInfo {
+    val releaseVersion = pluginInfo.releases.first().version
+    val pluginFilename = "${pluginInfo.id}-$releaseVersion.zip"
+    Files.copy(
+      paths.repository.resolve("${pluginInfo.id}/$releaseVersion/$pluginFilename"),
+      paths.plugins.resolve(pluginFilename),
+      StandardCopyOption.REPLACE_EXISTING
+    )
+    return pluginInfo
+  }
+
+  /**
+   * Compiles a test plugin and generates a ZIP artifact of it inside the `repository` temp directory.
+   *
+   * Compilation is necessary in this case so that we can assert the plugin and its extensions are actually being
+   * correctly loaded into the PluginClassLoader, rather than mistakenly resolving a type from the test source set.
+   */
+  private fun createPlugin(
+    repository: Path,
+    pluginVersion: String = "0.0.1",
+    className: String = "Generated"
+  ): PluginInfo {
+    val generatedPluginPath = Files.createTempDirectory("generated-plugin")
+    val pluginBuilder = TestPluginBuilder(
+      pluginPath = generatedPluginPath,
+      name = className,
+      version = pluginVersion
+    )
+    pluginBuilder.build()
+
+    val releasePath = File(repository.resolve("${pluginBuilder.pluginId}/$pluginVersion").toUri())
+      .also { it.mkdirs() }
+      .let { pluginRepositoryPath ->
+        val pluginPath = pluginRepositoryPath.resolve("${pluginBuilder.pluginId}-$pluginVersion.zip").toPath()
+
+        val zip = PluginZip.Builder(pluginPath, pluginBuilder.pluginId)
+          .pluginClass(pluginBuilder.canonicalPluginClass)
+          .pluginVersion(pluginBuilder.version)
+
+        "classes/${pluginBuilder.canonicalPluginClass.replace(".", "/")}.class".let {
+          zip.addFile(Paths.get(it), generatedPluginPath.resolve(it).toFile().readBytes())
+        }
+        "classes/${pluginBuilder.canonicalExtensionClass.replace(".", "/")}.class".let {
+          zip.addFile(Paths.get(it), generatedPluginPath.resolve(it).toFile().readBytes())
+        }
+        zip.addFile(Paths.get("META-INF/extensions.idx"), pluginBuilder.canonicalExtensionClass)
+
+        zip.build()
+
+        pluginPath
+      }
+
+    return PluginInfo().apply {
+      id = pluginBuilder.pluginId
+      name = pluginBuilder.name
+      description = "A generated TestPlugin named $name"
+      provider = "Spinnaker"
+      releases = listOf(
+        PluginInfo.PluginRelease().apply {
+          version = pluginBuilder.version
+          date = Date.from(Instant.now())
+          url = releasePath.toUri().toURL().toString()
+        }
+      )
+    }
+  }
+
+  /**
+   * Creates two sets of temporary directories:
+   *
+   * - `repository`, simulating a remote plugin repository that PF4J will download from
+   * - `plugins`, simulating a local plugins directory that will be used by the PluginManager to load from
+   */
+  private fun setupTestPluginInfra(): TestPaths {
+    val repositoryDir = Files.createTempDirectory("repository")
+    val pluginsDir = Files.createTempDirectory("plugins")
+    return TestPaths(pluginsDir, repositoryDir)
+  }
+
+  private inner class TestPaths(
+    val plugins: Path,
+    val repository: Path
+  )
+}

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -144,6 +144,7 @@ dependencies {
     api("org.jooq:jooq:3.12.3")
     api("org.objenesis:objenesis:2.5.1")
     api("org.pf4j:pf4j:3.2.0")
+    api("org.pf4j:pf4j-update:2.2.0")
     api("org.springframework.boot:spring-boot-configuration-processor:${versions.springBoot}")
     api("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:2.1.5.RELEASE")
     api("org.springframework.security.extensions:spring-security-saml-dsl-core:1.0.5.RELEASE")


### PR DESCRIPTION
Current functionality is pretty naive: All plugins in the repository are downloaded, and the latest
plugin version is always selected as the desired plugin version to install.