### PR TITLE
fix(artifacts): Revert making constructors private

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -21,12 +21,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Data
 @Builder
 @JsonIgnoreProperties("kind")
@@ -60,6 +57,37 @@ public class Artifact {
 
   @JsonProperty("uuid")
   private String uuid;
+
+  // Deprecated as consumers should be using a builder; in the future this constructor will be
+  // removed from the public API
+  @Deprecated
+  public Artifact(
+      String type,
+      boolean customKind,
+      String name,
+      String version,
+      String location,
+      String reference,
+      Map<String, Object> metadata,
+      String artifactAccount,
+      String provenance,
+      String uuid) {
+    this.type = type;
+    this.customKind = customKind;
+    this.name = name;
+    this.version = version;
+    this.location = location;
+    this.reference = reference;
+    this.metadata = metadata;
+    this.artifactAccount = artifactAccount;
+    this.provenance = provenance;
+    this.uuid = uuid;
+  }
+
+  // Deprecated as consumers should be using a builder; in the future this constructor will be
+  // removed from the public API
+  @Deprecated
+  public Artifact() {}
 
   // Add extra, unknown data to the metadata map:
   @JsonAnySetter

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -17,13 +17,10 @@
 package com.netflix.spinnaker.kork.artifacts.model;
 
 import java.util.regex.Pattern;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Data
 @Builder
 public class ExpectedArtifact {
@@ -33,6 +30,29 @@ public class ExpectedArtifact {
   Artifact defaultArtifact;
   String id; // UUID to use this ExpectedArtifact by reference in Pipelines.
   Artifact boundArtifact;
+
+  // Deprecated as consumers should be using a builder; in the future this constructor will be
+  // removed from the public API
+  @Deprecated
+  public ExpectedArtifact(
+      Artifact matchArtifact,
+      boolean usePriorArtifact,
+      boolean useDefaultArtifact,
+      Artifact defaultArtifact,
+      String id,
+      Artifact boundArtifact) {
+    this.matchArtifact = matchArtifact;
+    this.usePriorArtifact = usePriorArtifact;
+    this.useDefaultArtifact = useDefaultArtifact;
+    this.defaultArtifact = defaultArtifact;
+    this.id = id;
+    this.boundArtifact = boundArtifact;
+  }
+
+  // Deprecated as consumers should be using a builder; in the future this constructor will be
+  // removed from the public API
+  @Deprecated
+  public ExpectedArtifact() {}
 
   /**
    * Decide if the "matchArtifact" matches the incoming artifact. Any fields not specified in the


### PR DESCRIPTION
This reverts commit 66d3391b2c071ea932d972343e6fa32a9452bb91.

When bumping the services, I realized that deserialization with Jackson is using the all-args constructor implicitly.  We need to configure the Artifact and ExpectedArtifact classes to use the builder for deserialization.  I will make this change and re-apply later today, but I don't want to leave things broken all day so reverting for now.