### PR TITLE
feat(plugins): Support for extracting plugin bundles

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -72,15 +73,18 @@ public class PluginsAutoConfiguration {
   @Bean
   public static SpinnakerPluginManager pluginManager(
       PluginStatusProvider pluginStatusProvider,
-      Environment environment,
+      ApplicationContext applicationContext,
       ConfigResolver configResolver) {
     return new SpinnakerPluginManager(
         pluginStatusProvider,
         configResolver,
+        applicationContext.getApplicationName(),
         Paths.get(
-            environment.getProperty(
-                PluginsConfigurationProperties.ROOT_PATH_CONFIG,
-                PluginsConfigurationProperties.DEFAULT_ROOT_PATH)));
+            applicationContext
+                .getEnvironment()
+                .getProperty(
+                    PluginsConfigurationProperties.ROOT_PATH_CONFIG,
+                    PluginsConfigurationProperties.DEFAULT_ROOT_PATH)));
   }
 
   @Bean

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractor.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.bundle
+
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import org.pf4j.util.FileUtils
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
+
+/**
+ * Provides extraction capabilities for plugin bundles.
+ *
+ * Plugin Bundles are a ZIP files containing service-specific plugin ZIP files. When the plugin bundle is downloaded,
+ * we first need to extract the bundle, then locate the service plugin ZIP and extract that. Plugin bundles are based
+ * on naming convention, so we can assume that a service ZIP will always be "{service}.zip".
+ *
+ * Individual service plugins will be as what PF4J would normally expect.
+ */
+class PluginBundleExtractor {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  /**
+   * Extract the bundle. This does not unpack any of the underlying plugin zips.
+   */
+  fun extractBundle(bundlePath: Path): Path {
+    return FileUtils.expandIfZip(bundlePath)
+  }
+
+  /**
+   * Extract a specific service from a bundle.
+   */
+  fun extractService(bundlePath: Path, service: String): Path {
+    val extractedPath = extractBundle(bundlePath)
+    if (!looksLikeBundle(extractedPath)) {
+      log.debug("Plugin path does not appear to be a bundle, using as-is: {}", bundlePath)
+      return extractedPath
+    }
+
+    val servicePluginZipPath = extractedPath.resolve("$service.zip")
+    if (servicePluginZipPath.toFile().exists()) {
+      return FileUtils.expandIfZip(servicePluginZipPath)
+    }
+
+    // If thrown, this is an indicator that either: A) There's a bug in the plugin framework resolving which plugin
+    // bundles should actually be downloaded, or B) The plugin author incorrectly identified this [service] as one
+    // that the plugin extends (via the PluginInfo `requires` list).
+    throw IntegrationException("Downloaded plugin bundle does not have plugin for service '$service'")
+  }
+
+  /**
+   * Inspects the initially extracted [pluginPath] and looks for nested zip files. If nested zip files cannot be
+   * found, it's assumed that the plugin path provided was not a plugin bundle.
+   */
+  private fun looksLikeBundle(pluginPath: Path): Boolean {
+    return pluginPath.toFile().listFiles()?.any { it.name.endsWith(".zip") } ?: false
+  }
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt
@@ -31,12 +31,19 @@ import strikt.assertions.isTrue
 
 class SpinnakerPluginManagerTest : JUnit5Minutests {
 
-  fun tests() = rootContext {
+  fun tests() = rootContext<SpinnakerPluginManager> {
+    fixture {
+      SpinnakerPluginManager(
+        FakePluginStatusProvider(),
+        FakeConfigResolver(),
+        "kork",
+        Paths.get("plugins")
+      )
+    }
 
     test("SpinnakerPluginManager is initialized properly and usable") {
-      val pluginManager = SpinnakerPluginManager(FakePluginStatusProvider(), FakeConfigResolver(), Paths.get("plugins"))
       val testPluginWrapper = PluginWrapper(
-        pluginManager,
+        this,
         DefaultPluginDescriptor(
           "TestPlugin",
           "desc",
@@ -50,9 +57,9 @@ class SpinnakerPluginManagerTest : JUnit5Minutests {
         null
       )
       testPluginWrapper.pluginState = PluginState.DISABLED
-      pluginManager.setPlugins(listOf(testPluginWrapper))
+      setPlugins(listOf(testPluginWrapper))
 
-      expectThat(pluginManager.enablePlugin("TestPlugin")).isTrue()
+      expectThat(enablePlugin("TestPlugin")).isTrue()
     }
   }
 }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractorTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractorTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.bundle
+
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expect
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.isTrue
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.net.URL
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class PluginBundleExtractorTest : JUnit5Minutests {
+
+  fun tests() = rootContext<PluginBundleExtractor> {
+    fixture { PluginBundleExtractor() }
+
+    before {
+      // Creates 3 zips: Two service plugin zips, and then a bundle zip containing the service plugin zips
+      val bundleDir = ZipBuilder.workspace.resolve("bundleSrc").also {
+        try {
+          Files.createDirectory(it)
+        } catch (e: FileAlreadyExistsException) {
+          // Do nothing
+        }
+      }
+
+      ZipBuilder(javaClass.getResource("/bundle/deck").toPath(), "deck.zip", bundleDir).build()
+      ZipBuilder(javaClass.getResource("/bundle/orca").toPath(), "orca.zip", bundleDir).build()
+      ZipBuilder(bundleDir, "bundle.zip", ZipBuilder.workspace).build()
+    }
+
+    after {
+      ZipBuilder.workspace.toFile().listFiles()?.forEach { it.deleteRecursively() }
+    }
+
+    context("bundle extraction") {
+      test("extracts bundles") {
+        extractBundle(ZipBuilder.workspace.resolve("bundle.zip"))
+
+        expect {
+          that(ZipBuilder.workspace.resolve("bundle/deck.zip").toFile()).get { exists() }.isTrue()
+          that(ZipBuilder.workspace.resolve("bundle/orca.zip").toFile()).get { exists() }.isTrue()
+        }
+      }
+
+      test("service is extracted from a bundle") {
+        extractService(ZipBuilder.workspace.resolve("bundle.zip"), "deck")
+
+        expectThat(ZipBuilder.workspace.resolve("bundle/deck/index.js").toFile()).get { exists() }.isTrue()
+      }
+
+      test("service can be extracted from already extracted bundle") {
+        extractService(
+          extractBundle(ZipBuilder.workspace.resolve("bundle.zip")),
+          "deck"
+        )
+
+        expectThat(ZipBuilder.workspace.resolve("bundle/deck/index.js").toFile()).get { exists() }.isTrue()
+      }
+
+      test("throws if bundle is missing expected service plugin") {
+        expectThrows<IntegrationException> {
+          extractService(ZipBuilder.workspace.resolve("bundle.zip"), "clouddriver")
+        }
+      }
+    }
+
+    test("backwards compatible with unbundled plugins") {
+      extractService(ZipBuilder.workspace.resolve("bundleSrc").resolve("deck.zip"), "deck")
+
+      expectThat(ZipBuilder.workspace.resolve("bundleSrc/deck/index.js").toFile()).get { exists() }.isTrue()
+    }
+  }
+
+  private class ZipBuilder(
+    private val sourceRootPath: Path,
+    private val zipFilename: String,
+    private val destination: Path
+  ) {
+
+    private val fileList: MutableList<String> = mutableListOf()
+
+    fun build() {
+      generateFileList(sourceRootPath.toFile())
+
+      try {
+      } catch (e: FileAlreadyExistsException) {
+        // Do nothing
+      }
+
+      FileOutputStream(destination.resolve(zipFilename).toString()).use { fos ->
+        ZipOutputStream(fos).use { zos ->
+          fileList.forEach { file ->
+            val ze = ZipEntry(Paths.get(file).fileName.toString())
+            zos.putNextEntry(ze)
+
+            FileInputStream(sourceRootPath.resolve(file).toString()).use { input ->
+              zos.write(input.readBytes())
+            }
+          }
+
+          zos.closeEntry()
+        }
+      }
+    }
+
+    fun generateFileList(node: File) {
+      if (node.isFile) {
+        fileList.add(generateZipEntry(node.toString()))
+      }
+      if (node.isDirectory) {
+        node.list()?.forEach {
+          generateFileList(File(node, it))
+        }
+      }
+    }
+
+    private fun generateZipEntry(filePath: String): String {
+      return filePath.substring(sourceRootPath.toString().length + 1, filePath.length)
+    }
+
+    companion object {
+      val workspace = Files.createTempDirectory("plugins")
+    }
+  }
+
+  private fun URL.toPath(): Path =
+    File(this.toURI()).toPath()
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateServiceTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateServiceTest.kt
@@ -47,7 +47,13 @@ class PluginUpdateServiceTest : JUnit5Minutests {
     val paths = setupTestPluginInfra()
 
     fixture {
-      val pluginManager = SpinnakerPluginManager(DefaultPluginStatusProvider(paths.plugins), mockk(), paths.plugins)
+      val pluginManager = SpinnakerPluginManager(
+        DefaultPluginStatusProvider(paths.plugins),
+        mockk(),
+        "kork",
+        paths.plugins
+      )
+
       PluginUpdateService(
         SpinnakerUpdateManager(
           pluginManager,

--- a/kork-plugins/src/test/resources/bundle/deck/index.js
+++ b/kork-plugins/src/test/resources/bundle/deck/index.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */


### PR DESCRIPTION
Plugin bundles are an aggregate of one or more PF4J plugin zip artifacts. It provides an experience for plugin developers to produce a single plugin artifact that is applied to one or more services. A bundle would look something like this:

```
my-cool-plugin.zip
  orca.zip
  deck.zip
  ...
```

The `PluginBundleExtractor` provides the ability to extract a downloaded plugin bundle and source the correct internal plugin artifact for use by a service. It is also backwards compatible with a normal PF4J plugin artifact, in case a developer does not need bundle capabilities.