### PR TITLE
fix(plugins): VersionRequirementsParser should throw InvalidPluginVersionRequirementException when SUPPORTS_PATTERN does not match

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/VersionRequirementsParser.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/VersionRequirementsParser.kt
@@ -16,7 +16,6 @@
 package com.netflix.spinnaker.kork.plugins
 
 import com.netflix.spinnaker.kork.exceptions.UserException
-import java.lang.IllegalStateException
 import java.util.regex.Pattern
 
 /**
@@ -43,10 +42,8 @@ object VersionRequirementsParser {
   fun parse(version: String): VersionRequirements {
     return SUPPORTS_PATTERN.matcher(version)
       .also {
-        try {
-          it.matches()
-        } catch (e: IllegalStateException) {
-          throw InvalidPluginVersionRequirementException(version, e)
+        if (!it.matches()) {
+          throw InvalidPluginVersionRequirementException(version)
         }
       }
       .let {
@@ -91,9 +88,8 @@ object VersionRequirementsParser {
     override fun toString(): String = "$service${operator.symbol}$version"
   }
 
-  class InvalidPluginVersionRequirementException(version: String, cause: Exception) : UserException(
-    "The provided version requirement '$version' is not valid: It must conform to '$SUPPORTS_PATTERN'",
-    cause
+  class InvalidPluginVersionRequirementException(version: String) : UserException(
+    "The provided version requirement '$version' is not valid: It must conform to '$SUPPORTS_PATTERN'"
   )
 
   class IllegalVersionRequirementsOperator(symbol: String, availableOperators: String) : UserException(

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/VersionRequirementsParserTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/VersionRequirementsParserTest.kt
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.kork.plugins.VersionRequirementsParser.VersionRequi
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expectThat
+import strikt.api.expectThrows
 import strikt.assertions.hasSize
 import strikt.assertions.isEqualTo
 
@@ -50,6 +51,12 @@ class VersionRequirementsParserTest : JUnit5Minutests {
         VersionRequirements("orca", VersionRequirementOperator.GT, "3.0.0")
       ))
       expectThat(result).isEqualTo("clouddriver>1.0.0,orca>3.0.0")
+    }
+
+    test("InvalidPluginVersionRequirementException thrown") {
+      expectThrows<VersionRequirementsParser.InvalidPluginVersionRequirementException> {
+        VersionRequirementsParser.parseAll("gate=foo")
+      }
     }
   }
 }


### PR DESCRIPTION
Supports https://github.com/spinnaker/front50/pull/690