### PR TITLE
feat(java): Add errorprone to Java sourcesets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,13 +61,16 @@ allprojects {
 
       dependencies {
         errorprone("com.google.errorprone:error_prone_core:2.3.4")
-        errorprone("com.uber.nullaway:nullaway:0.7.9")
+//        errorprone("com.uber.nullaway:nullaway:0.7.9")
         errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
       }
 
       tasks.withType(JavaCompile).configureEach {
         options.errorprone {
-          option("NullAway:AnnotatedPackages", "com.netflix.spinnaker")
+          // These rules crash errorprone
+          disable("ReferenceEquality") // Crashes errorprone
+          disable("BoxedPrimitiveEquality") // Crashes errorprone
+          disable("UnusedVariable") // Crashes errorprone
         }
       }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ buildscript {
     }
     classpath("com.netflix.nebula:nebula-kotlin-plugin:1.3.50")
     classpath("org.jetbrains.kotlin:kotlin-allopen:1.3.50")
+    classpath("net.ltgt.gradle:gradle-errorprone-plugin:1.1.1")
   }
 }
 
@@ -52,5 +53,23 @@ allprojects {
 
   repositories {
     jcenter()
+  }
+
+  subprojects {
+    if (name != "kork-bom" || name != "spinnaker-dependencies") {
+      apply plugin: "net.ltgt.errorprone"
+
+      dependencies {
+        errorprone("com.google.errorprone:error_prone_core:2.3.4")
+        errorprone("com.uber.nullaway:nullaway:0.7.9")
+        errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
+      }
+
+      tasks.withType(JavaCompile).configureEach {
+        options.errorprone {
+          option("NullAway:AnnotatedPackages", "com.netflix.spinnaker")
+        }
+      }
+    }
   }
 }

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/ExceptionSummary.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/ExceptionSummary.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.With;
 import lombok.experimental.Wither;
 
 /**
@@ -110,7 +111,7 @@ public class ExceptionSummary {
 
   @Getter
   @Builder
-  @Wither
+  @With
   public static class TraceDetail {
     /** The exception message. */
     private String message;


### PR DESCRIPTION
And here's the Java version. I guess since Lombok does a bunch of crazy stuff with internal javac APIs, errorprone can be a little dicey. I've disabled the checks that cause kork to blow up.

Just wanted this out there so people can debate errorprone + Lombok specifically.