### PR TITLE
chore(dependencies): bump Strikt

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -56,7 +56,7 @@ dependencies {
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
-  api(platform("io.strikt:strikt-bom:0.23.1"))
+  api(platform("io.strikt:strikt-bom:0.23.2"))
   api(platform("org.spockframework:spock-bom:1.3-groovy-2.5"))
   api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:1.5.17"))
   api(platform("org.testcontainers:testcontainers-bom:1.12.3"))


### PR DESCRIPTION
Fixes an annoying bug we're hitting in some Keel tests