### PR TITLE
fix(plugins): create spring context in post Processor

### DIFF
--- a/kork-plugins-spring-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/spring/SpringContextAndRegistry.java
+++ b/kork-plugins-spring-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/spring/SpringContextAndRegistry.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins.api.spring;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigRegistry;
+
+public interface SpringContextAndRegistry
+    extends ConfigurableApplicationContext, AnnotationConfigRegistry {}

--- a/kork-plugins-spring-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/spring/SpringPlugin.java
+++ b/kork-plugins-spring-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/spring/SpringPlugin.java
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.kork.annotations.VisibleForTesting;
 import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
  * Allows a plugin to use its own Spring {@link ApplicationContext}.
@@ -30,7 +29,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 @Alpha
 public abstract class SpringPlugin extends Plugin {
 
-  private AnnotationConfigApplicationContext applicationContext;
+  private SpringContextAndRegistry applicationContext;
 
   /**
    * Constructor to be used by plugin manager for plugin instantiation. Your plugins have to provide
@@ -46,12 +45,12 @@ public abstract class SpringPlugin extends Plugin {
   public abstract void initApplicationContext();
 
   /** @param applicationContext The {@link ApplicationContext} for the plugin. */
-  public void setApplicationContext(AnnotationConfigApplicationContext applicationContext) {
+  public void setApplicationContext(SpringContextAndRegistry applicationContext) {
     this.applicationContext = applicationContext;
   }
 
   @VisibleForTesting
-  public AnnotationConfigApplicationContext getApplicationContext() {
+  public SpringContextAndRegistry getApplicationContext() {
     return this.applicationContext;
   }
 

--- a/kork-plugins-spring-api/src/test/kotlin/com/netflix/spinnaker/kork/plugins/api/spring/SpringPluginTest.kt
+++ b/kork-plugins-spring-api/src/test/kotlin/com/netflix/spinnaker/kork/plugins/api/spring/SpringPluginTest.kt
@@ -19,7 +19,6 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.mockk
 import io.mockk.verify
-import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
 class SpringPluginTest : JUnit5Minutests {
 
@@ -35,7 +34,7 @@ class SpringPluginTest : JUnit5Minutests {
   }
 
   private inner class Fixture {
-    val applicationContext: AnnotationConfigApplicationContext = mockk(relaxed = true)
+    val applicationContext: SpringContextAndRegistry = mockk(relaxed = true)
     val plugin: SpringPlugin = TestSpringPlugin(mockk(relaxed = true)).also {
       it.applicationContext = applicationContext
     }

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -110,9 +111,10 @@ public class PluginsAutoConfiguration {
   public static ExtensionBeanDefinitionRegistryPostProcessor pluginBeanPostProcessor(
       SpinnakerPluginManager pluginManager,
       PluginUpdateService updateManagerService,
-      ApplicationEventPublisher applicationEventPublisher) {
+      ApplicationEventPublisher applicationEventPublisher,
+      ApplicationContext ctx) {
     return new ExtensionBeanDefinitionRegistryPostProcessor(
-        pluginManager, updateManagerService, applicationEventPublisher);
+        pluginManager, updateManagerService, applicationEventPublisher, ctx);
   }
 
   @Bean

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringContextAndRegistryDelegator.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringContextAndRegistryDelegator.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins
+
+import com.netflix.spinnaker.kork.plugins.api.spring.SpringContextAndRegistry
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.AnnotationConfigRegistry
+
+class SpringContextAndRegistryDelegator(
+  private val configurableApplicationContext: ConfigurableApplicationContext,
+  private val annotationConfigRegistry: AnnotationConfigRegistry
+) :
+  SpringContextAndRegistry,
+  ConfigurableApplicationContext by configurableApplicationContext,
+  AnnotationConfigRegistry by annotationConfigRegistry {
+
+  companion object {
+    operator fun <T> invoke(ctx: T): SpringContextAndRegistryDelegator
+      where T : ConfigurableApplicationContext,
+            T : AnnotationConfigRegistry {
+      return SpringContextAndRegistryDelegator(ctx, ctx)
+    }
+  }
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
@@ -27,7 +27,9 @@ import org.pf4j.ExtensionPoint
 import org.pf4j.PluginWrapper
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.support.GenericApplicationContext
+import org.springframework.core.env.StandardEnvironment
 
 class ExtensionBeanDefinitionRegistryPostProcessorTest : JUnit5Minutests {
 
@@ -104,7 +106,10 @@ class ExtensionBeanDefinitionRegistryPostProcessorTest : JUnit5Minutests {
     val applicationEventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
     val pluginDescriptor: SpinnakerPluginDescriptor = mockk(relaxed = true)
 
-    val subject = ExtensionBeanDefinitionRegistryPostProcessor(pluginManager, updateService, applicationEventPublisher)
+    val subject = ExtensionBeanDefinitionRegistryPostProcessor(pluginManager, updateService, applicationEventPublisher,
+      SpringContextAndRegistryDelegator(AnnotationConfigApplicationContext().also {
+        it.environment = StandardEnvironment()
+      }))
 
     init {
       every { extensionFactory.create(eq(FooExtension::class.java)) } returns FooExtension()


### PR DESCRIPTION
This is my initial attempt to get plugin spring components to load into the app in unsafe mode.
I'm testing it with this plugin which exercises a number of spring capabilities:
https://github.com/claymccoy/springExamplePlugin

It doesn't seem to load anything into the main app, but this still seems like a step in the right direction.
* The main app spring context is now used for unsafe Spring plugins.
* SpringContextAndRegistry exists so that I can make a class look like both ConfigurableApplicationContext and AnnotationConfigRegistry. This is because of a limitation in the Spring context class hierarchy. There wasn't a parent type that could handle both for the app context and the newly created plugin context. There may be a better way to do this.
* Creating the spring context was moved into the ExtensionBeanDefinitionRegistryPostProcessor. I think this fixes a bug with reinitializing the spring context on a plugin that has multiple extensions.

I've tested this with other plugin examples that I have made in safe and unsafe mode and everything still seems to work. I put this in as a fix because the bug fix is the immediate value.

I'm also hoping to get some feedback on what else needs to be done to get all the Spring stuff from my plugin fully loaded into the app.