### PR TITLE
fix(plugins): fix PluginManager plugin directory bootstrapping

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -49,10 +49,15 @@ public class PluginsAutoConfiguration {
   @Bean
   public static SpinnakerPluginManager pluginManager(
       PluginStatusProvider pluginStatusProvider,
-      PluginsConfigurationProperties properties,
+      Environment environment,
       ConfigResolver configResolver) {
     return new SpinnakerPluginManager(
-        pluginStatusProvider, configResolver, Paths.get(properties.rootPath));
+        pluginStatusProvider,
+        configResolver,
+        Paths.get(
+            environment.getProperty(
+                PluginsConfigurationProperties.ROOT_PATH_CONFIG,
+                PluginsConfigurationProperties.DEFAULT_ROOT_PATH)));
   }
 
   @Bean

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
@@ -22,13 +22,31 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @see PluginsAutoConfiguration
  */
-@ConfigurationProperties("spinnaker.plugins")
+@ConfigurationProperties(PluginsConfigurationProperties.CONFIG_NAMESPACE)
 public class PluginsConfigurationProperties {
+  public static final String CONFIG_NAMESPACE = "spinnaker.plugins";
+  public static final String DEFAULT_ROOT_PATH = "plugins";
 
   /**
    * The root filepath to the directory containing all plugins.
    *
    * <p>If an absolute path is not provided, the path will be calculated relative to the executable.
    */
-  public String rootPath = "plugins";
+  // Note that this property is not bound at PluginManager initialization time,
+  // but is retained here for documentation purposes. Later consumers of this property
+  // will see the correctly bound value that was used when initializing the plugin subsystem.
+  private String rootPath = DEFAULT_ROOT_PATH;
+
+  // If for some reason we change the associated property name ensure this constant
+  // is updated to match. This is the actual value we will read from the environment
+  // at init time.
+  public static final String ROOT_PATH_CONFIG = CONFIG_NAMESPACE + ".root-path";
+
+  public String getRootPath() {
+    return rootPath;
+  }
+
+  public void setRootPath(String rootPath) {
+    this.rootPath = rootPath;
+  }
 }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSystemTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSystemTest.kt
@@ -16,6 +16,9 @@
 package com.netflix.spinnaker.kork.plugins
 
 import com.netflix.spinnaker.config.PluginsAutoConfiguration
+import com.netflix.spinnaker.kork.plugins.finders.SpinnakerPropertiesPluginDescriptorFinder
+import com.netflix.spinnaker.kork.plugins.testplugin.TestPluginBuilder
+import com.netflix.spinnaker.kork.plugins.testplugin.api.TestExtension
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import org.pf4j.DefaultPluginDescriptor
@@ -25,49 +28,109 @@ import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import strikt.api.expect
+import strikt.api.expectThat
+import strikt.assertions.hasSize
 import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEmpty
+import strikt.assertions.isNotNull
+import java.nio.file.Files
+import java.nio.file.Path
 
 class PluginSystemTest : JUnit5Minutests {
 
-  fun tests() = rootContext<ApplicationContextRunner> {
-    fixture {
-      ApplicationContextRunner()
-        .withConfiguration(AutoConfigurations.of(
-          PluginsAutoConfiguration::class.java
-        ))
-    }
+  fun tests() = rootContext {
+    derivedContext<ApplicationContextRunner>("initialization tests") {
+      fixture {
+        ApplicationContextRunner()
+          .withConfiguration(AutoConfigurations.of(
+            PluginsAutoConfiguration::class.java
+          ))
+      }
 
-    test("supports no configuration") {
-      run { ctx: AssertableApplicationContext ->
-        expect {
-          that(ctx.getBean("pluginManager")).isA<SpinnakerPluginManager>()
-          that(ctx.getBean("pluginBeanPostProcessor")).isA<ExtensionBeanDefinitionRegistryPostProcessor>()
+      test("supports no configuration") {
+        run { ctx: AssertableApplicationContext ->
+          expect {
+            that(ctx.getBean("pluginManager")).isA<SpinnakerPluginManager>()
+            that(ctx.getBean("pluginBeanPostProcessor")).isA<ExtensionBeanDefinitionRegistryPostProcessor>()
+          }
+        }
+      }
+
+      test("SpinnakerPluginManager is initialized properly and usable") {
+        run { ctx: AssertableApplicationContext ->
+          val pluginManager = ctx.getBean("pluginManager") as SpinnakerPluginManager
+          val testPluginWrapper = PluginWrapper(
+            pluginManager,
+            DefaultPluginDescriptor(
+              "TestPlugin",
+              "desc",
+              "TestPlugin.java",
+              "1.0.0",
+              "",
+              "Armory",
+              "Apache"
+            ),
+            null,
+            null
+          )
+          testPluginWrapper.pluginState = PluginState.DISABLED
+          pluginManager.setPlugins(listOf(testPluginWrapper))
+
+          pluginManager.enablePlugin("TestPlugin")
         }
       }
     }
 
-    test("SpinnakerPluginManager is initialized properly and usable") {
-      run { ctx: AssertableApplicationContext ->
-        val pluginManager = ctx.getBean("pluginManager") as SpinnakerPluginManager
-        val testPluginWrapper = PluginWrapper(
-          pluginManager,
-          DefaultPluginDescriptor(
-            "TestPlugin",
-            "desc",
-            "TestPlugin.java",
-            "1.0.0",
-            "",
-            "Armory",
-            "Apache"
-          ),
-          null,
-          null
-        )
-        testPluginWrapper.pluginState = PluginState.DISABLED
-        pluginManager.setPlugins(listOf(testPluginWrapper))
+    derivedContext<GeneratedPluginFixture>("plugin loading tests") {
+      fixture {
+        GeneratedPluginFixture()
+      }
 
-        pluginManager.enablePlugin("TestPlugin")
+      test("An extension from an external plugin is available from the pluginManager") {
+        app.run { ctx: AssertableApplicationContext ->
+          val pluginManager = ctx.getBean("pluginManager") as SpinnakerPluginManager
+          expectThat(pluginManager.getPlugin(descriptor.pluginId)).isNotNull()
+          val extensions: List<TestExtension> = pluginManager.getExtensions(TestExtension::class.java, descriptor.pluginId)
+          expectThat(extensions).isNotEmpty()
+          expectThat(extensions).hasSize(1)
+          expectThat(extensions.first().testValue).isEqualTo("${testPluginName}TestExtension")
+        }
+      }
+
+      test("Extensions are registered as beans") {
+        app.run { ctx: AssertableApplicationContext ->
+          val extensions = ctx.getBeansOfType(TestExtension::class.java).filterKeys {
+            !it.endsWith("SystemExtension")
+          }
+          expectThat(extensions).isNotEmpty()
+          expectThat(extensions).hasSize(1)
+          expectThat(extensions.values.first().testValue).isEqualTo("${testPluginName}TestExtension")
+        }
       }
     }
+  }
+
+  private inner class GeneratedPluginFixture {
+    val app = ApplicationContextRunner()
+      .withPropertyValues(
+        "spinnaker.plugins.root-path=${pluginsDir.toAbsolutePath()}",
+        "spinnaker.plugins.${descriptor.pluginId}.enabled=true")
+      .withConfiguration(AutoConfigurations.of(PluginsAutoConfiguration::class.java))
+  }
+
+  // companion to avoid generating a plugin per test case
+  companion object GeneratedPlugin {
+    val testPluginName: String = "PluginSystemTest"
+    val pluginsDir: Path = Files.createTempDirectory("systemtest").also {
+      it.toFile().deleteOnExit()
+    }
+    val generatedPlugin: Path = Files.createTempDirectory(pluginsDir, "systemtestplugin").also {
+      it.toFile().deleteOnExit()
+    }
+    init {
+      TestPluginBuilder(pluginPath = generatedPlugin, name = testPluginName).build()
+    }
+    val descriptor: SpinnakerPluginDescriptor = SpinnakerPropertiesPluginDescriptorFinder().find(generatedPlugin) as SpinnakerPluginDescriptor
   }
 }


### PR DESCRIPTION
Fixes an issue reading the plugin directory configuration due to the SpinnakerPluginManager's early
initialization happening before ConfigurationProperties are bound.

Adds some tests to PluginSystemTest that load external plugins and extensions.