### PR TITLE
fix(plugins): Correctly read remote repositories from config

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/PlatformComponents.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/PlatformComponents.java
@@ -23,8 +23,11 @@ import com.netflix.spinnaker.kork.metrics.SpectatorConfiguration;
 import com.netflix.spinnaker.kork.version.ManifestVersionResolver;
 import com.netflix.spinnaker.kork.version.ServiceVersion;
 import com.netflix.spinnaker.kork.version.VersionResolver;
+import io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakersHealthIndicatorAutoConfiguration;
+import io.github.resilience4j.ratelimiter.autoconfigure.RateLimitersHealthIndicatorAutoConfiguration;
 import io.github.resilience4j.retry.RetryRegistry;
 import java.util.List;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -38,6 +41,11 @@ import org.springframework.context.annotation.Import;
   EurekaComponents.class,
   SpectatorConfiguration.class,
 })
+@ImportAutoConfiguration(
+    exclude = {
+      CircuitBreakersHealthIndicatorAutoConfiguration.class,
+      RateLimitersHealthIndicatorAutoConfiguration.class
+    })
 public class PlatformComponents {
   @Bean
   ServiceVersion serviceVersion(

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -17,12 +17,15 @@ package com.netflix.spinnaker.config;
 
 import static java.lang.String.format;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.config.PluginsConfigurationProperties.PluginRepositoryProperties;
 import com.netflix.spinnaker.kork.plugins.ExtensionBeanDefinitionRegistryPostProcessor;
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager;
 import com.netflix.spinnaker.kork.plugins.SpringPluginStatusProvider;
 import com.netflix.spinnaker.kork.plugins.config.ConfigResolver;
-import com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentExtensionConfigResolver;
+import com.netflix.spinnaker.kork.plugins.config.RepositoryConfigCoordinates;
+import com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentConfigResolver;
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationAspect;
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationState;
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.LogInvocationAspect;
@@ -33,7 +36,9 @@ import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.pf4j.PluginStatusProvider;
 import org.pf4j.update.DefaultUpdateRepository;
@@ -66,7 +71,7 @@ public class PluginsAutoConfiguration {
   @ConditionalOnMissingBean(ConfigResolver.class)
   public static ConfigResolver springEnvironmentConfigResolver(
       ConfigurableEnvironment environment) {
-    return new SpringEnvironmentExtensionConfigResolver(environment);
+    return new SpringEnvironmentConfigResolver(environment);
   }
 
   @Bean
@@ -85,23 +90,33 @@ public class PluginsAutoConfiguration {
 
   @Bean
   public static UpdateManager pluginUpdateManager(
-      SpinnakerPluginManager pluginManager, PluginsConfigurationProperties properties) {
-    // TODO(rz): If no repositories, should we setup something to default to?
+      SpinnakerPluginManager pluginManager, ConfigResolver configResolver) {
+    Map<String, PluginRepositoryProperties> repositoriesConfig =
+        configResolver.resolve(
+            new RepositoryConfigCoordinates(),
+            new TypeReference<HashMap<String, PluginRepositoryProperties>>() {});
+
     List<UpdateRepository> repositories =
-        properties.repositories.entrySet().stream()
-            .map(
-                entry -> {
-                  try {
-                    return new DefaultUpdateRepository(
-                        entry.getKey(), new URL(entry.getValue().url));
-                  } catch (MalformedURLException e) {
-                    throw new BeanCreationException(
-                        format("Plugin repository '%s' has malformed URL", entry.getKey()), e);
-                  }
-                })
+        repositoriesConfig.entrySet().stream()
+            .map(entry -> createUpdateRepository(entry.getKey(), entry.getValue().url))
             .collect(Collectors.toList());
 
+    if (repositories.isEmpty()) {
+      log.warn(
+          "No remote repositories defined, will fallback to looking for a "
+              + "'repositories.json' file next to the application executable");
+    }
+
     return new SpinnakerUpdateManager(pluginManager, repositories);
+  }
+
+  private static UpdateRepository createUpdateRepository(String name, String url) {
+    try {
+      return new DefaultUpdateRepository(name, new URL(url));
+    } catch (MalformedURLException e) {
+      throw new BeanCreationException(
+          format("Plugin repository '%s' has malformed URL: '%s'", name, url), e);
+    }
   }
 
   @Bean

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
@@ -44,8 +44,8 @@ class ExtensionBeanDefinitionRegistryPostProcessor(
   override fun postProcessBeanDefinitionRegistry(registry: BeanDefinitionRegistry) {
     val start = System.currentTimeMillis()
     log.debug("Preparing plugins")
-    pluginManager.loadPlugins()
     updateManagerService.checkForUpdates()
+    pluginManager.loadPlugins()
     pluginManager.startPlugins()
 
     log.debug("Finished preparing plugins in {}ms", System.currentTimeMillis() - start)

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateService.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateService.kt
@@ -43,6 +43,8 @@ import org.springframework.context.ApplicationEventPublisher
  *  plugin versions to use. We may not want the most recent release of a plugin.
  * TODO(rz): The front50 integration will need to be smart enough to understand what service is asking for plugins
  *  from the repository, and return only the plugins that are supposed to be installed on that service.
+ * TODO(rz): Consider not loading the plugins and deferring this to the PluginManager so that no errors are raised when
+ *  trying to load the same plugin twice.
  */
 class PluginUpdateService(
   internal val updateManager: UpdateManager,

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
@@ -15,14 +15,84 @@
  */
 package com.netflix.spinnaker.kork.plugins.update
 
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import org.pf4j.PluginManager
+import org.pf4j.PluginRuntimeException
+import org.pf4j.PluginState
 import org.pf4j.update.UpdateManager
 import org.pf4j.update.UpdateRepository
+import org.slf4j.LoggerFactory
 
 /**
  * TODO(rz): Update [hasPluginUpdate] such that it understands the latest plugin is not always the one desired
  */
 class SpinnakerUpdateManager(
-  pluginManager: PluginManager,
+  private val pluginManager: PluginManager,
   repositories: List<UpdateRepository>
-) : UpdateManager(pluginManager, repositories)
+) : UpdateManager(pluginManager, repositories) {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  /**
+   * TODO(rz): PF4J made this private, so it's gotta be duplicated here.
+   */
+  private val systemVersion: String = pluginManager.systemVersion
+
+  /**
+   * TODO(rz): Remove once PF4J releases a new version with REPLACE_EXISTING fix.
+   */
+  @Synchronized
+  override fun installPlugin(id: String?, version: String?): Boolean {
+    // Download to temporary location
+    val downloaded = downloadPlugin(id, version)
+
+    val pluginsRoot = pluginManager.pluginsRoot
+    val file = pluginsRoot.resolve(downloaded.fileName)
+    try {
+      Files.move(downloaded, file, StandardCopyOption.REPLACE_EXISTING)
+    } catch (e: IOException) {
+      throw PluginRuntimeException(e, "Failed to write file '{}' to plugins folder", file)
+    }
+
+    val pluginId = pluginManager.loadPlugin(file)
+    val state = pluginManager.startPlugin(pluginId)
+
+    return PluginState.STARTED == state
+  }
+
+  /**
+   * TODO(rz): Remove once PF4J releases a new version with REPLACE_EXISTING fix.
+   */
+  override fun updatePlugin(id: String?, version: String?): Boolean {
+    if (pluginManager.getPlugin(id) == null) {
+      throw PluginRuntimeException("Plugin {} cannot be updated since it is not installed", id)
+    }
+
+    if (!hasPluginUpdate(id)) {
+      log.warn("Plugin {} does not have an update available which is compatible with system version {}", id, systemVersion)
+      return false
+    }
+
+    // Download to temp folder
+    val downloaded = downloadPlugin(id, version)
+
+    if (!pluginManager.deletePlugin(id)) {
+      return false
+    }
+
+    val pluginsRoot = pluginManager.pluginsRoot
+    val file = pluginsRoot.resolve(downloaded.fileName)
+    try {
+      Files.move(downloaded, file, StandardCopyOption.REPLACE_EXISTING)
+    } catch (e: IOException) {
+      throw PluginRuntimeException("Failed to write plugin file {} to plugin folder", file)
+    }
+
+    val newPluginId = pluginManager.loadPlugin(file)
+    val state = pluginManager.startPlugin(newPluginId)
+
+    return PluginState.STARTED == state
+  }
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt
@@ -15,17 +15,19 @@
  */
 package com.netflix.spinnaker.kork.plugins
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.netflix.spinnaker.kork.plugins.config.ConfigCoordinates
 import com.netflix.spinnaker.kork.plugins.config.ConfigResolver
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import java.lang.reflect.ParameterizedType
+import java.nio.file.Paths
 import org.pf4j.DefaultPluginDescriptor
 import org.pf4j.PluginState
 import org.pf4j.PluginStatusProvider
 import org.pf4j.PluginWrapper
 import strikt.api.expectThat
 import strikt.assertions.isTrue
-import java.nio.file.Paths
 
 class SpinnakerPluginManagerTest : JUnit5Minutests {
 
@@ -63,4 +65,7 @@ class FakePluginStatusProvider : PluginStatusProvider {
 
 class FakeConfigResolver : ConfigResolver {
   override fun <T> resolve(coordinates: ConfigCoordinates, expectedType: Class<T>) = expectedType.newInstance()
+  override fun <T> resolve(coordinates: ConfigCoordinates, expectedType: TypeReference<T>): T =
+    @Suppress("UNCHECKED_CAST")
+    ((expectedType.type as ParameterizedType).rawType as Class<T>).newInstance()
 }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolverTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolverTest.kt
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.kork.plugins.config
 
+import com.fasterxml.jackson.core.type.TypeReference
+import com.netflix.spinnaker.config.PluginsConfigurationProperties.PluginRepositoryProperties
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
@@ -27,9 +29,10 @@ import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 
-class SpringEnvironmentExtensionConfigResolverTest : JUnit5Minutests {
+class SpringEnvironmentConfigResolverTest : JUnit5Minutests {
 
   fun tests() = rootContext<Fixture> {
     fixture {
@@ -37,8 +40,6 @@ class SpringEnvironmentExtensionConfigResolverTest : JUnit5Minutests {
     }
 
     test("plugin extension with shortened config path") {
-      every { environment.getProperty(any(), eq(TestExtensionConfig::class.java)) } returns TestExtensionConfig()
-
       expectThat(subject.resolve(
         PluginConfigCoordinates("netflix.sweet-plugin", "netflix.foo"),
         TestExtensionConfig::class.java
@@ -54,8 +55,6 @@ class SpringEnvironmentExtensionConfigResolverTest : JUnit5Minutests {
     }
 
     test("plugin extension with expanded path") {
-      every { environment.getProperty(any(), eq(TestExtensionConfig::class.java)) } returns TestExtensionConfig()
-
       expectThat(subject.resolve(
         PluginConfigCoordinates("netflix.very-important", "orca.stage"),
         TestExtensionConfig::class.java
@@ -70,8 +69,6 @@ class SpringEnvironmentExtensionConfigResolverTest : JUnit5Minutests {
     }
 
     test("system extension config path") {
-      every { environment.getProperty(any(), eq(TestExtensionConfig::class.java)) } returns TestExtensionConfig()
-
       expectThat(subject.resolve(
         SystemExtensionConfigCoordinates("netflix.bar"),
         TestExtensionConfig::class.java
@@ -88,11 +85,24 @@ class SpringEnvironmentExtensionConfigResolverTest : JUnit5Minutests {
             }
         }
     }
+
+    test("loading repository configs") {
+      expectThat(subject.resolve(
+        RepositoryConfigCoordinates(),
+        object : TypeReference<HashMap<String, PluginRepositoryProperties>>() {}
+      ))
+        .isA<Map<String, PluginRepositoryProperties>>()
+        .and {
+          get { get("foo") }
+            .isNotNull()
+            .get { url }.isEqualTo("http://localhost:9000")
+        }
+    }
   }
 
   private inner class Fixture {
     val environment: ConfigurableEnvironment = mockk(relaxed = true)
-    val subject = SpringEnvironmentExtensionConfigResolver(environment)
+    val subject = SpringEnvironmentConfigResolver(environment)
 
     init {
       every { environment.propertySources } returns MutablePropertySources().apply {
@@ -119,6 +129,7 @@ class SpringEnvironmentExtensionConfigResolverTest : JUnit5Minutests {
     "spinnaker.extensibility.plugins.netflix.sweet-plugin.extensions.netflix.foo.config.somelist[0].hello" to "Future Rob",
     "spinnaker.extensibility.plugins.netflix.very-important.extensions.orca.stage.config.optional" to "some new value",
     "spinnaker.extensibility.extensions.netflix.bar.config.somelist[0].hello" to "one",
-    "spinnaker.extensibility.extensions.netflix.bar.config.somelist[1].hello" to "two"
+    "spinnaker.extensibility.extensions.netflix.bar.config.somelist[1].hello" to "two",
+    "spinnaker.extensibility.repositories.foo.url" to "http://localhost:9000"
   )
 }


### PR DESCRIPTION
I forgot that Spring configs are not available when we're setting up the plugin framework, so remote repository configuration did not work. I've refactored `SpringEnvironmentConfigResolver` a little bit so it's not just for extension configuration, but can be used broadly for loading whatever kind of configs we need as POJOs, instead of resorting to only `Environment.getProperty`, etc.

I made a couple other changes while testing this stuff out, I think some of it related to the Boot 2.2 upgrade:

- Added `@ImportAutoConfiguration` excludes for some resilience4j stuff. It was causing Orca to crash while starting up. I'd like to have resilience4j all autowired, but it's an issue for another day.
- Moved plugin updates / downloads before PluginManager's call to `loadPlugins`. I was finding that if a plugin already exists and it's downloaded again, it'll crash the application. The current solution still causes an `ERROR` log, but doesn't crash anything. The error is just that the plugin is already loaded, but this doesn't break anything. Will fix separately.