### PR TITLE
fix(plugins): Change plugin config paths to avoid path conflicts

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(PluginsConfigurationProperties.CONFIG_NAMESPACE)
 public class PluginsConfigurationProperties {
-  public static final String CONFIG_NAMESPACE = "spinnaker.plugins";
+  public static final String CONFIG_NAMESPACE = "spinnaker.extensibility";
   public static final String DEFAULT_ROOT_PATH = "plugins";
 
   /**
@@ -37,21 +37,26 @@ public class PluginsConfigurationProperties {
   // Note that this property is not bound at PluginManager initialization time,
   // but is retained here for documentation purposes. Later consumers of this property
   // will see the correctly bound value that was used when initializing the plugin subsystem.
-  private String rootPath = DEFAULT_ROOT_PATH;
+  private String pluginsRootPath = DEFAULT_ROOT_PATH;
 
   // If for some reason we change the associated property name ensure this constant
   // is updated to match. This is the actual value we will read from the environment
   // at init time.
-  public static final String ROOT_PATH_CONFIG = CONFIG_NAMESPACE + ".root-path";
+  public static final String ROOT_PATH_CONFIG = CONFIG_NAMESPACE + ".plugins-root-path";
 
-  public String getRootPath() {
-    return rootPath;
+  public String getPluginsRootPath() {
+    return pluginsRootPath;
   }
 
-  public void setRootPath(String rootPath) {
-    this.rootPath = rootPath;
+  public void setPluginsRootPath(String pluginsRootPath) {
+    this.pluginsRootPath = pluginsRootPath;
   }
 
+  /**
+   * A definition of repositories for use in plugin downloads.
+   *
+   * <p>The key of this map is the name of the repository.
+   */
   public Map<String, PluginRepositoryProperties> repositories = new HashMap<>();
 
   public static class PluginRepositoryProperties {

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringPluginStatusProvider.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringPluginStatusProvider.kt
@@ -60,6 +60,6 @@ class SpringPluginStatusProvider(
     "$ROOT_CONFIG.$pluginId.enabled"
 
   companion object {
-    const val ROOT_CONFIG: String = "spinnaker.plugins"
+    const val ROOT_CONFIG: String = "spinnaker.extensibility.plugins"
   }
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolver.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolver.kt
@@ -65,14 +65,14 @@ class SpringEnvironmentExtensionConfigResolver(
           "extensions",
           coordinates.extensionId
         ).let {
-          "/spinnaker/plugins/${it.joinToString("/").replace(".", "/")}/config"
+          "/spinnaker/extensibility/plugins/${it.joinToString("/").replace(".", "/")}/config"
         }
       is SystemExtensionConfigCoordinates ->
-        "/spinnaker/extensions/${coordinates.extensionId.replace(".", "/")}/config"
+        "/spinnaker/extensibility/extensions/${coordinates.extensionId.replace(".", "/")}/config"
     }
     log.debug("Searching for config at '$pointer'")
 
-    val tree = mapper.valueToTree<ObjectNode>(environment.propertySourcesAsMap()).at(pointer)
+    val tree = mapper.valueToTree<ObjectNode>(propertySourcesAsMap()).at(pointer)
 
     if (tree is MissingNode) {
       log.debug("Missing configuration for '$coordinates': Loading default")
@@ -96,7 +96,7 @@ class SpringEnvironmentExtensionConfigResolver(
     }
   }
 
-  private fun ConfigurableEnvironment.propertySourcesAsMap(): Map<*, *> {
+  private fun propertySourcesAsMap(): Map<*, *> {
     return environment.propertySources.reversed()
       .filterIsInstance<EnumerablePropertySource<*>>()
       .fold(mutableMapOf<String, Any?>()) { acc, ps ->
@@ -112,7 +112,7 @@ class SpringEnvironmentExtensionConfigResolver(
    */
   private fun EnumerablePropertySource<*>.toRelevantProperties(): Map<String, Any?> =
     propertyNames
-      .filter { it.startsWith("spinnaker.plugins") || it.startsWith("spinnaker.extensions") }
+      .filter { it.startsWith("spinnaker.extensibility") }
       .map { it to getProperty(it) }
       .toMap()
 }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSystemTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSystemTest.kt
@@ -114,8 +114,8 @@ class PluginSystemTest : JUnit5Minutests {
   private inner class GeneratedPluginFixture {
     val app = ApplicationContextRunner()
       .withPropertyValues(
-        "spinnaker.plugins.root-path=${pluginsDir.toAbsolutePath()}",
-        "spinnaker.plugins.${descriptor.pluginId}.enabled=true")
+        "spinnaker.extensibility.plugins-root-path=${pluginsDir.toAbsolutePath()}",
+        "spinnaker.extensibility.plugins.${descriptor.pluginId}.enabled=true")
       .withConfiguration(AutoConfigurations.of(PluginsAutoConfiguration::class.java))
   }
 

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolverTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentExtensionConfigResolverTest.kt
@@ -113,12 +113,12 @@ class SpringEnvironmentExtensionConfigResolverTest : JUnit5Minutests {
   )
 
   private val properties = mapOf<String, Any?>(
-    "spinnaker.plugins.netflix.sweet-plugin.enabled" to "true",
-    "spinnaker.plugins.netflix.sweet-plugin.extensions.netflix.foo.config.somestring" to "overridden default",
-    "spinnaker.plugins.netflix.sweet-plugin.extensions.netflix.foo.config.someint" to 10,
-    "spinnaker.plugins.netflix.sweet-plugin.extensions.netflix.foo.config.somelist[0].hello" to "Future Rob",
-    "spinnaker.plugins.netflix.very-important.extensions.orca.stage.config.optional" to "some new value",
-    "spinnaker.extensions.netflix.bar.config.somelist[0].hello" to "one",
-    "spinnaker.extensions.netflix.bar.config.somelist[1].hello" to "two"
+    "spinnaker.extensibility.plugins.netflix.sweet-plugin.enabled" to "true",
+    "spinnaker.extensibility.plugins.netflix.sweet-plugin.extensions.netflix.foo.config.somestring" to "overridden default",
+    "spinnaker.extensibility.plugins.netflix.sweet-plugin.extensions.netflix.foo.config.someint" to 10,
+    "spinnaker.extensibility.plugins.netflix.sweet-plugin.extensions.netflix.foo.config.somelist[0].hello" to "Future Rob",
+    "spinnaker.extensibility.plugins.netflix.very-important.extensions.orca.stage.config.optional" to "some new value",
+    "spinnaker.extensibility.extensions.netflix.bar.config.somelist[0].hello" to "one",
+    "spinnaker.extensibility.extensions.netflix.bar.config.somelist[1].hello" to "two"
   )
 }


### PR DESCRIPTION
Previously, config looked like this:

```yaml
spinnaker:
  plugins:
    repositories:
      spinnakerRepo:
        url: repo.url
    netflix.helloworld:
      enabled: true
      config: {}
```

Where `pluginId`s under `spinnaker.plugins` were conflicting with `repositories` and `rootPath`. This PR introduces another layer of configuration, putting all extensibility-related config under a single root path of `spinnaker.extensibility`.

```yaml
spinnaker:
  extensibility:
    repositories:
      spinnakerRepo:
        url: repo.url
    plugins:
      netflix.helloworld:
        enabled: true
        config: {}
```

With this, I also renamed `rootPath` to `pluginsRootPath`, as this is more descriptive of its functionality.