### PR TITLE
refactor(plugins): Move plugins-api to api package

### DIFF
--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/ConfigurableExtension.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/ConfigurableExtension.java
@@ -1,19 +1,20 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
-package com.netflix.spinnaker.kork.plugins;
+package com.netflix.spinnaker.kork.plugins.api;
 
 import com.netflix.spinnaker.kork.annotations.Alpha;
 

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/SpinnakerExtension.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/SpinnakerExtension.java
@@ -1,19 +1,20 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
-package com.netflix.spinnaker.kork.plugins;
+package com.netflix.spinnaker.kork.plugins.api;
 
 import com.netflix.spinnaker.kork.annotations.Alpha;
 import java.lang.annotation.Documented;

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactory.kt
@@ -17,6 +17,8 @@ package com.netflix.spinnaker.kork.plugins
 
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import com.netflix.spinnaker.kork.exceptions.SystemException
+import com.netflix.spinnaker.kork.plugins.api.ConfigurableExtension
+import com.netflix.spinnaker.kork.plugins.api.SpinnakerExtension
 import com.netflix.spinnaker.kork.plugins.api.spring.SpringPlugin
 import com.netflix.spinnaker.kork.plugins.config.ConfigCoordinates
 import com.netflix.spinnaker.kork.plugins.config.ConfigResolver

--- a/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/unsafe/UnsafeTestExtension.java
+++ b/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/unsafe/UnsafeTestExtension.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.kork.plugins.testplugin.unsafe;
 
-import com.netflix.spinnaker.kork.plugins.SpinnakerExtension;
+import com.netflix.spinnaker.kork.plugins.api.SpinnakerExtension;
 import com.netflix.spinnaker.kork.plugins.testplugin.api.TestExtension;
 import org.pf4j.Extension;
 

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.kork.plugins
 
+import com.netflix.spinnaker.kork.plugins.api.ConfigurableExtension
+import com.netflix.spinnaker.kork.plugins.api.SpinnakerExtension
 import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
 import com.netflix.spinnaker.kork.plugins.events.ExtensionLoaded
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationAspect

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactoryTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpringExtensionFactoryTest.kt
@@ -16,6 +16,8 @@
 package com.netflix.spinnaker.kork.plugins
 
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import com.netflix.spinnaker.kork.plugins.api.ConfigurableExtension
+import com.netflix.spinnaker.kork.plugins.api.SpinnakerExtension
 import com.netflix.spinnaker.kork.plugins.config.ConfigResolver
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilder.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilder.kt
@@ -167,7 +167,7 @@ class TestPluginBuilder(
     """
     package $packageName;
 
-    import com.netflix.spinnaker.kork.plugins.SpinnakerExtension;
+    import com.netflix.spinnaker.kork.plugins.api.SpinnakerExtension;
     import com.netflix.spinnaker.kork.plugins.testplugin.api.TestExtension;
     import org.pf4j.Extension;
 

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/types.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/types.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.kork.plugins
 
+import com.netflix.spinnaker.kork.plugins.api.SpinnakerExtension
 import com.netflix.spinnaker.kork.plugins.api.spring.SpringPlugin
 import org.pf4j.PluginWrapper
 import org.springframework.beans.factory.annotation.Autowired


### PR DESCRIPTION
I noticed while doing unrelated work that `kork-plugins` and `kork-plugins-api` modules shared the same package. This is quite undesirable, especially as we introduce more APIs for plugins to use and create implementations for said APIs in `kork-plugins`.

This is a pretty bigly breaking change, but it's gotta happen imo and may as well happen sooner than later.