### PR TITLE
fix(plugins): FileDownloaderProperties should be optional

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.config;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import lombok.SneakyThrows;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -71,7 +72,7 @@ public class PluginsConfigurationProperties {
     private String url;
 
     /** Configuration for an optional override of {@link org.pf4j.update.FileDownloader}. */
-    public FileDownloaderProperties fileDownloader;
+    @Nullable public FileDownloaderProperties fileDownloader;
 
     /** Custom {@link org.pf4j.update.FileDownloader} configuration. */
     public static class FileDownloaderProperties {

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/FileDownloaderProvider.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/FileDownloaderProvider.kt
@@ -32,8 +32,8 @@ object FileDownloaderProvider {
    * Get a [FileDownloader] for the [UpdateRepository].
    */
   @JvmStatic
-  fun get(fileDownloaderProperties: FileDownloaderProperties): FileDownloader {
-    if (fileDownloaderProperties.className == null) {
+  fun get(fileDownloaderProperties: FileDownloaderProperties?): FileDownloader {
+    if (fileDownloaderProperties?.className == null) {
       return SimpleFileDownloader()
     }
 

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/FileDownloaderProviderTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/FileDownloaderProviderTest.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.kork.plugins.update.downloader
 import com.netflix.spinnaker.config.PluginsConfigurationProperties
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import org.pf4j.update.SimpleFileDownloader
 import strikt.api.expectThat
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
@@ -39,6 +40,11 @@ class FileDownloaderProviderTest : JUnit5Minutests {
           }))
           .isA<ProcessFileDownloader>()
           .get { config.command }.isEqualTo("curl -O")
+      }
+
+      test("defaults to SimpleFileDownloader") {
+        expectThat(get(null))
+          .isA<SimpleFileDownloader>()
       }
     }
   }


### PR DESCRIPTION
Safely call FileDownloaderProperties in FileDownloaderProvider.

Closes: https://github.com/spinnaker/spinnaker/issues/5324