### PR TITLE
refactor(artifacts): Make artifact constructors private

### DIFF
--- a/kork-artifacts/kork-artifacts.gradle
+++ b/kork-artifacts/kork-artifacts.gradle
@@ -8,7 +8,11 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-databind"
   api "com.hubspot.jinjava:jinjava"
 
+  testImplementation "org.assertj:assertj-core"
   testImplementation "org.codehaus.groovy:groovy-all"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-params"
+  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.spockframework:spock-core"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -19,13 +19,19 @@ package com.netflix.spinnaker.kork.artifacts.model;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Data
-@Builder
+@Builder(toBuilder = true)
+@JsonDeserialize(builder = Artifact.ArtifactBuilder.class)
 @JsonIgnoreProperties("kind")
 public class Artifact {
   @JsonProperty("type")
@@ -58,37 +64,6 @@ public class Artifact {
   @JsonProperty("uuid")
   private String uuid;
 
-  // Deprecated as consumers should be using a builder; in the future this constructor will be
-  // removed from the public API
-  @Deprecated
-  public Artifact(
-      String type,
-      boolean customKind,
-      String name,
-      String version,
-      String location,
-      String reference,
-      Map<String, Object> metadata,
-      String artifactAccount,
-      String provenance,
-      String uuid) {
-    this.type = type;
-    this.customKind = customKind;
-    this.name = name;
-    this.version = version;
-    this.location = location;
-    this.reference = reference;
-    this.metadata = metadata;
-    this.artifactAccount = artifactAccount;
-    this.provenance = provenance;
-    this.uuid = uuid;
-  }
-
-  // Deprecated as consumers should be using a builder; in the future this constructor will be
-  // removed from the public API
-  @Deprecated
-  public Artifact() {}
-
   // Add extra, unknown data to the metadata map:
   @JsonAnySetter
   public void putMetadata(String key, Object value) {
@@ -97,4 +72,7 @@ public class Artifact {
     }
     metadata.put(key, value);
   }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class ArtifactBuilder {}
 }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -16,13 +16,19 @@
 
 package com.netflix.spinnaker.kork.artifacts.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Data
-@Builder
+@Builder(toBuilder = true)
+@JsonDeserialize(builder = ExpectedArtifact.ExpectedArtifactBuilder.class)
 public class ExpectedArtifact {
   Artifact matchArtifact;
   boolean usePriorArtifact;
@@ -30,29 +36,6 @@ public class ExpectedArtifact {
   Artifact defaultArtifact;
   String id; // UUID to use this ExpectedArtifact by reference in Pipelines.
   Artifact boundArtifact;
-
-  // Deprecated as consumers should be using a builder; in the future this constructor will be
-  // removed from the public API
-  @Deprecated
-  public ExpectedArtifact(
-      Artifact matchArtifact,
-      boolean usePriorArtifact,
-      boolean useDefaultArtifact,
-      Artifact defaultArtifact,
-      String id,
-      Artifact boundArtifact) {
-    this.matchArtifact = matchArtifact;
-    this.usePriorArtifact = usePriorArtifact;
-    this.useDefaultArtifact = useDefaultArtifact;
-    this.defaultArtifact = defaultArtifact;
-    this.id = id;
-    this.boundArtifact = boundArtifact;
-  }
-
-  // Deprecated as consumers should be using a builder; in the future this constructor will be
-  // removed from the public API
-  @Deprecated
-  public ExpectedArtifact() {}
 
   /**
    * Decide if the "matchArtifact" matches the incoming artifact. Any fields not specified in the
@@ -104,4 +87,7 @@ public class ExpectedArtifact {
   private boolean patternMatches(String us, String other) {
     return Pattern.compile(us).matcher(other).matches();
   }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class ExpectedArtifactBuilder {}
 }

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ArtifactTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ArtifactTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.artifacts.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class ArtifactTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void deserialize() throws IOException {
+    Artifact originalArtifact =
+        Artifact.builder()
+            .type("gcs/object")
+            .customKind(false)
+            .uuid("6b9a5d0b-5706-41da-b379-234c27971482")
+            .name("my-artifact")
+            .version("3")
+            .location("somewhere")
+            .provenance("history")
+            .build();
+
+    String json = objectMapper.writeValueAsString(originalArtifact);
+    Artifact deserializedArtifact = objectMapper.readValue(json, Artifact.class);
+    assertThat(originalArtifact).isEqualTo(deserializedArtifact);
+  }
+}

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.artifacts.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class ExpectedArtifactTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void deserialize() throws IOException {
+    ExpectedArtifact originalArtifact =
+        ExpectedArtifact.builder()
+            .usePriorArtifact(true)
+            .useDefaultArtifact(false)
+            .matchArtifact(Artifact.builder().type("gcs/object").name("my-artifact").build())
+            .build();
+
+    String json = objectMapper.writeValueAsString(originalArtifact);
+    ExpectedArtifact deserializedArtifact = objectMapper.readValue(json, ExpectedArtifact.class);
+    assertThat(originalArtifact).isEqualTo(deserializedArtifact);
+  }
+}


### PR DESCRIPTION
The all-arg and no-arg constructors for Artifact and ExpectedArtifact are marked as deprecated, as consumers should be constructing artifacts by using the lombok-generated builder class.

Remove the no-arg constructors entirely, and make the all-arg constructors private.  The all-arg constructors are used by the inner builder class; had we omitted the explicit AllArgsConstructor annotation, the Builder annotation would have generated a package-private all-args constructor for us. The goal of explicitly adding the annotation is so that we can make the constructor private.

As Jackson was depending on the public constructor for deserialization, add the JsonDeserialize and JsonPOJOBuilder annotations that tell Jackson to use the inner builder class when deserializing these classes, and add tests to ensure the deserialization works. (We define the empty inner builder class only so we can add the annotation; lombok will fill in this empty class.)

[This is re-applying #463 after fixing the deserialization bug.]