### PR TITLE
fix(plugins): create plugins directory if not present

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
@@ -24,6 +24,7 @@ import org.pf4j.PluginState
 import org.pf4j.update.UpdateManager
 import org.pf4j.update.UpdateRepository
 import org.slf4j.LoggerFactory
+import java.io.File
 
 /**
  * TODO(rz): Update [hasPluginUpdate] such that it understands the latest plugin is not always the one desired
@@ -50,6 +51,7 @@ class SpinnakerUpdateManager(
 
     val pluginsRoot = pluginManager.pluginsRoot
     val file = pluginsRoot.resolve(downloaded.fileName)
+    File(pluginsRoot.toString()).mkdirs()
     try {
       Files.move(downloaded, file, StandardCopyOption.REPLACE_EXISTING)
     } catch (e: IOException) {


### PR DESCRIPTION
SpinnakerUpdateManager attempts to put plugins into a root directory, this causes the service to crash if the directory does not exist. This PR ensures the directory is present 