### PR TITLE
refactor(plugins): makes SpinnakerPluginDescriptor a subclass of DefaultPluginDescriptor.

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginDescriptor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginDescriptor.kt
@@ -15,7 +15,9 @@
  */
 package com.netflix.spinnaker.kork.plugins
 
+import org.pf4j.DefaultPluginDescriptor
 import org.pf4j.PluginDescriptor
+import java.util.Objects
 
 /**
  * Decorates the default [PluginDescriptor] with additional Spinnaker-specific metadata.
@@ -23,6 +25,42 @@ import org.pf4j.PluginDescriptor
  * @param unsafe If set to true, a plugin will be created using the parent application ClassLoader.
  */
 class SpinnakerPluginDescriptor(
-  private val baseDescriptor: PluginDescriptor,
-  val unsafe: Boolean = false
-) : PluginDescriptor by baseDescriptor
+  pluginId: String? = null,
+  pluginDescription: String? = null,
+  pluginClass: String? = null,
+  version: String? = null,
+  requires: String? = null,
+  provider: String? = null,
+  license: String? = null,
+  var unsafe: Boolean = false
+) : DefaultPluginDescriptor(
+  pluginId,
+  pluginDescription,
+  pluginClass,
+  version,
+  requires ?: "",
+  provider,
+  license) {
+
+  // TODO(cf): rework once upstream equals/hashCode change is released:
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as SpinnakerPluginDescriptor
+
+    return Objects.equals(unsafe, other.unsafe) &&
+      Objects.equals(pluginId, other.pluginId) &&
+      Objects.equals(pluginDescription, other.pluginDescription) &&
+      Objects.equals(pluginClass, other.pluginClass) &&
+      Objects.equals(version, other.version) &&
+      Objects.equals(requires, other.requires) &&
+      Objects.equals(provider, other.provider) &&
+      Objects.equals(license, other.license)
+  }
+
+  override fun hashCode(): Int {
+    return Objects.hash(
+      unsafe, pluginId, pluginDescription, pluginClass, version, requires, provider, license)
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerManifestPluginDescriptorFinder.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerManifestPluginDescriptorFinder.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.kork.plugins.finders
 
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor
 import com.netflix.spinnaker.kork.plugins.validate
+import org.pf4j.DefaultPluginDescriptor
 import org.pf4j.ManifestPluginDescriptorFinder
 import org.pf4j.PluginDescriptor
 import java.util.jar.Manifest
@@ -27,14 +28,14 @@ import java.util.jar.Manifest
  */
 internal class SpinnakerManifestPluginDescriptorFinder : ManifestPluginDescriptorFinder() {
   override fun createPluginDescriptor(manifest: Manifest): PluginDescriptor =
-    super.createPluginDescriptor(manifest)
-      .also { it.validate() }
-      .let {
-        SpinnakerPluginDescriptor(
-          it,
-          manifest.mainAttributes.getValue(PLUGIN_UNSAFE)?.toBoolean() ?: false
-        )
+    super.createPluginDescriptor(manifest).also {
+      if (it is SpinnakerPluginDescriptor) {
+        it.unsafe = manifest.mainAttributes.getValue(PLUGIN_UNSAFE)?.toBoolean() ?: false
       }
+      it.validate()
+    }
+
+  override fun createPluginDescriptorInstance(): DefaultPluginDescriptor = SpinnakerPluginDescriptor()
 
   companion object {
     const val PLUGIN_UNSAFE = "Plugin-Unsafe"

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerPropertiesPluginDescriptorFinder.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerPropertiesPluginDescriptorFinder.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.kork.plugins.finders
 
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor
 import com.netflix.spinnaker.kork.plugins.validate
+import org.pf4j.DefaultPluginDescriptor
 import org.pf4j.PluginDescriptor
 import org.pf4j.PropertiesPluginDescriptorFinder
 import java.util.Properties
@@ -30,14 +31,14 @@ internal class SpinnakerPropertiesPluginDescriptorFinder(
 ) : PropertiesPluginDescriptorFinder(propertiesFileName) {
 
   override fun createPluginDescriptor(properties: Properties): PluginDescriptor =
-    super.createPluginDescriptor(properties)
-      .also { it.validate() }
-      .let {
-        SpinnakerPluginDescriptor(
-          it,
-          properties.getProperty(PLUGIN_UNSAFE)?.toBoolean() ?: false
-        )
+    super.createPluginDescriptor(properties).also {
+      if (it is SpinnakerPluginDescriptor) {
+        it.unsafe = properties.getProperty(PLUGIN_UNSAFE)?.toBoolean() ?: false
       }
+      it.validate()
+    }
+
+  override fun createPluginDescriptorInstance(): DefaultPluginDescriptor = SpinnakerPluginDescriptor()
 
   companion object {
     const val PLUGIN_UNSAFE = "plugin.unsafe"

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactoryTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactoryTest.kt
@@ -24,7 +24,6 @@ import io.mockk.mockk
 import org.pf4j.Extension
 import org.pf4j.ExtensionPoint
 import org.pf4j.Plugin
-import org.pf4j.PluginDescriptor
 import org.pf4j.PluginWrapper
 import strikt.api.expectThat
 import strikt.api.expectThrows
@@ -94,9 +93,9 @@ class SpringExtensionFactoryTest : JUnit5Minutests {
   }
 
   private fun createPluginDescriptor(pluginId: String): SpinnakerPluginDescriptor {
-    val descriptor: PluginDescriptor = mockk(relaxed = true)
+    val descriptor: SpinnakerPluginDescriptor = mockk(relaxed = true)
     every { descriptor.pluginId } returns pluginId
-    return SpinnakerPluginDescriptor(descriptor)
+    return descriptor
   }
 
   interface TheExtensionPoint : ExtensionPoint

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/utils.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/utils.kt
@@ -20,14 +20,13 @@ import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor
 import io.mockk.every
 import io.mockk.mockk
 import org.pf4j.ExtensionPoint
-import org.pf4j.PluginDescriptor
 import java.lang.reflect.Method
 
 internal fun createPluginDescriptor(pluginId: String, version: String): SpinnakerPluginDescriptor {
-  val descriptor: PluginDescriptor = mockk(relaxed = true)
+  val descriptor: SpinnakerPluginDescriptor = mockk(relaxed = true)
   every { descriptor.pluginId } returns pluginId
   every { descriptor.version } returns version
-  return SpinnakerPluginDescriptor(descriptor)
+  return descriptor
 }
 
 internal fun createMethod(): Method {

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/spring/actuator/SpinnakerPluginEndpointTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/spring/actuator/SpinnakerPluginEndpointTest.kt
@@ -24,7 +24,6 @@ import dev.minutest.rootContext
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.assertThrows
-import org.pf4j.DefaultPluginDescriptor
 import org.pf4j.PluginDescriptor
 import org.pf4j.PluginWrapper
 import strikt.api.expectThat
@@ -64,7 +63,7 @@ class SpinnakerPluginEndpointTest : JUnit5Minutests {
     val subject = SpinnakerPluginEndpoint(pluginManager)
 
     init {
-      val pluginWrapper = PluginWrapper(pluginManager, SpinnakerPluginDescriptor(DefaultPluginDescriptor("test", "", "", "", "", "", "")), null, this.javaClass.classLoader)
+      val pluginWrapper = PluginWrapper(pluginManager, SpinnakerPluginDescriptor("test", "", "", "", "", "", ""), null, this.javaClass.classLoader)
       every { pluginManager.getPlugins() } returns listOf(pluginWrapper)
       every { pluginManager.getPlugin("abc") } returns null
       every { pluginManager.getPlugin("test") } returns pluginWrapper

--- a/kork-plugins/src/test/resources/testplugin/plugin.properties
+++ b/kork-plugins/src/test/resources/testplugin/plugin.properties
@@ -1,0 +1,25 @@
+#
+# Copyright 2019 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+plugin.id=netflix/testplugin
+plugin.description=No You pass the butter
+plugin.class=org.pf4j.Plugin
+plugin.version=0.0.1
+plugin.provider=Netflix
+plugin.dependencies=
+plugin.requires=*
+plugin.license=Apache 2.0
+plugin.unsafe=false
+plugin.namespace=netflix


### PR DESCRIPTION
This was largely to implement equals/hashCode but also plays slightly nicer with the
expected extension mechanism of PF4J.

There is a slightly worse immutability story here, but the base PluginDescriptor is
already a fully nullable POJO so I don't think it is too bad to have our new
attributes as var as well.

Also adds some PluginLoading tests (the original driver for the desire to have an
equality test on SpinnakerPluginDescriptor..). These are implemented as a generic
TCK as I have a follow-up PR that introduces a new plugin-type that exercises the
same set of tests for that type.