### PR TITLE
feat(plugins): Added privileged Spring plugin

### DIFF
--- a/kork-plugins-spring-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/spring/PrivilegedSpringPlugin.java
+++ b/kork-plugins-spring-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/spring/PrivilegedSpringPlugin.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.api.spring;
+
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import org.pf4j.Plugin;
+import org.pf4j.PluginWrapper;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Allows a plugin to register BeanDefinitions to be loaded in the application Spring {@link
+ * ApplicationContext}.
+ *
+ * <p>This can be used in plugins that want to wire themselves into the application's Spring
+ * Context.
+ */
+@Alpha
+public abstract class PrivilegedSpringPlugin extends Plugin {
+
+  /**
+   * Constructor to be used by plugin manager for plugin instantiation. Your plugins have to provide
+   * constructor with this exact signature to be successfully loaded by manager.
+   *
+   * @param wrapper
+   */
+  public PrivilegedSpringPlugin(PluginWrapper wrapper) {
+    super(wrapper);
+  }
+
+  public abstract void registerBeanDefinitions(BeanDefinitionRegistry registry);
+
+  protected BeanDefinition beanDefinitionFor(Class beanClass) {
+    return BeanDefinitionBuilder.genericBeanDefinition(beanClass)
+        .setScope(BeanDefinition.SCOPE_SINGLETON)
+        .setAutowireMode(AutowireCapableBeanFactory.AUTOWIRE_CONSTRUCTOR)
+        .getBeanDefinition();
+  }
+
+  protected BeanDefinition primaryBeanDefinitionFor(Class beanClass) {
+    final BeanDefinition beanDefinition = beanDefinitionFor(beanClass);
+    beanDefinition.setPrimary(true);
+    return beanDefinition;
+  }
+
+  protected void registerBean(BeanDefinition beanDefinition, BeanDefinitionRegistry registry)
+      throws ClassNotFoundException {
+    final Class loadedBeanClass =
+        this.getClass().getClassLoader().loadClass(beanDefinition.getBeanClassName());
+    registry.registerBeanDefinition(loadedBeanClass.getName(), beanDefinition);
+  }
+}

--- a/kork-plugins-spring-api/src/test/kotlin/com/netflix/spinnaker/kork/plugins/api/spring/PrivilegedSpringPluginTest.kt
+++ b/kork-plugins-spring-api/src/test/kotlin/com/netflix/spinnaker/kork/plugins/api/spring/PrivilegedSpringPluginTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.api.spring
+
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.mockk
+import io.mockk.verify
+import org.pf4j.PluginWrapper
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.beans.factory.support.BeanDefinitionBuilder
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+
+class PrivilegedSpringPluginTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    test("should register bean definition") {
+      plugin.registerBeanDefinitions(registry)
+      verify(exactly = 1) { registry.registerBeanDefinition(
+        "com.netflix.spinnaker.kork.plugins.api.spring.TestPrivilegedSpringPlugin\$MyService",
+        BeanDefinitionBuilder.genericBeanDefinition(TestPrivilegedSpringPlugin.MyService::class.java)
+          .setScope(BeanDefinition.SCOPE_SINGLETON)
+          .setAutowireMode(AutowireCapableBeanFactory.AUTOWIRE_CONSTRUCTOR)
+          .getBeanDefinition().also {
+            it.isPrimary = true
+          }
+      )}
+    }
+  }
+
+  private inner class Fixture {
+    val registry: BeanDefinitionRegistry = mockk(relaxed = true)
+    val pluginWrapper: PluginWrapper = mockk(relaxed = true)
+    val plugin: PrivilegedSpringPlugin = TestPrivilegedSpringPlugin(pluginWrapper)
+  }
+}

--- a/kork-plugins-spring-api/src/test/kotlin/com/netflix/spinnaker/kork/plugins/api/spring/types.kt
+++ b/kork-plugins-spring-api/src/test/kotlin/com/netflix/spinnaker/kork/plugins/api/spring/types.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.kork.plugins.api.spring
 import org.pf4j.Extension
 import org.pf4j.PluginWrapper
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -39,4 +40,14 @@ internal class TestSpringPlugin(wrapper: PluginWrapper) : SpringPlugin(wrapper) 
   }
 
   internal class MyObject(val something: Int)
+}
+
+
+internal class TestPrivilegedSpringPlugin(wrapper: PluginWrapper) : PrivilegedSpringPlugin(wrapper) {
+
+  override fun registerBeanDefinitions(registry: BeanDefinitionRegistry) {
+    registerBean(primaryBeanDefinitionFor(MyService::class.java), registry)
+  }
+
+  internal class MyService
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.kork.plugins
 
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
 import com.netflix.spinnaker.kork.plugins.events.ExtensionLoaded
 import com.netflix.spinnaker.kork.plugins.proxy.ExtensionInvocationProxy
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationAspect
@@ -26,6 +27,8 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.beans.factory.support.BeanDefinitionRegistry
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor
 import org.springframework.context.ApplicationEventPublisher
+
+import kotlin.jvm.javaClass
 
 /**
  * The primary point of integration between PF4J and Spring, this class is invoked early
@@ -47,6 +50,13 @@ class ExtensionBeanDefinitionRegistryPostProcessor(
     updateManagerService.checkForUpdates()
     pluginManager.loadPlugins()
     pluginManager.startPlugins()
+
+    pluginManager.startedPlugins.forEach { pluginWrapper ->
+      val p = pluginWrapper.plugin
+      if (p is PrivilegedSpringPlugin) {
+        p.registerBeanDefinitions(registry)
+      }
+    }
 
     log.debug("Finished preparing plugins in {}ms", System.currentTimeMillis() - start)
   }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.kork.plugins
 
+import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
 import com.netflix.spinnaker.kork.plugins.events.ExtensionLoaded
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationAspect
 import com.netflix.spinnaker.kork.plugins.update.PluginUpdateService
@@ -41,6 +42,17 @@ class ExtensionBeanDefinitionRegistryPostProcessorTest : JUnit5Minutests {
 
         verify(exactly = 1) { pluginManager.loadPlugins() }
         verify(exactly = 1) { pluginManager.startPlugins() }
+      }
+
+      test("privileged Spring plugins register bean definitions") {
+        val plugin: PrivilegedSpringPlugin = mockk(relaxed = true)
+        val registry = GenericApplicationContext()
+        every { pluginWrapper.plugin } returns plugin
+        every { pluginManager.startedPlugins } returns listOf(pluginWrapper)
+
+        subject.postProcessBeanDefinitionRegistry(registry)
+
+        verify(exactly = 1) { plugin.registerBeanDefinitions(registry) }
       }
     }
 


### PR DESCRIPTION
This allows plugins to wire themselves into the application’s Spring context by explicitly registering BeanDefinitions.
See https://github.com/claymccoy/springExamplePlugin for a working example and list of capabilities.
Note that unsafe mode in your plugin is not required for this.

I tried this the way that was intended by sharing the app's Spring context and it didn't load my plugin beans correctly.
https://github.com/spinnaker/kork/pull/454
I did some research about Spring context initialization and lifecycle and tried a lot of different things. The full application context doesn't seem to be fully ready at this point. So I tried using postProcessBeanFactory to create and register the plugin beans, but that didn't work quite right either. The recommended approach is using postProcessBeanDefinitionRegistry to register bean definitions and this seems to work great, though it forces you to be a bit more explicit. The example plugin linked above has docs and code demonstrating how this works.