### PR TITLE
chore(dependencies): Upgrade Spring Cloud to Hoxton.SR1

### DIFF
--- a/kork-config/kork-config.gradle
+++ b/kork-config/kork-config.gradle
@@ -11,6 +11,8 @@ dependencies {
 
   api "org.springframework.cloud:spring-cloud-context"
   api "org.springframework.cloud:spring-cloud-config-server"
+  api "org.springframework.cloud:spring-cloud-starter-aws"
+  api "org.springframework.vault:spring-vault-core"
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.assertj:assertj-core"

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/CloudConfigAutoConfiguration.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/CloudConfigAutoConfiguration.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.kork.configserver.autoconfig;
 
 import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
 import com.netflix.spinnaker.kork.configserver.ConfigFileService;
-import java.util.Optional;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.config.server.bootstrap.ConfigServerBootstrapConfiguration;
@@ -37,9 +36,8 @@ import org.springframework.context.annotation.Import;
 @AutoConfigureAfter({ConfigServerAutoConfiguration.class, ConfigServerBootstrapConfiguration.class})
 public class CloudConfigAutoConfiguration {
   @Bean
-  ConfigFileService configFileService(
-      Optional<CloudConfigResourceService> cloudConfigResourceService) {
-    return new ConfigFileService(cloudConfigResourceService.get());
+  ConfigFileService configFileService(CloudConfigResourceService cloudConfigResourceService) {
+    return new ConfigFileService(cloudConfigResourceService);
   }
 
   @Configuration

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/RemoteConfigSourceConfigured.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/RemoteConfigSourceConfigured.java
@@ -25,7 +25,8 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 public class RemoteConfigSourceConfigured implements Condition {
-  private static final String DEFAULT_REMOTE_REPO_TYPES = "default,git,vault,jdbc,credhub";
+  private static final String DEFAULT_REMOTE_REPO_TYPES =
+      "default,git,vault,jdbc,credhub,awsS3,redis";
 
   @Override
   public boolean matches(ConditionContext context, @NotNull AnnotatedTypeMetadata metadata) {

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/SpringCloudAwsConfiguration.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/SpringCloudAwsConfiguration.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver.autoconfig;
+
+import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.REGION_PROVIDER_BEAN_NAME;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
+import org.springframework.cloud.aws.core.env.stack.StackResourceRegistry;
+import org.springframework.cloud.aws.core.env.stack.config.StackResourceRegistryFactoryBean;
+import org.springframework.cloud.aws.core.region.RegionProvider;
+import org.springframework.cloud.aws.core.region.StaticRegionProvider;
+import org.springframework.cloud.config.server.environment.AwsS3EnvironmentProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+
+@Configuration
+@AutoConfigureBefore({
+  ContextRegionProviderAutoConfiguration.class,
+  ContextStackAutoConfiguration.class
+})
+class SpringCloudAwsConfiguration {
+  @Bean(REGION_PROVIDER_BEAN_NAME)
+  @ConditionalOnMissingBean({RegionProvider.class, AwsS3EnvironmentProperties.class})
+  public StaticRegionProvider defaultAwsS3RegionProvider() {
+    // provide a default to prevent Spring Cloud AWS auto-configuration failures
+    return new StaticRegionProvider("us-east-1");
+  }
+
+  @Bean(REGION_PROVIDER_BEAN_NAME)
+  @ConditionalOnMissingBean(RegionProvider.class)
+  @ConditionalOnBean(AwsS3EnvironmentProperties.class)
+  public StaticRegionProvider environmentPropertiesAwsS3RegionProvider(
+      AwsS3EnvironmentProperties s3EnvironmentProperties) {
+    // use the same region as configured for Spring Cloud Config
+    return new StaticRegionProvider(s3EnvironmentProperties.getRegion());
+  }
+
+  /**
+   * Spring Cloud AWS auto-configuration defaults to auto-detecting a stack, which only works when
+   * running on EC2. Disable stack auto-detection by default.
+   *
+   * @param environment the Spring environment
+   * @return {@code null} to allow auto-configuration to do further configuration
+   */
+  @Bean
+  @ConditionalOnMissingBean(StackResourceRegistry.class)
+  public StackResourceRegistryFactoryBean stackResourceRegistryFactoryBean(
+      ConfigurableEnvironment environment) {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("cloud.aws.stack.auto", "false");
+    PropertySource<?> propertySource =
+        new MapPropertySource("springCloudAwsConfiguration", properties);
+    environment.getPropertySources().addLast(propertySource);
+    return null;
+  }
+}

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/SpringCloudAwsS3ResourceLoaderConfiguration.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/SpringCloudAwsS3ResourceLoaderConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver.autoconfig;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.cloud.aws.autoconfigure.context.ContextResourceLoaderAutoConfiguration;
+import org.springframework.cloud.aws.context.support.io.SimpleStorageProtocolResolverConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * The Spring Cloud Config resources API uses a Spring ResourceLoader to provide access to files in
+ * AWS S3 using a "s3://" resource scheme. This configuration ensures that this ResourceLoader
+ * support is properly initialized and available before Spring starts to load configuration
+ * properties.
+ *
+ * <p>See
+ * https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/io/ResourceLoader.html
+ * See
+ * https://cloud.spring.io/spring-cloud-static/spring-cloud-aws/2.1.3.RELEASE/single/spring-cloud-aws.html#_resource_handling
+ */
+@Configuration
+@Profile("awss3")
+@Conditional(RemoteConfigSourceConfigured.class)
+@AutoConfigureAfter(ContextResourceLoaderAutoConfiguration.class)
+class SpringCloudAwsS3ResourceLoaderConfiguration {
+  @Bean
+  public AwsS3ResourceLoaderBeanPostProcessor awsS3ResourceLoaderBeanPostProcessor() {
+    return new AwsS3ResourceLoaderBeanPostProcessor();
+  }
+
+  private static class AwsS3ResourceLoaderBeanPostProcessor implements BeanFactoryPostProcessor {
+    public AwsS3ResourceLoaderBeanPostProcessor() {}
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory)
+        throws BeansException {
+      String[] beanNames =
+          beanFactory.getBeanNamesForType(SimpleStorageProtocolResolverConfigurer.class);
+      for (String beanName : beanNames) {
+        beanFactory.getBean(beanName);
+      }
+    }
+  }
+}

--- a/kork-config/src/main/resources/META-INF/spring.factories
+++ b/kork-config/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,6 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.configserver.autoconfig.CloudConfigAutoConfiguration
+  com.netflix.spinnaker.kork.configserver.autoconfig.CloudConfigAutoConfiguration, \
+  com.netflix.spinnaker.kork.configserver.autoconfig.SpringCloudAwsConfiguration, \
+  com.netflix.spinnaker.kork.configserver.autoconfig.SpringCloudAwsS3ResourceLoaderConfiguration
 org.springframework.context.ApplicationListener=\
   com.netflix.spinnaker.kork.configserver.CloudConfigApplicationListener

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -35,7 +35,7 @@ ext {
     spectator      : "0.75.0",
     spek           : "1.2.1",
     springBoot     : "2.2.4.RELEASE",
-    springCloud    : "Greenwich.SR2",
+    springCloud    : "Hoxton.SR1",
     swagger        : "2.9.2"
   ]
 }
@@ -146,9 +146,11 @@ dependencies {
     api("org.pf4j:pf4j:3.2.0")
     api("org.pf4j:pf4j-update:2.3.0")
     api("org.springframework.boot:spring-boot-configuration-processor:${versions.springBoot}")
+    api("org.springframework.cloud:spring-cloud-starter-aws")
     api("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:2.1.5.RELEASE")
     api("org.springframework.security.extensions:spring-security-saml-dsl-core:1.0.5.RELEASE")
     api("org.springframework.security.extensions:spring-security-saml2-core:1.0.9.RELEASE")
+    api("org.springframework.vault:spring-vault-core:2.2.0.RELEASE")
     api("org.threeten:threeten-extra:1.0")
   }
 }


### PR DESCRIPTION
The Spring Cloud Hoxton.SR1 release train includes a new version of Spring Cloud Config that provides additional capabilities for Spinnaker. 

* Additional Vault authentication options such as AWS EC2, AWS IAM, Google Cloud Compute, Google Cloud IAM, and Kubernetes. This requires a new dependency on Spring Cloud Vault. 

* AWS s3 as an additional Config Server backend option, including the ability to serve credentials files via the [`configserver:` syntax](https://www.spinnaker.io/setup/configuration/#configuration-files). This requires a new dependency on Spring Cloud AWS. 

* Redis as an additional Config Server backend option. 

Corresponding documentation updates in https://github.com/spinnaker/spinnaker.github.io/pull/1653