### PR TITLE
fix(secrets): Do not share yamlparser across threads

### DIFF
--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/engines/AbstractStorageSecretEngine.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/engines/AbstractStorageSecretEngine.java
@@ -35,8 +35,6 @@ public abstract class AbstractStorageSecretEngine implements SecretEngine {
 
   protected Map<String, Map<String, Object>> cache = new HashMap<>();
 
-  protected Yaml yamlParser = new Yaml();
-
   public byte[] decrypt(EncryptedSecret encryptedSecret) {
     String fileUri = encryptedSecret.getParams().get(STORAGE_FILE_URI);
     String key = encryptedSecret.getParams().get(STORAGE_PROP_KEY);
@@ -92,6 +90,12 @@ public abstract class AbstractStorageSecretEngine implements SecretEngine {
     throw new UnsupportedOperationException("This operation is not supported");
   }
 
+  protected Yaml getYamlParser() {
+    // Yaml parser is not thread safe, we need separate instances for each thread
+    // https://bitbucket.org/asomov/snakeyaml/wiki/Documentation#markdown-header-threading
+    return new Yaml();
+  }
+
   protected abstract InputStream downloadRemoteFile(EncryptedSecret encryptedSecret)
       throws IOException;
 
@@ -110,7 +114,7 @@ public abstract class AbstractStorageSecretEngine implements SecretEngine {
   }
 
   protected void parseAsYaml(String fileURI, InputStream inputStream) {
-    Map<String, Object> parsed = yamlParser.load(inputStream);
+    Map<String, Object> parsed = getYamlParser().load(inputStream);
     cache.put(fileURI, parsed);
   }
 

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/engines/AbstractStorageEngineTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/engines/AbstractStorageEngineTest.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
-import org.yaml.snakeyaml.Yaml;
 
 public class AbstractStorageEngineTest {
   AbstractStorageSecretEngine engine;
@@ -53,7 +52,6 @@ public class AbstractStorageEngineTest {
   @Test
   public void canParseYaml() throws SecretDecryptionException {
     ByteArrayInputStream bis = readStream("test: value\na:\n  b: othervalue\nc:\n  - d\n  - e");
-    engine.yamlParser = new Yaml();
     engine.parseAsYaml("a/b", bis);
     assertTrue(Arrays.equals("value".getBytes(), engine.getParsedValue("a/b", "test")));
     assertTrue(Arrays.equals("othervalue".getBytes(), engine.getParsedValue("a/b", "a.b")));


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5287

The issue is caused by a multithreading race condition, in which there are separate threads trying to read the `InputStream` and parse the file into memory. It seems that one thread closed the stream while the other was still reading from it, hence the warning `Not all bytes were read from the S3ObjectInputStream, aborting HTTP connection`. Snake yaml library is clear with regard to `Yaml` instance not being thread safe: https://bitbucket.org/asomov/snakeyaml/wiki/Documentation#markdown-header-threading

This is a log of the error with added lines before and after the call to `yamlParser.load(inputStream)`, note that the log line `Before yamlParser.load` is printed twice from different threads, then the warning is also printed twice from those same threads:

```
2020-01-08 18:58:46.952  INFO 1 --- [           main] c.n.s.k.s.e.AbstractStorageSecretEngine  : Before yamlParser.load
2020-01-08 18:58:46.952  INFO 1 --- [igurationSource] c.n.s.k.s.e.AbstractStorageSecretEngine  : Before yamlParser.load
2020-01-08 18:58:46.952  WARN 1 --- [igurationSource] c.a.s.s.internal.S3AbortableInputStream  : Not all bytes were read from the S3ObjectInputStream, aborting HTTP connection. This is likely an error and
 may result in sub-optimal behavior. Request only the bytes you need via a ranged GET or drain the input stream after use.
2020-01-08 18:58:46.953  WARN 1 --- [           main] c.a.s.s.internal.S3AbortableInputStream  : Not all bytes were read from the S3ObjectInputStream, aborting HTTP connection. This is likely an error and
 may result in sub-optimal behavior. Request only the bytes you need via a ranged GET or drain the input stream after use.
2020-01-08 18:58:46.957 ERROR 1 --- [igurationSource] c.n.config.AbstractPollingScheduler      : Error getting result from polling source

java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.ArrayList.rangeCheck(ArrayList.java:657)
        at java.util.ArrayList.remove(ArrayList.java:496)
        at org.yaml.snakeyaml.scanner.ScannerImpl.getToken(ScannerImpl.java:260)
        at org.yaml.snakeyaml.parser.ParserImpl$ParseStreamStart.produce(ParserImpl.java:184)
        at org.yaml.snakeyaml.parser.ParserImpl.peekEvent(ParserImpl.java:158)
        at org.yaml.snakeyaml.parser.ParserImpl.getEvent(ParserImpl.java:168)
        at org.yaml.snakeyaml.composer.Composer.getSingleNode(Composer.java:104)
        at org.yaml.snakeyaml.constructor.BaseConstructor.getSingleData(BaseConstructor.java:141)
        at org.yaml.snakeyaml.Yaml.loadFromReader(Yaml.java:525)
        at org.yaml.snakeyaml.Yaml.load(Yaml.java:453)
        at com.netflix.spinnaker.kork.secrets.engines.AbstractStorageSecretEngine.parseAsYaml(AbstractStorageSecretEngine.java:117)
        at com.netflix.spinnaker.kork.secrets.engines.AbstractStorageSecretEngine.decrypt(AbstractStorageSecretEngine.java:61)
        at com.netflix.spinnaker.kork.secrets.SecretManager.decryptAsBytes(SecretManager.java:90)
        at com.netflix.spinnaker.kork.secrets.SecretManager.decrypt(SecretManager.java:48)
        at com.netflix.spinnaker.kork.secrets.SecretAwarePropertySource.getProperty(SecretAwarePropertySource.java:44)
        at com.netflix.spinnaker.kork.archaius.SpringEnvironmentPolledConfigurationSource.lambda$poll$0(SpringEnvironmentPolledConfigurationSource.java:46)
        at java.util.concurrent.CopyOnWriteArrayList$COWIterator.forEachRemaining(CopyOnWriteArrayList.java:1206)
        at com.netflix.spinnaker.kork.archaius.SpringEnvironmentPolledConfigurationSource.poll(SpringEnvironmentPolledConfigurationSource.java:41)
        at com.netflix.config.AbstractPollingScheduler$1.run(AbstractPollingScheduler.java:163)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
2020-01-08 18:58:46.964  WARN 1 --- [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans
.factory.UnsatisfiedDependencyException: Error creating bean with name 'artifactCredentialsRepository' defined in URL [jar:file:/opt/clouddriver/lib/clouddriver-artifacts-6.4.4-22f8150-stable544.jar!/com/
netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.class]: Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.Unsati
sfiedDependencyException: Error creating bean with name 'bitbucketArtifactConfiguration' defined in URL [jar:file:/opt/clouddriver/lib/clouddriver-artifacts-6.4.4-22f8150-stable544.jar!/com/netflix/spinna
ker/clouddriver/artifacts/bitbucket/BitbucketArtifactConfiguration.class]: Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.boot.context.properties
.ConfigurationPropertiesBindException: Error creating bean with name 'artifacts.bitbucket-com.netflix.spinnaker.clouddriver.artifacts.bitbucket.BitbucketArtifactProviderProperties': Could not bind propert
ies to 'BitbucketArtifactProviderProperties' : prefix=artifacts.bitbucket, ignoreInvalidFields=false, ignoreUnknownFields=true; nested exception is org.springframework.boot.context.properties.bind.BindExc
eption: Failed to bind properties under 'artifacts.bitbucket.accounts' to java.util.List<com.netflix.spinnaker.clouddriver.artifacts.bitbucket.BitbucketArtifactAccount>
2020-01-08 18:58:46.973  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Stopping service [Tomcat]
2020-01-08 18:58:46.983  WARN 1 --- [           main] o.a.c.loader.WebappClassLoaderBase       : The web application [ROOT] appears to have started a thread named [spectator-gauge-polling-0] but has faile
d to stop it. This is very likely to create a memory leak. Stack trace of thread:
 sun.misc.Unsafe.park(Native Method)
 java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
 java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2078)
 java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1093)
 java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:809)
 java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1074)
 java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1134)
 java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
 java.lang.Thread.run(Thread.java:748)
2020-01-08 18:58:47.002  INFO 1 --- [           main] ConditionEvaluationReportLoggingListener :

Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2020-01-08 18:58:47.006 ERROR 1 --- [           main] o.s.b.d.LoggingFailureAnalysisReporter   :

***************************
APPLICATION FAILED TO START
***************************


Description:

Failed to bind properties under 'artifacts.bitbucket.accounts' to java.util.List<com.netflix.spinnaker.clouddriver.artifacts.bitbucket.BitbucketArtifactAccount>:

    Reason: Socket is closed

Action:

Update your application's configuration

```

After the changes in this PR the log looks like:
```
2020-01-08 19:51:58.764  INFO 1 --- [           main] c.n.s.k.s.e.AbstractStorageSecretEngine  : Before yamlParser.load
2020-01-08 19:51:58.764  INFO 1 --- [igurationSource] c.n.s.k.s.e.AbstractStorageSecretEngine  : Before yamlParser.load
2020-01-08 19:51:58.766  INFO 1 --- [           main] c.n.s.k.s.e.AbstractStorageSecretEngine  : After yamlParser.load
2020-01-08 19:51:58.766  INFO 1 --- [igurationSource] c.n.s.k.s.e.AbstractStorageSecretEngine  : After yamlParser.load
```

After several restarts the original issue no longer appears.