### PR TITLE
refactor(plugins): Plugin version and service requirement selected via SpinnakerUpdateManager

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/Front50UpdateRepositoryConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/Front50UpdateRepositoryConfiguration.java
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.kork.plugins.update.front50.Front50UpdateRepository
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import java.net.URL;
 import java.util.Map;
-import java.util.Objects;
 import okhttp3.OkHttpClient;
 import org.pf4j.update.UpdateRepository;
 import org.pf4j.update.verifier.CompoundVerifier;
@@ -97,7 +96,6 @@ public class Front50UpdateRepositoryConfiguration {
 
     return new Front50UpdateRepository(
         PluginsConfigurationProperties.FRONT5O_REPOSITORY,
-        Objects.requireNonNull(environment.getProperty("spring.application.name")),
         front50Url,
         FileDownloaderProvider.get(front50RepositoryProps.fileDownloader),
         new CompoundVerifier(),

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -37,6 +37,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.pf4j.PluginStatusProvider;
 import org.pf4j.update.UpdateRepository;
@@ -135,8 +136,13 @@ public class PluginsAutoConfiguration {
   public static PluginUpdateService pluginUpdateManagerAgent(
       SpinnakerUpdateManager updateManager,
       SpinnakerPluginManager pluginManager,
+      Environment environment,
       ApplicationEventPublisher applicationEventPublisher) {
-    return new PluginUpdateService(updateManager, pluginManager, applicationEventPublisher);
+    return new PluginUpdateService(
+        updateManager,
+        pluginManager,
+        Objects.requireNonNull(environment.getProperty("spring.application.name")),
+        applicationEventPublisher);
   }
 
   @Bean

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.kork.plugins.update
 
 import org.pf4j.PluginManager
+import org.pf4j.update.PluginInfo
 import org.pf4j.update.UpdateManager
 import org.pf4j.update.UpdateRepository
 import org.slf4j.LoggerFactory
@@ -49,6 +50,19 @@ class SpinnakerUpdateManager(
    */
   override fun updatePlugin(id: String?, version: String?): Boolean {
     throw UnsupportedOperationException("UpdateManager updatePlugin is not supported")
+  }
+
+  /**
+   * This is the current strategy to select a plugin for release; find the latest release
+   * version and check if that release requires the specified Spinnaker service.
+   *
+   * TODO(jonsie): We will eventually want to filter based on a configured plugin version and the
+   *  required service version (i.e. echo>=1.0.0).
+   */
+  fun getLastPluginRelease(pluginId: String, serviceName: String): PluginInfo.PluginRelease? {
+    val lastRelease = getLastPluginRelease(pluginId)
+    if (lastRelease.requires.contains(serviceName)) return lastRelease
+    return null
   }
 
   /**

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/front50/Front50Service.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/front50/Front50Service.kt
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.kork.plugins.update.SpinnakerPluginInfo
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Path
-import retrofit2.http.Query
 
 /**
  * List and get plugin info objects from Front50. Used in conjunction with [Front50UpdateRepository]
@@ -33,5 +32,5 @@ interface Front50Service {
   fun getById(@Path("id") id: String): Call<SpinnakerPluginInfo>
 
   @GET("/pluginInfo")
-  fun list(@Query("service") service: String): Call<Collection<SpinnakerPluginInfo>>
+  fun listAll(): Call<Collection<SpinnakerPluginInfo>>
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/front50/Front50UpdateRepository.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/front50/Front50UpdateRepository.kt
@@ -30,12 +30,11 @@ import java.net.URL
  * Optional [UpdateRepository].
  *
  * Wired up if the property `spinnaker.extensibility.repositories.front50.enabled` is `true`.
- * Pulls Front50 plugin info objects for the relevant service and populates the available plugin
- * info cache in [org.pf4j.update.UpdateManager].
+ * Pulls Front50 plugin info objects and populates the available plugin info cache in
+ * [org.pf4j.update.UpdateManager].
  */
 class Front50UpdateRepository(
   private val repositoryName: String,
-  private val applicationName: String,
   private val url: URL,
   private val downloader: FileDownloader = SimpleFileDownloader(),
   private val verifier: FileVerifier = CompoundVerifier(),
@@ -57,7 +56,7 @@ class Front50UpdateRepository(
   override fun getPlugins(): MutableMap<String, SpinnakerPluginInfo> {
     return plugins.ifEmpty {
       log.debug("Populating plugin info cache from front50")
-      val response = front50Service.list(applicationName).execute()
+      val response = front50Service.listAll().execute()
 
       if (!response.isSuccessful) {
         throw SystemException("Unable to list front50 plugin info", response.message())

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSystemTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSystemTest.kt
@@ -43,6 +43,9 @@ class PluginSystemTest : JUnit5Minutests {
     derivedContext<ApplicationContextRunner>("initialization tests") {
       fixture {
         ApplicationContextRunner()
+          .withPropertyValues(
+            "spring.application.name=kork"
+          )
           .withConfiguration(AutoConfigurations.of(
             PluginsAutoConfiguration::class.java
           ))
@@ -114,6 +117,7 @@ class PluginSystemTest : JUnit5Minutests {
   private inner class GeneratedPluginFixture {
     val app = ApplicationContextRunner()
       .withPropertyValues(
+        "spring.application.name=kork",
         "spinnaker.extensibility.plugins-root-path=${pluginsDir.toAbsolutePath()}",
         "spinnaker.extensibility.plugins.${descriptor.pluginId}.enabled=true")
       .withConfiguration(AutoConfigurations.of(

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateServiceTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/PluginUpdateServiceTest.kt
@@ -59,6 +59,7 @@ class PluginUpdateServiceTest : JUnit5Minutests {
           listOf(DefaultUpdateRepository("testing", paths.repository.toUri().toURL()))
         ),
         pluginManager,
+        "kork",
         mockk(relaxed = true)
       )
     }
@@ -240,6 +241,7 @@ class PluginUpdateServiceTest : JUnit5Minutests {
       provider = "Spinnaker"
       releases = listOf(
         PluginInfo.PluginRelease().apply {
+          requires = "kork"
           version = pluginBuilder.version
           date = Date.from(Instant.now())
           url = releasePath.toUri().toURL().toString()

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/front50/Front50UpdateRepositoryTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/front50/Front50UpdateRepositoryTest.kt
@@ -40,7 +40,7 @@ class Front50UpdateRepositoryTest : JUnit5Minutests {
     fixture { Fixture() }
 
     test("getPlugins populates the plugins cache, subsequent getPlugin returns cached item") {
-      every { front50Service.list(applicationName).execute() } returns response
+      every { front50Service.listAll().execute() } returns response
 
       val plugins = subject.getPlugins()
 
@@ -58,7 +58,7 @@ class Front50UpdateRepositoryTest : JUnit5Minutests {
     }
 
     test("Response error results in thrown SystemException") {
-      every { front50Service.list(applicationName).execute() } returns Response.error(500, mockk(relaxed = true))
+      every { front50Service.listAll().execute() } returns Response.error(500, mockk(relaxed = true))
       assertThrows<SystemException> { (subject.getPlugins()) }
     }
 
@@ -71,14 +71,12 @@ class Front50UpdateRepositoryTest : JUnit5Minutests {
   private inner class Fixture {
     val front50Service: Front50Service = mockk(relaxed = true)
     val pluginId = "netflix.custom-stage"
-    val applicationName = "orca"
     val repositoryName = "front50"
     val front50Url = URL("https://front50.com")
     val pluginReleaseState = State.CANDIDATE
 
     val subject = Front50UpdateRepository(
       repositoryName,
-      applicationName,
       front50Url,
       SimpleFileDownloader(),
       CompoundVerifier(),


### PR DESCRIPTION
This does a few things for us:
- Update repositories should return all plugin info objects, that includes the front50 repo.  Cache the world.  This keeps the process of determining which plugin to install unified, which leads me to...
- `SpinnakerUpdateManager.getLastPluginRelease` will be used to select the plugin version for installation.  There will be a follow up PR to Gate for this (for use in the `DeckPluginCache`). We will eventually refactor this, but at least it's all in one place.