### PR TITLE
fix(plugins): check classes/META-INF/ for MANIFEST.MF before other lo…

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerManifestPluginDescriptorFinder.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/finders/SpinnakerManifestPluginDescriptorFinder.kt
@@ -20,6 +20,8 @@ import com.netflix.spinnaker.kork.plugins.validate
 import org.pf4j.DefaultPluginDescriptor
 import org.pf4j.ManifestPluginDescriptorFinder
 import org.pf4j.PluginDescriptor
+import java.io.File
+import java.nio.file.Path
 import java.util.jar.Manifest
 
 /**
@@ -34,6 +36,14 @@ internal class SpinnakerManifestPluginDescriptorFinder : ManifestPluginDescripto
       }
       it.validate()
     }
+
+  override fun getManifestPath(pluginPath: Path?): Path {
+    var manifest = File(pluginPath.toString() + "/classes/META-INF/MANIFEST.MF")
+    if (manifest.exists()) {
+      return manifest.toPath()
+    }
+    return super.getManifestPath(pluginPath)
+  }
 
   override fun createPluginDescriptorInstance(): DefaultPluginDescriptor = SpinnakerPluginDescriptor()
 


### PR DESCRIPTION
…cations
Different plugin manifest files are found when running locally vs running in a container. This is due to the PF4J function, [FileUtils.findFile](https://github.com/pf4j/pf4j/blob/master/pf4j/src/main/java/org/pf4j/util/FileUtils.java#L243), returning different files. This PR checks to see if there is a manifest file in `/classes/META-INF/` before falling back to default functionality. 