### PR TITLE
chore(api): make AuthenticatedRequest::getSpinnakerApplication public

### DIFF
--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java
@@ -232,7 +232,7 @@ public class AuthenticatedRequest {
     return Optional.ofNullable(MDC.get(Header.EXECUTION_ID.getHeader()));
   }
 
-  private static Optional<String> getSpinnakerApplication() {
+  public static Optional<String> getSpinnakerApplication() {
     return Optional.ofNullable(MDC.get(Header.APPLICATION.getHeader()));
   }
 


### PR DESCRIPTION
Seems like this was made private by mistake and I intend to use it in gate.