### PR TITLE
fix(dependencies): Spring Boot 2.2 upgrade issues

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolver.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolver.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.node.MissingNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TreeTraversingParser
 import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.netflix.spinnaker.kork.annotations.Alpha
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import com.netflix.spinnaker.kork.exceptions.SystemException
@@ -54,7 +55,7 @@ class SpringEnvironmentExtensionConfigResolver(
   private val mapper = ObjectMapper()
     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
     .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-    .findAndRegisterModules()
+    .registerModules(KotlinModule())
 
   override fun <T> resolve(coordinates: ConfigCoordinates, expectedType: Class<T>): T {
     val pointer = when (coordinates) {

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -52,7 +52,7 @@ dependencies {
   api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.3.2"))
   api(platform("org.jetbrains.kotlin:kotlin-bom:1.3.61"))
   api(platform("org.junit:junit-bom:5.5.2"))
-  api(platform("com.fasterxml.jackson:jackson-bom:2.9.9.20190807"))
+  api(platform("com.fasterxml.jackson:jackson-bom:2.10.1"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))


### PR DESCRIPTION
* Forgot to update `com.fasterxml.jackson:jackson-bom` to 2.10.1 in the boot-2.2 PR, leaving both 2.9.9 and 2.10.1 in the classpath of many services and causing orca to fail.

* Boot 2.2 brings Liquibase 3.8.2 which JAR contains a misplaced `META-INF/services/com.fasterxml.jackson.databind.Module` file.

  Jackson's `ObjectMapper.findModules()` will scan the classpath for such files in order to dynamically loads all Jackson modules found. The liquibase file contains `com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule` but this class isn't provided by the liquibase JAR nor necessarily elsewhere in the classpath.

  Kork tests weren't impacted because they don't execute with liquibase loaded on the classpath.

  Orca for example is loading both kork-plugins and liquibase, causing `SpringEnvironmentExtensionConfigResolver` to fail initializing because its ObjectMapper can't find the module "published" by the liquibase jar.


  Only specifying the necessary Jackson modules fixes the issue without the code having to be modified again once liquibase's JAR is fixed.
https://liquibase.jira.com/browse/CORE-3522