### PR TITLE
feat(context): provide a RequestContext abstraction

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/common/Header.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/common/Header.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.common;
+
+/**
+ * Known X-SPINNAKER headers, but any X-SPINNAKER-* key in the MDC will be automatically propagated
+ * to the HTTP headers.
+ *
+ * <p>Use makeCustomerHeader() to add customer headers
+ */
+public enum Header {
+  USER("X-SPINNAKER-USER", true),
+  ACCOUNTS("X-SPINNAKER-ACCOUNTS", true),
+  USER_ORIGIN("X-SPINNAKER-USER-ORIGIN", false),
+  REQUEST_ID("X-SPINNAKER-REQUEST-ID", false),
+  EXECUTION_ID("X-SPINNAKER-EXECUTION-ID", false),
+  EXECUTION_TYPE("X-SPINNAKER-EXECUTION-TYPE", false),
+  APPLICATION("X-SPINNAKER-APPLICATION", false);
+
+  private String header;
+  private boolean isRequired;
+
+  Header(String header, boolean isRequired) {
+    this.header = header;
+    this.isRequired = isRequired;
+  }
+
+  public String getHeader() {
+    return header;
+  }
+
+  public boolean isRequired() {
+    return isRequired;
+  }
+
+  public static String XSpinnakerPrefix = "X-SPINNAKER-";
+  public static String XSpinnakerAnonymous = XSpinnakerPrefix + "ANONYMOUS";
+
+  public static String makeCustomHeader(String header) {
+    return XSpinnakerPrefix + header.toUpperCase();
+  }
+
+  @Override
+  public String toString() {
+    return "Header{" + "header='" + header + '\'' + '}';
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/dynamicconfig/SpringDynamicConfigService.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/dynamicconfig/SpringDynamicConfigService.java
@@ -87,6 +87,6 @@ public class SpringDynamicConfigService implements DynamicConfigService, Environ
   }
 
   private static String flagPropertyName(String flagName) {
-    return format("%s.enabled", flagName);
+    return flagName.endsWith(".enabled") ? flagName : format("%s.enabled", flagName);
   }
 }

--- a/kork-security/kork-security.gradle
+++ b/kork-security/kork-security.gradle
@@ -5,6 +5,8 @@ apply from: "$rootDir/gradle/lombok.gradle"
 dependencies {
   api(platform(project(":spinnaker-dependencies")))
 
+  api project(":kork-core")
+
   api "org.springframework.security:spring-security-core"
   api "org.codehaus.groovy:groovy-all"
   api "com.hubspot.jinjava:jinjava"

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.security;
 import static java.lang.String.format;
 
 import com.google.common.base.Preconditions;
+import com.netflix.spinnaker.kork.common.Header;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -31,49 +32,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.CollectionUtils;
 
 public class AuthenticatedRequest {
-  /**
-   * Known X-SPINNAKER headers, but any X-SPINNAKER-* key in the MDC will be automatically
-   * propagated to the HTTP headers.
-   *
-   * <p>Use makeCustomerHeader() to add customer headers
-   */
-  public enum Header {
-    USER("X-SPINNAKER-USER", true),
-    ACCOUNTS("X-SPINNAKER-ACCOUNTS", true),
-    USER_ORIGIN("X-SPINNAKER-USER-ORIGIN", false),
-    REQUEST_ID("X-SPINNAKER-REQUEST-ID", false),
-    EXECUTION_ID("X-SPINNAKER-EXECUTION-ID", false),
-    EXECUTION_TYPE("X-SPINNAKER-EXECUTION-TYPE", false),
-    APPLICATION("X-SPINNAKER-APPLICATION", false);
-
-    private String header;
-    private boolean isRequired;
-
-    Header(String header, boolean isRequired) {
-      this.header = header;
-      this.isRequired = isRequired;
-    }
-
-    public String getHeader() {
-      return header;
-    }
-
-    public boolean isRequired() {
-      return isRequired;
-    }
-
-    public static String XSpinnakerPrefix = "X-SPINNAKER-";
-    public static String XSpinnakerAnonymous = XSpinnakerPrefix + "ANONYMOUS";
-
-    public static String makeCustomHeader(String header) {
-      return XSpinnakerPrefix + header.toUpperCase();
-    }
-
-    @Override
-    public String toString() {
-      return "Header{" + "header='" + header + '\'' + '}';
-    }
-  }
 
   /**
    * Allow a given HTTP call to be anonymous. Normally, all requests to Spinnaker services should be
@@ -226,7 +184,11 @@ public class AuthenticatedRequest {
   }
 
   public static Optional<String> get(Header header) {
-    return Optional.ofNullable(MDC.get(header.getHeader()));
+    return get(header.getHeader());
+  }
+
+  public static Optional<String> get(String header) {
+    return Optional.ofNullable(MDC.get(header));
   }
 
   public static void setAccounts(String accounts) {

--- a/kork-security/src/test/groovy/com/netflix/spinnaker/security/AuthenticatedRequestSpec.groovy
+++ b/kork-security/src/test/groovy/com/netflix/spinnaker/security/AuthenticatedRequestSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.security
 
+import com.netflix.spinnaker.kork.common.Header
 import org.slf4j.MDC
 import spock.lang.Specification
 
@@ -23,7 +24,7 @@ class AuthenticatedRequestSpec extends Specification {
   void "should extract user details by priority (Principal > MDC)"() {
     when:
     MDC.clear()
-    MDC.put(AuthenticatedRequest.Header.USER.header, "spinnaker-user")
+    MDC.put(Header.USER.header, "spinnaker-user")
 
     then:
     AuthenticatedRequest.getSpinnakerUser().get() == "spinnaker-user"
@@ -33,7 +34,7 @@ class AuthenticatedRequestSpec extends Specification {
   void "should extract allowed account details by priority (Principal > MDC"() {
     when:
     MDC.clear()
-    MDC.put(AuthenticatedRequest.Header.ACCOUNTS.header, "account1,account2")
+    MDC.put(Header.ACCOUNTS.header, "account1,account2")
 
     then:
     AuthenticatedRequest.getSpinnakerAccounts().get() == "account1,account2"
@@ -51,8 +52,8 @@ class AuthenticatedRequestSpec extends Specification {
 
   void "should propagate user/allowed account details"() {
     when:
-    MDC.put(AuthenticatedRequest.Header.USER.header, "spinnaker-user")
-    MDC.put(AuthenticatedRequest.Header.ACCOUNTS.header, "account1,account2")
+    MDC.put(Header.USER.header, "spinnaker-user")
+    MDC.put(Header.ACCOUNTS.header, "account1,account2")
 
     def closure = AuthenticatedRequest.propagate({
       assert AuthenticatedRequest.getSpinnakerUser().get() == "spinnaker-user"
@@ -60,14 +61,14 @@ class AuthenticatedRequestSpec extends Specification {
       return true
     })
 
-    MDC.put(AuthenticatedRequest.Header.USER.header, "spinnaker-another-user")
-    MDC.put(AuthenticatedRequest.Header.ACCOUNTS.header, "account1,account3")
+    MDC.put(Header.USER.header, "spinnaker-another-user")
+    MDC.put(Header.ACCOUNTS.header, "account1,account3")
     closure.call()
 
     then:
     // ensure MDC context is restored
-    MDC.get(AuthenticatedRequest.Header.USER.header) == "spinnaker-another-user"
-    MDC.get(AuthenticatedRequest.Header.ACCOUNTS.header) == "account1,account3"
+    MDC.get(Header.USER.header) == "spinnaker-another-user"
+    MDC.get(Header.ACCOUNTS.header) == "account1,account3"
 
     when:
     MDC.clear()
@@ -80,8 +81,8 @@ class AuthenticatedRequestSpec extends Specification {
   void "should propagate headers"() {
     when:
     MDC.clear()
-    MDC.put(AuthenticatedRequest.Header.USER.header, "spinnaker-another-user")
-    MDC.put(AuthenticatedRequest.Header.makeCustomHeader("cloudprovider"), "aws")
+    MDC.put(Header.USER.header, "spinnaker-another-user")
+    MDC.put(Header.makeCustomHeader("cloudprovider"), "aws")
 
     then:
     Map allheaders = AuthenticatedRequest.getAuthenticationHeaders()

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/filters/AuthenticatedRequestFilter.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/filters/AuthenticatedRequestFilter.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.filters
 
+import com.netflix.spinnaker.kork.common.Header
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.security.User
 import groovy.util.logging.Slf4j
@@ -30,8 +31,6 @@ import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import java.security.cert.X509Certificate
-
-import static com.netflix.spinnaker.security.AuthenticatedRequest.Header
 
 @Slf4j
 class AuthenticatedRequestFilter implements Filter {

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/AuthenticatedRequestContext.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/AuthenticatedRequestContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.web.context;
+
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.util.Optional;
+
+public class AuthenticatedRequestContext implements RequestContext {
+  @Override
+  public Optional<String> get(String header) {
+    return AuthenticatedRequest.get(header);
+  }
+
+  @Override
+  public void set(String header, String value) {
+    AuthenticatedRequest.set(header, value);
+  }
+
+  @Override
+  public void clear() {
+    AuthenticatedRequest.clear();
+  }
+}

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/AuthenticatedRequestContextProvider.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/AuthenticatedRequestContextProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.web.context;
+
+public class AuthenticatedRequestContextProvider implements RequestContextProvider {
+  private static final AuthenticatedRequestContext context = new AuthenticatedRequestContext();
+
+  @Override
+  public RequestContext get() {
+    return context;
+  }
+}

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/RequestContext.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/RequestContext.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.web.context;
+
+import com.netflix.spinnaker.kork.common.Header;
+import java.util.Optional;
+
+public interface RequestContext {
+  default Optional<String> getAccounts() {
+    return get(Header.ACCOUNTS);
+  }
+
+  default Optional<String> getUser() {
+    return get(Header.USER);
+  }
+
+  default Optional<String> getUserOrigin() {
+    return get(Header.USER_ORIGIN);
+  }
+
+  default Optional<String> getRequestId() {
+    return get(Header.REQUEST_ID);
+  }
+
+  default Optional<String> getExecutionId() {
+    return get(Header.EXECUTION_ID);
+  }
+
+  default Optional<String> getApplication() {
+    return get(Header.APPLICATION);
+  }
+
+  default Optional<String> getExecutionType() {
+    return get(Header.EXECUTION_TYPE);
+  }
+
+  default Optional<String> get(Header header) {
+    return get(header.getHeader());
+  }
+
+  // setters
+  default void setAccounts(String accounts) {
+    set(Header.ACCOUNTS, accounts);
+  }
+
+  default void setUser(String user) {
+    set(Header.USER, user);
+  }
+
+  default void setUserOrigin(String value) {
+    set(Header.USER_ORIGIN, value);
+  }
+
+  default void setRequestId(String value) {
+    set(Header.REQUEST_ID, value);
+  }
+
+  default void setExecutionId(String value) {
+    set(Header.EXECUTION_ID, value);
+  }
+
+  default void setApplication(String value) {
+    set(Header.APPLICATION, value);
+  }
+
+  default void setExecutionType(String value) {
+    set(Header.EXECUTION_TYPE, value);
+  }
+
+  default void set(Header header, String value) {
+    set(header.getHeader(), value);
+  }
+
+  // the only things that need to be overridden
+  Optional<String> get(String header);
+
+  void set(String header, String value);
+
+  void clear();
+}

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/RequestContext.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/RequestContext.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.kork.web.context;
 
 import com.netflix.spinnaker.kork.common.Header;
+import java.util.Collection;
 import java.util.Optional;
 
 public interface RequestContext {
@@ -54,12 +55,16 @@ public interface RequestContext {
   }
 
   // setters
-  default void setAccounts(String accounts) {
-    set(Header.ACCOUNTS, accounts);
+  default void setAccounts(Collection<String> accounts) {
+    setAccounts(String.join(",", accounts));
   }
 
-  default void setUser(String user) {
-    set(Header.USER, user);
+  default void setAccounts(String value) {
+    set(Header.ACCOUNTS, value);
+  }
+
+  default void setUser(String value) {
+    set(Header.USER, value);
   }
 
   default void setUserOrigin(String value) {

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/RequestContextProvider.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/RequestContextProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.web.context;
+
+public interface RequestContextProvider {
+  RequestContext get();
+}

--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/MetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/MetricsInterceptor.java
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.okhttp;
 
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.security.AuthenticatedRequest;
+import com.netflix.spinnaker.kork.common.Header;
 import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
@@ -55,10 +55,10 @@ class MetricsInterceptor {
     URL url = null;
 
     try {
-      String xSpinAnonymous = MDC.get(AuthenticatedRequest.Header.XSpinnakerAnonymous);
+      String xSpinAnonymous = MDC.get(Header.XSpinnakerAnonymous);
 
       if (xSpinAnonymous == null && !skipHeaderCheck) {
-        for (AuthenticatedRequest.Header header : AuthenticatedRequest.Header.values()) {
+        for (Header header : Header.values()) {
           String headerValue =
               (request != null)
                   ? request.header(header.getHeader())


### PR DESCRIPTION
This PR lifts Header out of AuthenticatedRequest and moves it into kork-core so that it can be accessed from both kork-web and kork-security.

In kork-web, we introduce a RequestContext interface with a concrete implementation that pulls values from AuthenticatedRequest. Consumers that need to access values from a RequestContext just need to get an autowired RequestContextProvider.

This should make code that depends on these values to be more easily testable and make it easier to go from one type of context to another (as I am currently doing in gate).