### PR TITLE
feat(plugins): plugin reference plugin type for local development

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/PluginRefPluginDescriptorFinder.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/PluginRefPluginDescriptorFinder.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins.finders
+
+import com.netflix.spinnaker.kork.plugins.pluginref.PluginRef
+import org.pf4j.PluginDescriptor
+import org.pf4j.PluginDescriptorFinder
+import java.nio.file.Path
+
+/**
+ * A [PluginDescriptorFinder] that uses a [PluginRef] to determine the root directory to
+ * then delegate to the provided [descriptorFinder].
+ */
+class PluginRefPluginDescriptorFinder(private val descriptorFinder: PluginDescriptorFinder) : PluginDescriptorFinder {
+  override fun isApplicable(pluginPath: Path?): Boolean {
+    if (!PluginRef.isPluginRef(pluginPath)) {
+      return false
+    }
+
+    val ref = PluginRef.loadPluginRef(pluginPath)
+    return descriptorFinder.isApplicable(ref.refPath)
+  }
+
+  override fun find(pluginPath: Path?): PluginDescriptor {
+    val ref = PluginRef.loadPluginRef(pluginPath)
+    return descriptorFinder.find(ref.refPath)
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/loaders/PluginRefPluginLoader.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/loaders/PluginRefPluginLoader.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins.loaders
+
+import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor
+import com.netflix.spinnaker.kork.plugins.pluginref.PluginRef
+import org.pf4j.BasePluginLoader
+import org.pf4j.PluginClassLoader
+import org.pf4j.PluginClasspath
+import org.pf4j.PluginDescriptor
+import org.pf4j.PluginLoader
+import org.pf4j.PluginManager
+import java.nio.file.Path
+
+/**
+ * A [PluginLoader] that can produce a [PluginClassLoader] from a [PluginRef].
+ */
+class PluginRefPluginLoader(val pluginManager: PluginManager) : PluginLoader {
+  override fun loadPlugin(pluginPath: Path?, pluginDescriptor: PluginDescriptor?): ClassLoader {
+    if (pluginDescriptor is SpinnakerPluginDescriptor && pluginDescriptor.unsafe) {
+      return UnsafePluginClassLoader(pluginManager, pluginDescriptor, javaClass.classLoader)
+    }
+
+    val ref = PluginRef.loadPluginRef(pluginPath)
+
+    val cp = PluginClasspath()
+    cp.addClassesDirectories(ref.classesDirs)
+    cp.addJarsDirectories(ref.libsDirs)
+
+    return BasePluginLoader(pluginManager, cp).loadPlugin(ref.refPath, pluginDescriptor)
+  }
+
+  override fun isApplicable(pluginPath: Path?): Boolean = PluginRef.isPluginRef(pluginPath)
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/pluginref/PluginRef.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/pluginref/PluginRef.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins.pluginref
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.netflix.spinnaker.kork.exceptions.UserException
+import org.pf4j.Plugin
+import org.pf4j.PluginDescriptor
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * A [PluginRef] is a type of [Plugin] that exists as a pointer to an actual Plugin for use
+ * during Plugin development.
+ *
+ * This class includes helper methods via its companion object to support this as a JSON
+ * document with a .plugin-ref extension.
+ *
+ * The intention of [PluginRef] is to allow a runtime experience similar to dropping a fully
+ * packaged plugin into the host application, without requiring the packaging and deployment
+ * step (aside from a one time generation and copy/link of the [PluginRef] file).
+ */
+data class PluginRef(
+  /**
+   * The path to the concrete [Plugin] implementation.
+   *
+   * This path will be used to locate a [PluginDescriptor] for the [Plugin].
+   */
+  val pluginPath: String,
+
+  /**
+   * A list of directories containing compiled class-files for the [Plugin].
+   *
+   * These directories should match the build output directories in the [Plugin]'s
+   * development workspace or IDE.
+   */
+  val classesDirs: List<String>,
+
+  /**
+   * A list of directories containing jars scoped to the [Plugin].
+   *
+   * These jars should be referenced from the [Plugin]'s development workspace or IDE.
+   */
+  val libsDirs: List<String>
+) {
+  companion object {
+    const val EXTENSION = ".plugin-ref"
+
+    private val mapper = jacksonObjectMapper()
+
+    fun isPluginRef(path: Path?): Boolean =
+      path != null && Files.isRegularFile(path) && path.toString().toLowerCase().endsWith(EXTENSION)
+
+    fun loadPluginRef(path: Path?): PluginRef {
+      if (!isPluginRef(path)) {
+        throw InvalidPluginRefException(path)
+      }
+
+      try {
+        val ref = mapper.readValue(path!!.toFile(), PluginRef::class.java)
+        return if (ref.refPath.isAbsolute) {
+          ref
+        } else {
+          ref.copy(pluginPath = path.parent.resolve(ref.refPath).toAbsolutePath().toString())
+        }
+      } catch (ex: IOException) {
+        throw MalformedPluginRefException(path!!, ex)
+      }
+    }
+  }
+
+  val refPath: Path
+    @JsonIgnore
+    get() = Paths.get(pluginPath)
+}
+
+class InvalidPluginRefException(path: Path?) :
+  UserException(path?.let { "${it.fileName} is not a plugin-ref file" } ?: "Null path passed as plugin-ref")
+
+class MalformedPluginRefException(path: Path, cause: Throwable) :
+  UserException("${path.fileName} is not a valid plugin-ref", cause)

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/repository/PluginRefPluginRepository.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/repository/PluginRefPluginRepository.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins.repository
+
+import com.netflix.spinnaker.kork.plugins.pluginref.PluginRef
+import org.pf4j.BasePluginRepository
+import org.pf4j.Plugin
+import org.pf4j.PluginRepository
+import org.pf4j.util.ExtensionFileFilter
+import java.nio.file.Path
+
+/**
+ * A [PluginRepository] supporting [PluginRef] type [Plugin]s by matching files with the extension [PluginRef.EXTENSION].
+ */
+class PluginRefPluginRepository(pluginPath: Path) : BasePluginRepository(pluginPath, ExtensionFileFilter(PluginRef.EXTENSION)) {
+  override fun deletePluginPath(pluginPath: Path?): Boolean = false
+}

--- a/kork-plugins/src/test/resources/test.plugin-ref
+++ b/kork-plugins/src/test/resources/test.plugin-ref
@@ -1,0 +1,5 @@
+{
+  "pluginPath": "testplugin",
+  "classesDirs": [],
+  "libsDirs": []
+}

--- a/kork-plugins/src/test/resources/testplugin/plugin.properties
+++ b/kork-plugins/src/test/resources/testplugin/plugin.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-plugin.id=netflix/testplugin
+plugin.id=spinnaker.testplugin
 plugin.description=No You pass the butter
 plugin.class=org.pf4j.Plugin
 plugin.version=0.0.1
@@ -22,4 +22,3 @@ plugin.dependencies=
 plugin.requires=*
 plugin.license=Apache 2.0
 plugin.unsafe=false
-plugin.namespace=netflix


### PR DESCRIPTION
This introduces a new plugin type that is registered if pf4j is
set to development mode to enable a local plugin development
experience.

A plugin-ref is a JSON file with a pointer to the actual location
of a plugin and a list of the classes and libraries to include
when building the PluginClasspath.

This allows a runtime experience similar to dropping a fully
packaged plugin into the host application, without requiring
the packaging and deployment step - aside from a one time
generation and copy/link of the plugin-ref file.

This changeset includes all the plumbing to make plugin-ref
a supported type of plugin, but there is still work to do
in tooling and documentation to make the development
experience reasonable.

With this changeset and the following set of steps, you can
work with the host application and the plugin project open
in IntelliJ, launch the host application, and debug into
the plugin project. To do this you need to:

1. create a plugin-ref file, which is a JSON document:
```
{
  "pluginPath": "/path/to/plugin",
  "classesDirs": [
    "paths",
    "with",
    "code",
    "e.g. PLUGIN_PROJECT/build/classes/java/main"],
  "libsDirs": [
    "paths",
    "with",
    "jars"]
}
```

2. copy or link the plugin-ref file into the host
applications plugins directory

3. configure the host-application with the plugin enabled:
```
spinnaker.extensibility:
  plugins:
    <my plugin id>:
      enabled: true
```

4. run the host application with `pf4j.mode=development`

Given that set of steps you can then open the host
application project in IntelliJ. You can then add the
plugin project as a new project into the same workspace (
on the gradle tab, the `+` button).
Then create a Run Configuration for the host application,
but edit the Before Launch to do a Build Project instead
of just Build.

When you have alllll these steps complete, if you run the
host application you should see it pick up your plugin-ref,
and add your plugin. Additionally you can run in debug
mode and you will be able to set breakpoints in your plugin
and debug through it.