### PR TITLE
chore(plugins): Publicly expose downloadPluginRelease on UpdateManager

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.pf4j.PluginStatusProvider;
-import org.pf4j.update.UpdateManager;
 import org.pf4j.update.UpdateRepository;
 import org.pf4j.update.verifier.CompoundVerifier;
 import org.slf4j.Logger;
@@ -100,7 +99,7 @@ public class PluginsAutoConfiguration {
   }
 
   @Bean
-  public static UpdateManager pluginUpdateManager(
+  public static SpinnakerUpdateManager pluginUpdateManager(
       SpinnakerPluginManager pluginManager, List<UpdateRepository> updateRepositories) {
     return new SpinnakerUpdateManager(pluginManager, updateRepositories);
   }
@@ -134,7 +133,7 @@ public class PluginsAutoConfiguration {
 
   @Bean
   public static PluginUpdateService pluginUpdateManagerAgent(
-      UpdateManager updateManager,
+      SpinnakerUpdateManager updateManager,
       SpinnakerPluginManager pluginManager,
       ApplicationEventPublisher applicationEventPublisher) {
     return new PluginUpdateService(updateManager, pluginManager, applicationEventPublisher);

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateService.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateService.kt
@@ -21,9 +21,9 @@ import com.netflix.spinnaker.kork.plugins.events.PluginDownloaded.Operation.INST
 import com.netflix.spinnaker.kork.plugins.events.PluginDownloaded.Operation.UPDATE
 import com.netflix.spinnaker.kork.plugins.events.PluginDownloaded.Status.FAILED
 import com.netflix.spinnaker.kork.plugins.events.PluginDownloaded.Status.SUCCEEDED
-import org.pf4j.update.UpdateManager
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
+import java.nio.file.Path
 
 /**
  * The [PluginUpdateService] is responsible for sourcing plugin updates from a plugin repository on startup.
@@ -47,7 +47,7 @@ import org.springframework.context.ApplicationEventPublisher
  *  trying to load the same plugin twice.
  */
 class PluginUpdateService(
-  internal val updateManager: UpdateManager,
+  internal val updateManager: SpinnakerUpdateManager,
   internal val pluginManager: SpinnakerPluginManager,
   internal val applicationEventPublisher: ApplicationEventPublisher
 ) {
@@ -57,6 +57,10 @@ class PluginUpdateService(
   fun checkForUpdates() {
     updateExistingPlugins()
     installNewPlugins()
+  }
+
+  fun download(pluginId: String, version: String): Path {
+    return updateManager.downloadPluginRelease(pluginId, version)
   }
 
   internal fun updateExistingPlugins() {

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
@@ -25,6 +25,7 @@ import org.pf4j.update.UpdateManager
 import org.pf4j.update.UpdateRepository
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.nio.file.Path
 
 /**
  * TODO(rz): Update [hasPluginUpdate] such that it understands the latest plugin is not always the one desired
@@ -96,5 +97,9 @@ class SpinnakerUpdateManager(
     val state = pluginManager.startPlugin(newPluginId)
 
     return PluginState.STARTED == state
+  }
+
+  fun downloadPluginRelease(pluginId: String, version: String): Path {
+    return downloadPlugin(pluginId, version)
   }
 }


### PR DESCRIPTION
This is in support of deck asset proxy work in Gate.