### PR TITLE
chore(config): add config for a default RequestContextProvider

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/RequestContextConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/RequestContextConfiguration.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.config
+
+import com.netflix.spinnaker.kork.web.context.AuthenticatedRequestContextProvider
+import com.netflix.spinnaker.kork.web.context.RequestContextProvider
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RequestContextConfiguration {
+  @Bean
+  @ConditionalOnMissingBean
+  RequestContextProvider requestContextProvider() {
+    return new AuthenticatedRequestContextProvider()
+  }
+}

--- a/kork-web/src/main/java/com/netflix/spinnaker/config/RequestContextConfiguration.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/config/RequestContextConfiguration.java
@@ -12,22 +12,21 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package com.netflix.spinnaker.config
+package com.netflix.spinnaker.config;
 
-import com.netflix.spinnaker.kork.web.context.AuthenticatedRequestContextProvider
-import com.netflix.spinnaker.kork.web.context.RequestContextProvider
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
+import com.netflix.spinnaker.kork.web.context.AuthenticatedRequestContextProvider;
+import com.netflix.spinnaker.kork.web.context.RequestContextProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
-class RequestContextConfiguration {
+public class RequestContextConfiguration {
   @Bean
   @ConditionalOnMissingBean
-  RequestContextProvider requestContextProvider() {
-    return new AuthenticatedRequestContextProvider()
+  public RequestContextProvider requestContextProvider() {
+    return new AuthenticatedRequestContextProvider();
   }
 }


### PR DESCRIPTION
Not sure if kork-web is the right place for this to get picked up automatically as a config by most services, but it depends on things in -core and in -security and I wasn't sure how to untangle these dependencies.