### PR TITLE
refactor(plugins): Remove separate namespace in favor of canonical ID

### DIFF
--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/SpinnakerExtension.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/SpinnakerExtension.java
@@ -35,12 +35,6 @@ import org.pf4j.Extension;
 @Target(ElementType.TYPE)
 @Documented
 public @interface SpinnakerExtension {
-  /**
-   * The namespace of the extension. Generally speaking, this would be your organization, e.g.
-   * "netflix".
-   */
-  String namespace();
-
-  /** The unique id of the extension within the namespace. */
+  /** The unique canonical id of the extension. */
   String id();
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/CanonicalPluginIdValidator.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/CanonicalPluginIdValidator.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins
+
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import org.pf4j.PluginDescriptor
+import java.util.regex.Pattern
+
+/**
+ * Validates that a given [PluginDescriptor] plugin ID conforms to the Spinnaker canonical plugin ID format.
+ */
+object CanonicalPluginIdValidator {
+
+  private val pattern = Pattern.compile("^[\\w\\-]+\\.[\\w\\-]+$")
+
+  fun validate(pluginDescriptor: PluginDescriptor) {
+    if (!pattern.matcher(pluginDescriptor.pluginId).matches()) {
+      throw MalformedPluginIdException(pluginDescriptor.pluginId)
+    }
+  }
+
+  private class MalformedPluginIdException(
+    providedId: String
+  ) : IntegrationException(
+    "Plugin '$providedId' does not conform to Spinnaker's Canonical Plugin ID. " +
+      "Canonical IDs must follow a '{namespace}.{pluginId}' format ($pattern)."
+  )
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginDescriptor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginDescriptor.kt
@@ -20,20 +20,9 @@ import org.pf4j.PluginDescriptor
 /**
  * Decorates the default [PluginDescriptor] with additional Spinnaker-specific metadata.
  *
- * @param namespace The plugin namespace. This should be the name of your org (github username, org, etc).
  * @param unsafe If set to true, a plugin will be created using the parent application ClassLoader.
  */
 class SpinnakerPluginDescriptor(
   private val baseDescriptor: PluginDescriptor,
-  val namespace: String,
-  val unsafe: Boolean = false,
-  val pluginName: String = baseDescriptor.pluginId
-) : PluginDescriptor by baseDescriptor {
-  override fun getPluginId(): String {
-    if (namespace == "undefined") {
-      return baseDescriptor.pluginId
-    } else {
-      return "$namespace.${baseDescriptor.pluginId}"
-    }
-  }
-}
+  val unsafe: Boolean = false
+) : PluginDescriptor by baseDescriptor

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactory.kt
@@ -66,9 +66,7 @@ class SpringExtensionFactory(
     val coordinates = pluginWrapper.getCoordinates()
 
     loadConfig(extension, PluginConfigCoordinates(
-      coordinates.namespace,
       coordinates.id,
-      annot.namespace,
       annot.id
     ))
 
@@ -85,7 +83,6 @@ class SpringExtensionFactory(
     }
 
     loadConfig(extension, SystemExtensionConfigCoordinates(
-      annot.namespace,
       annot.id
     ))
 
@@ -170,10 +167,9 @@ class SpringExtensionFactory(
   }
 
   private fun PluginWrapper.getCoordinates(): PluginCoordinates =
-    (descriptor as SpinnakerPluginDescriptor).let { PluginCoordinates(it.namespace, it.pluginName) }
+    (descriptor as SpinnakerPluginDescriptor).let { PluginCoordinates(it.pluginId) }
 
   private inner class PluginCoordinates(
-    val namespace: String,
     val id: String
   )
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/ConfigResolver.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/ConfigResolver.kt
@@ -32,7 +32,6 @@ interface ConfigResolver {
 }
 
 sealed class ConfigCoordinates(
-  val extensionNamespace: String,
   val extensionId: String
 )
 
@@ -40,16 +39,13 @@ sealed class ConfigCoordinates(
  * Config coordinates for a plugin's extension.
  */
 class PluginConfigCoordinates(
-  val pluginNamespace: String,
   val pluginId: String,
-  extensionNamespace: String,
   extensionId: String
-) : ConfigCoordinates(extensionNamespace, extensionId)
+) : ConfigCoordinates(extensionId)
 
 /**
  * Config coordinates for a system extension.
  */
 class SystemExtensionConfigCoordinates(
-  extensionNamespace: String,
   extensionId: String
-) : ConfigCoordinates(extensionNamespace, extensionId)
+) : ConfigCoordinates(extensionId)

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolver.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolver.kt
@@ -60,16 +60,14 @@ class SpringEnvironmentExtensionConfigResolver(
     val pointer = when (coordinates) {
       is PluginConfigCoordinates ->
         listOf(
-          if (coordinates.pluginNamespace == "undefined") null else coordinates.pluginNamespace,
           coordinates.pluginId,
           "extensions",
-          coordinates.extensionNamespace,
           coordinates.extensionId
-        ).filter { it != null }.let {
-          "/spinnaker/plugins/${it.joinToString("/")}/config"
+        ).let {
+          "/spinnaker/plugins/${it.joinToString("/").replace(".", "/")}/config"
         }
       is SystemExtensionConfigCoordinates ->
-        "/spinnaker/extensions/${coordinates.extensionNamespace}/${coordinates.extensionId}/config"
+        "/spinnaker/extensions/${coordinates.extensionId.replace(".", "/")}/config"
     }
     log.debug("Searching for config at '$pointer'")
 

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.kork.plugins
 
+import org.pf4j.PluginDescriptor
 import org.pf4j.PluginWrapper
 
 /**
@@ -28,4 +29,11 @@ internal fun PluginWrapper.isUnsafe(): Boolean {
       false
     }
   }
+}
+
+/**
+ * Validates a [PluginDescriptor] according to additional Spinnaker conventions.
+ */
+internal fun PluginDescriptor.validate() {
+  CanonicalPluginIdValidator.validate(this)
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerManifestPluginDescriptorFinder.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerManifestPluginDescriptorFinder.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.kork.plugins.finders
 
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor
+import com.netflix.spinnaker.kork.plugins.validate
 import org.pf4j.ManifestPluginDescriptorFinder
 import org.pf4j.PluginDescriptor
 import java.util.jar.Manifest
@@ -26,14 +27,16 @@ import java.util.jar.Manifest
  */
 internal class SpinnakerManifestPluginDescriptorFinder : ManifestPluginDescriptorFinder() {
   override fun createPluginDescriptor(manifest: Manifest): PluginDescriptor =
-    SpinnakerPluginDescriptor(
-      super.createPluginDescriptor(manifest),
-      manifest.mainAttributes.getValue(PLUGIN_NAMESPACE) ?: "undefined",
-      manifest.mainAttributes.getValue(PLUGIN_UNSAFE)?.toBoolean() ?: false
-    )
+    super.createPluginDescriptor(manifest)
+      .also { it.validate() }
+      .let {
+        SpinnakerPluginDescriptor(
+          it,
+          manifest.mainAttributes.getValue(PLUGIN_UNSAFE)?.toBoolean() ?: false
+        )
+      }
 
   companion object {
-    const val PLUGIN_NAMESPACE = "Plugin-Namespace"
     const val PLUGIN_UNSAFE = "Plugin-Unsafe"
   }
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerPropertiesPluginDescriptorFinder.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerPropertiesPluginDescriptorFinder.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.kork.plugins.finders
 
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor
+import com.netflix.spinnaker.kork.plugins.validate
 import org.pf4j.PluginDescriptor
 import org.pf4j.PropertiesPluginDescriptorFinder
 import java.util.Properties
@@ -29,14 +30,16 @@ internal class SpinnakerPropertiesPluginDescriptorFinder(
 ) : PropertiesPluginDescriptorFinder(propertiesFileName) {
 
   override fun createPluginDescriptor(properties: Properties): PluginDescriptor =
-    SpinnakerPluginDescriptor(
-      super.createPluginDescriptor(properties),
-      properties.getProperty(PLUGIN_NAMESPACE) ?: "undefined",
-      properties.getProperty(PLUGIN_UNSAFE)?.toBoolean() ?: false
-    )
+    super.createPluginDescriptor(properties)
+      .also { it.validate() }
+      .let {
+        SpinnakerPluginDescriptor(
+          it,
+          properties.getProperty(PLUGIN_UNSAFE)?.toBoolean() ?: false
+        )
+      }
 
   companion object {
-    const val PLUGIN_NAMESPACE = "plugin.namespace"
     const val PLUGIN_UNSAFE = "plugin.unsafe"
   }
 }

--- a/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/unsafe/UnsafeTestExtension.java
+++ b/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/unsafe/UnsafeTestExtension.java
@@ -22,7 +22,7 @@ import org.pf4j.Extension;
 
 /** An unsafe (in codebase) implementation of TestExtension. */
 @Extension
-@SpinnakerExtension(namespace = "spinnaker", id = "unsafe-test-extension")
+@SpinnakerExtension(id = "spinnaker.unsafe-test-extension")
 public class UnsafeTestExtension implements TestExtension {
   @Override
   public String getTestValue() {

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
@@ -117,7 +117,7 @@ class ExtensionBeanDefinitionRegistryPostProcessorTest : JUnit5Minutests {
     }
   }
 
-  @SpinnakerExtension(namespace = "netflix", id = "foo")
+  @SpinnakerExtension(id = "netflix.foo")
   private class FooExtension : ExampleExtensionPoint, ConfigurableExtension<FooExtension.FooExtensionConfig> {
     lateinit var config: FooExtensionConfig
 

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSystemTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSystemTest.kt
@@ -63,7 +63,7 @@ class PluginSystemTest : JUnit5Minutests {
           val testPluginWrapper = PluginWrapper(
             pluginManager,
             DefaultPluginDescriptor(
-              "TestPlugin",
+              "Armory.TestPlugin",
               "desc",
               "TestPlugin.java",
               "1.0.0",
@@ -77,7 +77,7 @@ class PluginSystemTest : JUnit5Minutests {
           testPluginWrapper.pluginState = PluginState.DISABLED
           pluginManager.setPlugins(listOf(testPluginWrapper))
 
-          pluginManager.enablePlugin("TestPlugin")
+          pluginManager.enablePlugin("Armory.TestPlugin")
         }
       }
     }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactoryTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactoryTest.kt
@@ -60,7 +60,7 @@ class SpringExtensionFactoryTest : JUnit5Minutests {
     context("plugin extensions") {
       test("without config") {
         every { pluginManager.whichPlugin(any()) } returns pluginWrapper
-        every { pluginWrapper.descriptor } returns createPluginDescriptor("pluginz", "bestone")
+        every { pluginWrapper.descriptor } returns createPluginDescriptor("pluginz.bestone")
 
         expectThat(subject.create(MyPlugin.NoConfigExtension::class.java))
           .isA<MyPlugin.NoConfigExtension>()
@@ -68,7 +68,7 @@ class SpringExtensionFactoryTest : JUnit5Minutests {
 
       test("with config") {
         every { pluginManager.whichPlugin(any()) } returns pluginWrapper
-        every { pluginWrapper.descriptor } returns createPluginDescriptor("pluginz", "bestone")
+        every { pluginWrapper.descriptor } returns createPluginDescriptor("pluginz.bestone")
 
         val config = MyPlugin.ConfiguredExtension.TheConfig()
         every { configResolver.resolve(any(), any<Class<MyPlugin.ConfiguredExtension.TheConfig>>()) } returns config
@@ -93,18 +93,18 @@ class SpringExtensionFactoryTest : JUnit5Minutests {
     val pluginWrapper: PluginWrapper = mockk(relaxed = true)
   }
 
-  private fun createPluginDescriptor(namespace: String, pluginId: String): SpinnakerPluginDescriptor {
+  private fun createPluginDescriptor(pluginId: String): SpinnakerPluginDescriptor {
     val descriptor: PluginDescriptor = mockk(relaxed = true)
     every { descriptor.pluginId } returns pluginId
-    return SpinnakerPluginDescriptor(descriptor, namespace)
+    return SpinnakerPluginDescriptor(descriptor)
   }
 
   interface TheExtensionPoint : ExtensionPoint
 
-  @SpinnakerExtension(namespace = "kork", id = "noconfig")
+  @SpinnakerExtension(id = "kork.noconfig")
   class NoConfigSystemExtension : TheExtensionPoint
 
-  @SpinnakerExtension(namespace = "kork", id = "configured")
+  @SpinnakerExtension(id = "kork.configured")
   class ConfiguredSystemExtension : TheExtensionPoint, ConfigurableExtension<ConfiguredSystemExtension.TheConfig> {
     lateinit var config: Any
     override fun setConfiguration(configuration: TheConfig) {
@@ -119,10 +119,10 @@ class SpringExtensionFactoryTest : JUnit5Minutests {
 
   class MyPlugin(wrapper: PluginWrapper) : Plugin(wrapper) {
 
-    @SpinnakerExtension(namespace = "plugin", id = "noconfig")
+    @SpinnakerExtension(id = "plugin.noconfig")
     class NoConfigExtension : TheExtensionPoint
 
-    @SpinnakerExtension(namespace = "plugin", id = "configured")
+    @SpinnakerExtension(id = "plugin.configured")
     class ConfiguredExtension : TheExtensionPoint, ConfigurableExtension<ConfiguredExtension.TheConfig> {
       lateinit var config: Any
       override fun setConfiguration(configuration: TheConfig) {

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolverTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolverTest.kt
@@ -40,7 +40,7 @@ class SpringEnvironmentExtensionConfigResolverTest : JUnit5Minutests {
       every { environment.getProperty(any(), eq(TestExtensionConfig::class.java)) } returns TestExtensionConfig()
 
       expectThat(subject.resolve(
-        PluginConfigCoordinates("netflix", "sweet-plugin", "netflix", "foo"),
+        PluginConfigCoordinates("netflix.sweet-plugin", "netflix.foo"),
         TestExtensionConfig::class.java
       ))
         .isA<TestExtensionConfig>()
@@ -57,7 +57,7 @@ class SpringEnvironmentExtensionConfigResolverTest : JUnit5Minutests {
       every { environment.getProperty(any(), eq(TestExtensionConfig::class.java)) } returns TestExtensionConfig()
 
       expectThat(subject.resolve(
-        PluginConfigCoordinates("netflix", "very-important", "orca", "stage"),
+        PluginConfigCoordinates("netflix.very-important", "orca.stage"),
         TestExtensionConfig::class.java
       ))
         .isA<TestExtensionConfig>()
@@ -73,7 +73,7 @@ class SpringEnvironmentExtensionConfigResolverTest : JUnit5Minutests {
       every { environment.getProperty(any(), eq(TestExtensionConfig::class.java)) } returns TestExtensionConfig()
 
       expectThat(subject.resolve(
-        SystemExtensionConfigCoordinates("netflix", "bar"),
+        SystemExtensionConfigCoordinates("netflix.bar"),
         TestExtensionConfig::class.java
       ))
         .isA<TestExtensionConfig>()

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerManifestPluginDescriptorFinderTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerManifestPluginDescriptorFinderTest.kt
@@ -42,11 +42,10 @@ class SpinnakerManifestPluginDescriptorFinderTest : JUnit5Minutests {
     test("unsafe property is decorated into plugin descriptor") {
       val descriptorFinder = SpinnakerManifestPluginDescriptorFinder()
 
-      expectThat(descriptorFinder.find(pluginsPath.resolve("test-plugin-1")))
+      expectThat(descriptorFinder.find(pluginsPath.resolve("pf4j.test-plugin-1")))
         .isA<SpinnakerPluginDescriptor>()
         .and {
           get { pluginId }.isEqualTo("pf4j.test-plugin-1")
-          get { pluginName }.isEqualTo("test-plugin-1")
           get { unsafe }.isTrue()
         }
     }
@@ -54,21 +53,20 @@ class SpinnakerManifestPluginDescriptorFinderTest : JUnit5Minutests {
 
   private class Fixture(val pluginsPath: Path) {
     init {
-      val pluginPath = Files.createDirectories(pluginsPath.resolve("test-plugin-1"))
+      val pluginPath = Files.createDirectories(pluginsPath.resolve("pf4j.test-plugin-1"))
       storeManifestToPath(getPlugin1Manifest(), pluginPath)
     }
 
     private fun getPlugin1Manifest(): Manifest {
       return PluginJar.createManifest(mapOf(
-        ManifestPluginDescriptorFinder.PLUGIN_ID to "test-plugin-1",
+        ManifestPluginDescriptorFinder.PLUGIN_ID to "pf4j.test-plugin-1",
         ManifestPluginDescriptorFinder.PLUGIN_CLASS to TestPlugin::class.java.name,
         ManifestPluginDescriptorFinder.PLUGIN_VERSION to "0.0.1",
         ManifestPluginDescriptorFinder.PLUGIN_DESCRIPTION to "Test Plugin 1",
         ManifestPluginDescriptorFinder.PLUGIN_PROVIDER to "Decebal Suiu",
-        ManifestPluginDescriptorFinder.PLUGIN_DEPENDENCIES to "test-plugin-2,test-plugin-3@~1.0",
+        ManifestPluginDescriptorFinder.PLUGIN_DEPENDENCIES to "foo.test-plugin-2,foo.test-plugin-3@~1.0",
         ManifestPluginDescriptorFinder.PLUGIN_REQUIRES to "*",
         ManifestPluginDescriptorFinder.PLUGIN_LICENSE to "Apache-2.0",
-        SpinnakerManifestPluginDescriptorFinder.PLUGIN_NAMESPACE to "pf4j",
         SpinnakerManifestPluginDescriptorFinder.PLUGIN_UNSAFE to "true"
       ))
     }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerPropertiesPluginDescriptorFinderTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerPropertiesPluginDescriptorFinderTest.kt
@@ -44,11 +44,10 @@ class SpinnakerPropertiesPluginDescriptorFinderTest : JUnit5Minutests {
     test("unsafe property is decorated into plugin descriptor") {
       val descriptorFinder = SpinnakerPropertiesPluginDescriptorFinder()
 
-      expectThat(descriptorFinder.find(pluginsPath.resolve("test-plugin-1")))
+      expectThat(descriptorFinder.find(pluginsPath.resolve("pf4j.test-plugin-1")))
         .isA<SpinnakerPluginDescriptor>()
         .and {
           get { pluginId }.isEqualTo("pf4j.test-plugin-1")
-          get { pluginName }.isEqualTo("test-plugin-1")
           get { unsafe }.isTrue()
         }
     }
@@ -57,21 +56,20 @@ class SpinnakerPropertiesPluginDescriptorFinderTest : JUnit5Minutests {
   private class Fixture(val pluginsPath: Path) {
 
     init {
-      val pluginPath = Files.createDirectory(pluginsPath.resolve("test-plugin-1"))
+      val pluginPath = Files.createDirectory(pluginsPath.resolve("pf4j.test-plugin-1"))
       storePropertiesToPath(getPlugin1Properties(), pluginPath)
     }
 
     private fun getPlugin1Properties(): Properties {
       return PluginZip.createProperties(mapOf(
-        PropertiesPluginDescriptorFinder.PLUGIN_ID to "test-plugin-1",
+        PropertiesPluginDescriptorFinder.PLUGIN_ID to "pf4j.test-plugin-1",
         PropertiesPluginDescriptorFinder.PLUGIN_CLASS to TestPlugin::class.java.name,
         PropertiesPluginDescriptorFinder.PLUGIN_VERSION to "0.0.1",
         PropertiesPluginDescriptorFinder.PLUGIN_DESCRIPTION to "Test Plugin 1",
         PropertiesPluginDescriptorFinder.PLUGIN_PROVIDER to "Decebal Suiu",
-        PropertiesPluginDescriptorFinder.PLUGIN_DEPENDENCIES to "test-plugin-2,test-plugin-3@~1.0",
+        PropertiesPluginDescriptorFinder.PLUGIN_DEPENDENCIES to "foo.test-plugin-2,foo.test-plugin-3@~1.0",
         PropertiesPluginDescriptorFinder.PLUGIN_REQUIRES to ">=1",
         PropertiesPluginDescriptorFinder.PLUGIN_LICENSE to "Apache-2.0",
-        SpinnakerPropertiesPluginDescriptorFinder.PLUGIN_NAMESPACE to "pf4j",
         SpinnakerPropertiesPluginDescriptorFinder.PLUGIN_UNSAFE to "true"
       ))
     }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilder.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilder.kt
@@ -172,7 +172,7 @@ class TestPluginBuilder(
     import org.pf4j.Extension;
 
     @Extension
-    @SpinnakerExtension(namespace = "spinnaker", id = "${name.toLowerCase()}-test-extension")
+    @SpinnakerExtension(id = "spinnaker.${name.toLowerCase()}-test-extension")
     public class ${name}TestExtension implements TestExtension {
       @Override
       public String getTestValue() {
@@ -192,6 +192,5 @@ class TestPluginBuilder(
     plugin.requires=*
     plugin.license=Apache 2.0
     plugin.unsafe=false
-    plugin.namespace=spinnaker
     """.trimIndent()
 }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/types.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/types.kt
@@ -26,7 +26,7 @@ internal class TestSpringPlugin(wrapper: PluginWrapper) : SpringPlugin(wrapper) 
     applicationContext.register(TestSpringPluginConfiguration::class.java)
   }
 
-  @SpinnakerExtension(namespace = "kork", id = "test")
+  @SpinnakerExtension(id = "kork.test")
   class TestExtension {
     @Autowired
     lateinit var myConfig: MyObject

--- a/kork-plugins/src/test/resources/unsafe-testplugin/plugin.properties
+++ b/kork-plugins/src/test/resources/unsafe-testplugin/plugin.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-plugin.id=spinnaker/unsafetestplugin
+plugin.id=spinnaker.unsafetestplugin
 plugin.description=An unsafe test Plugin
 plugin.class=com.netflix.spinnaker.kork.plugins.testplugin.unsafe.UnsafeTestPlugin
 plugin.version=0.0.1
@@ -22,4 +22,3 @@ plugin.dependencies=
 plugin.requires=*
 plugin.license=Apache 2.0
 plugin.unsafe=true
-plugin.namespace=spinnaker


### PR DESCRIPTION
Having a separate - yet basically required - namespace property for plugins
felt clumsy and was likely asking for bugs. This change removes the separate
namespace attribute from plugin descriptors in favor of requiring plugin IDs
to follow a new canonical ID format: `{namespace}.{pluginId}`.

This also removes the `pluginName` attribute from descriptors, as it appears
that is no longer necessary either from the couple tests that were asserting
its presence and values - `pluginId` has the same value.