### PR TITLE
refactor(artifacts): Make ExpectedArtifact immutable

### DIFF
--- a/kork-artifacts/kork-artifacts.gradle
+++ b/kork-artifacts/kork-artifacts.gradle
@@ -5,6 +5,7 @@ apply from: "$rootDir/gradle/lombok.gradle"
 dependencies {
   api(platform(project(":spinnaker-dependencies")))
 
+  implementation project(":kork-annotations")
   implementation "com.fasterxml.jackson.core:jackson-databind"
   api "com.hubspot.jinjava:jinjava"
 

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -22,20 +22,20 @@ import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Data
 @Builder(toBuilder = true)
 @JsonDeserialize(builder = ExpectedArtifact.ExpectedArtifactBuilder.class)
-public class ExpectedArtifact {
-  Artifact matchArtifact;
-  boolean usePriorArtifact;
-  boolean useDefaultArtifact;
-  Artifact defaultArtifact;
-  String id; // UUID to use this ExpectedArtifact by reference in Pipelines.
-  Artifact boundArtifact;
+@Value
+public final class ExpectedArtifact {
+  private final Artifact matchArtifact;
+  private final boolean usePriorArtifact;
+  private final boolean useDefaultArtifact;
+  private final Artifact defaultArtifact;
+  private final String id; // UUID to use this ExpectedArtifact by reference in Pipelines.
+  private final Artifact boundArtifact;
 
   /**
    * Decide if the "matchArtifact" matches the incoming artifact. Any fields not specified in the
@@ -89,5 +89,5 @@ public class ExpectedArtifact {
   }
 
   @JsonPOJOBuilder(withPrefix = "")
-  public static class ExpectedArtifactBuilder {}
+  public static final class ExpectedArtifactBuilder {}
 }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -18,7 +18,9 @@ package com.netflix.spinnaker.kork.artifacts.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,14 +30,15 @@ import org.apache.commons.lang3.StringUtils;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(toBuilder = true)
 @JsonDeserialize(builder = ExpectedArtifact.ExpectedArtifactBuilder.class)
+@NonnullByDefault
 @Value
 public final class ExpectedArtifact {
   private final Artifact matchArtifact;
   private final boolean usePriorArtifact;
   private final boolean useDefaultArtifact;
-  private final Artifact defaultArtifact;
+  @Nullable private final Artifact defaultArtifact;
   private final String id; // UUID to use this ExpectedArtifact by reference in Pipelines.
-  private final Artifact boundArtifact;
+  @Nullable private final Artifact boundArtifact;
 
   /**
    * Decide if the "matchArtifact" matches the incoming artifact. Any fields not specified in the
@@ -80,7 +83,7 @@ public final class ExpectedArtifact {
     return true;
   }
 
-  private boolean matches(String us, String other) {
+  private boolean matches(@Nullable String us, @Nullable String other) {
     return StringUtils.isEmpty(us) || (other != null && patternMatches(us, other));
   }
 

--- a/kork-artifacts/src/test/groovy/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactSpec.groovy
+++ b/kork-artifacts/src/test/groovy/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactSpec.groovy
@@ -53,7 +53,7 @@ class ExpectedArtifactSpec extends Specification {
 
   def "test regex matching"() {
     when:
-    def expectedArtifact = ExpectedArtifact.builder().matchArtifact(Artifact.builder().name(expectedName).build()).build()
+    def expectedArtifact = ExpectedArtifact.builder().id("test").matchArtifact(Artifact.builder().name(expectedName).build()).build()
     def incomingArtifact = Artifact.builder().name(incomingName).build()
 
     then:
@@ -75,7 +75,7 @@ class ExpectedArtifactSpec extends Specification {
 
   def "each considered field must match"() {
     when:
-    def expectedArtifact = ExpectedArtifact.builder().matchArtifact(factory(MATCH_STRING)).build()
+    def expectedArtifact = ExpectedArtifact.builder().id("test").matchArtifact(factory(MATCH_STRING)).build()
 
     then:
     expectedArtifact.matches(factory(MATCH_STRING))

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactTest.java
@@ -32,6 +32,7 @@ final class ExpectedArtifactTest {
   public void deserialize() throws IOException {
     ExpectedArtifact originalArtifact =
         ExpectedArtifact.builder()
+            .id("test")
             .usePriorArtifact(true)
             .useDefaultArtifact(false)
             .matchArtifact(Artifact.builder().type("gcs/object").name("my-artifact").build())


### PR DESCRIPTION
* refactor(artifacts): Make ExpectedArtifact immutable 

  There was only ever one place where ExpectedArtifact was being mutated, which was to set the boundArtifact. This place has been updated to return a copy of the artifact instead of mutating it, so none of the setters in this class are used. Remove the setters and mark the fields (as well as the class) final.

  Technically the class is only shallowly immutable, as Artifact itself remains mutable, but this should still make it much easier to reason about expected artifacts and reduce action-at-a-distance bugs.

* refactor(artifacts): Add nullable annotations to ExpectedArtifact 

  defaultArtifact and boundArtifact can be null; the existing code that uses ExpectedArtifacts assumes that both id and matchArtifact are not null (and will NPE if not) so explicitly annotate these as Nonnull.