### PR TITLE
fix(plugins): Update repository URL should be sourced via getOrElse call

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/Front50UpdateRepositoryConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/Front50UpdateRepositoryConfiguration.java
@@ -72,7 +72,7 @@ public class Front50UpdateRepositoryConfiguration {
                 () ->
                     Binder.get(environment)
                         .bind("services.front50.base-url", Bindable.of(URL.class))
-                        .orElse(front50RepositoryProps.getUrl()));
+                        .orElseGet(front50RepositoryProps::getUrl));
 
     OkHttpClient okHttpClient =
         new OkHttp3ClientConfiguration(okHttpClientProperties)


### PR DESCRIPTION
This is what I get for trying to be nice and making this config process simple.  The call to `orElse` actually calls `front50RepositoryProps.getUrl` regardless of the BindResult, which results in an exception when that is not set.  This resolves that issue.