### PR TITLE
fix(plugins): Source application name from spring.application.name prop for SpinnakerPluginManager

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -90,7 +90,8 @@ public class PluginsAutoConfiguration {
     return new SpinnakerPluginManager(
         pluginStatusProvider,
         configResolver,
-        applicationContext.getApplicationName(),
+        Objects.requireNonNull(
+            applicationContext.getEnvironment().getProperty("spring.application.name")),
         Paths.get(
             applicationContext
                 .getEnvironment()


### PR DESCRIPTION
We've made this change elsewhere (front50 update repository) but I need to make it here now too.  Without this the application name is empty, since the `applicationContext. getApplicationName()` does not use the property `spring.application.name` (looks like it tries to source the name from servlet context path).  Anyways, that results is `PluginBundleExtractor` throwing an `IntegrationException`.  This hasn't been an issue until now since I'm actually trying to load a bundled plugin on the backend.