### PR TITLE
feat(plugins): HTTP client plugin API

### DIFF
--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/PluginSdks.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/PluginSdks.java
@@ -15,6 +15,11 @@
  */
 package com.netflix.spinnaker.kork.plugins.api;
 
+import com.netflix.spinnaker.kork.annotations.Beta;
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClient;
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClientRegistry;
+import javax.annotation.Nonnull;
+
 /**
  * A convenience interface for accessing plugin SDK services.
  *
@@ -32,4 +37,10 @@ package com.netflix.spinnaker.kork.plugins.api;
  * }
  * }</pre>
  */
-public interface PluginSdks {}
+public interface PluginSdks {
+
+  /** Get the {@link HttpClientRegistry}, containing all configured {@link HttpClient}s. */
+  @Beta
+  @Nonnull
+  HttpClientRegistry http();
+}

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/HttpClient.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/HttpClient.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.api.httpclient;
+
+import com.netflix.spinnaker.kork.annotations.Beta;
+import javax.annotation.Nonnull;
+
+/**
+ * A simple HTTP client abstraction for use by plugins to talk to other Spinnaker services.
+ *
+ * <p>Many plugins will need to communicate with other Spinnaker services. Supplying plugins with a
+ * Retrofit client or similar, and including all of its dependencies as a global plugin contract,
+ * would be cause for a potential dependency management nightmare. HttpClient is used as an
+ * abstraction layer over what HTTP libraries we use internally to talk between services, allowing
+ * us to change the internals over time easier without affecting the plugin community.
+ *
+ * <p>Since this is an abstraction, plugins will not need to configure their own HTTP clients with
+ * keystores/truststores, etc, as operators will be defining this once for the Spinnaker service
+ * that the plugin is for.
+ *
+ * <p>It is not mandatory for plugins to use this HttpClient for all HTTP/RPC needs. If a plugin
+ * wants to use Spring's WebClient, Retrofit, or something else, they are still able to do so.
+ *
+ * <pre>{@code
+ * // Internal services can be retrieved by name.
+ * HttpClient front50Client = httpClientProvider.getInternalService("front50");
+ *
+ * Response response = front50Client.get(new Request("getApplication", "/v2/applications/gate"));
+ *
+ * Application app = response.getBody(Application.class);
+ * }</pre>
+ *
+ * TODO(rz): Add async api as well?
+ */
+@Beta
+public interface HttpClient {
+  @Nonnull
+  Response get(@Nonnull Request request);
+
+  @Nonnull
+  Response post(@Nonnull Request request);
+
+  @Nonnull
+  Response put(@Nonnull Request request);
+
+  @Nonnull
+  Response delete(@Nonnull Request request);
+
+  @Nonnull
+  Response patch(@Nonnull Request request);
+}

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/HttpClientConfig.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/HttpClientConfig.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.api.httpclient;
+
+import com.netflix.spinnaker.kork.annotations.Beta;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+/** The {@link HttpClient} configuration. */
+@Beta
+public class HttpClientConfig {
+
+  /** Security-related configuration options. */
+  private final SecurityConfig security = new SecurityConfig();
+
+  /** Connection-related configuration options. */
+  private final ConnectionConfig connection = new ConnectionConfig();
+
+  /** Connection pool-related configuration options. */
+  private final ConnectionPoolConfig connectionPool = new ConnectionPoolConfig();
+
+  public SecurityConfig getSecurity() {
+    return security;
+  }
+
+  public ConnectionConfig getConnection() {
+    return connection;
+  }
+
+  public ConnectionPoolConfig getConnectionPool() {
+    return connectionPool;
+  }
+
+  public static class SecurityConfig {
+
+    private static final String DEFAULT_TYPE = "PKCS12";
+
+    /** Filesystem path to an optional KeyStore. */
+    private Path keyStorePath;
+
+    /** Password for the {@code keyStorePath}. */
+    private String keyStorePassword;
+
+    /** The type of KeyStore. Defaults to PKCS12. */
+    private String keyStoreType = DEFAULT_TYPE;
+
+    /** Filesystem path to an optional TrustStore. */
+    private Path trustStorePath;
+
+    /** Password for the {@code trustStorePath}. */
+    private String trustStorePassword;
+
+    /** The type of TrustStore. Defaults to PKCS12. */
+    private String trustStoreType = DEFAULT_TYPE;
+
+    /** List of acceptable TLS versions. */
+    private List<String> tlsVersions;
+
+    /** List of acceptable cipher suites. */
+    private List<String> cipherSuites;
+
+    public Path getKeyStorePath() {
+      return keyStorePath;
+    }
+
+    public SecurityConfig setKeyStorePath(Path keyStorePath) {
+      this.keyStorePath = keyStorePath;
+      return this;
+    }
+
+    public Path getTrustStorePath() {
+      return trustStorePath;
+    }
+
+    public SecurityConfig setTrustStorePath(Path trustStorePath) {
+      this.trustStorePath = trustStorePath;
+      return this;
+    }
+
+    public String getKeyStorePassword() {
+      return keyStorePassword;
+    }
+
+    public SecurityConfig setKeyStorePassword(String keyStorePassword) {
+      this.keyStorePassword = keyStorePassword;
+      return this;
+    }
+
+    public String getTrustStorePassword() {
+      return trustStorePassword;
+    }
+
+    public SecurityConfig setTrustStorePassword(String trustStorePassword) {
+      this.trustStorePassword = trustStorePassword;
+      return this;
+    }
+
+    public String getKeyStoreType() {
+      return keyStoreType;
+    }
+
+    public SecurityConfig setKeyStoreType(String keyStoreType) {
+      this.keyStoreType = keyStoreType;
+      return this;
+    }
+
+    public String getTrustStoreType() {
+      return trustStoreType;
+    }
+
+    public SecurityConfig setTrustStoreType(String trustStoreType) {
+      this.trustStoreType = trustStoreType;
+      return this;
+    }
+
+    public List<String> getTlsVersions() {
+      return tlsVersions;
+    }
+
+    public SecurityConfig setTlsVersions(List<String> tlsVersions) {
+      this.tlsVersions = tlsVersions;
+      return this;
+    }
+
+    public List<String> getCipherSuites() {
+      return cipherSuites;
+    }
+
+    public SecurityConfig setCipherSuites(List<String> cipherSuites) {
+      this.cipherSuites = cipherSuites;
+      return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      SecurityConfig that = (SecurityConfig) o;
+
+      if (!Objects.equals(keyStorePath, that.keyStorePath)) return false;
+      if (!Objects.equals(keyStorePassword, that.keyStorePassword)) return false;
+      if (!Objects.equals(keyStoreType, that.keyStoreType)) return false;
+      if (!Objects.equals(trustStorePath, that.trustStorePath)) return false;
+      if (!Objects.equals(trustStorePassword, that.trustStorePassword)) return false;
+      if (!Objects.equals(trustStoreType, that.trustStoreType)) return false;
+      if (!Objects.equals(tlsVersions, that.tlsVersions)) return false;
+      return Objects.equals(cipherSuites, that.cipherSuites);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = keyStorePath != null ? keyStorePath.hashCode() : 0;
+      result = 31 * result + (keyStorePassword != null ? keyStorePassword.hashCode() : 0);
+      result = 31 * result + (keyStoreType != null ? keyStoreType.hashCode() : 0);
+      result = 31 * result + (trustStorePath != null ? trustStorePath.hashCode() : 0);
+      result = 31 * result + (trustStorePassword != null ? trustStorePassword.hashCode() : 0);
+      result = 31 * result + (trustStoreType != null ? trustStoreType.hashCode() : 0);
+      result = 31 * result + (tlsVersions != null ? tlsVersions.hashCode() : 0);
+      result = 31 * result + (cipherSuites != null ? cipherSuites.hashCode() : 0);
+      return result;
+    }
+  }
+
+  public static class ConnectionConfig {
+
+    /** Network connection timeout. */
+    private Duration connectTimeout;
+
+    /** Response timeout. */
+    private Duration readTimeout;
+
+    /** Whether or not to retry on a network connection failure. Defaults to true. */
+    private boolean retryOnConnectionFailure = true;
+
+    public Duration getConnectTimeout() {
+      return connectTimeout;
+    }
+
+    public ConnectionConfig setConnectTimeout(Duration connectTimeout) {
+      this.connectTimeout = connectTimeout;
+      return this;
+    }
+
+    public Duration getReadTimeout() {
+      return readTimeout;
+    }
+
+    public ConnectionConfig setReadTimeout(Duration readTimeout) {
+      this.readTimeout = readTimeout;
+      return this;
+    }
+
+    public boolean isRetryOnConnectionFailure() {
+      return retryOnConnectionFailure;
+    }
+
+    public ConnectionConfig setRetryOnConnectionFailure(boolean retryOnConnectionFailure) {
+      this.retryOnConnectionFailure = retryOnConnectionFailure;
+      return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      ConnectionConfig that = (ConnectionConfig) o;
+
+      if (retryOnConnectionFailure != that.retryOnConnectionFailure) return false;
+      if (!Objects.equals(connectTimeout, that.connectTimeout)) return false;
+      return Objects.equals(readTimeout, that.readTimeout);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = connectTimeout != null ? connectTimeout.hashCode() : 0;
+      result = 31 * result + (readTimeout != null ? readTimeout.hashCode() : 0);
+      result = 31 * result + (retryOnConnectionFailure ? 1 : 0);
+      return result;
+    }
+  }
+
+  public static class ConnectionPoolConfig {
+    /** Max number of idle connections to keep in memory. */
+    private Integer maxIdleConnections;
+
+    /** The amount of time to keep a connection alive. */
+    private Duration keepAlive;
+
+    public Integer getMaxIdleConnections() {
+      return maxIdleConnections;
+    }
+
+    public void setMaxIdleConnections(Integer maxIdleConnections) {
+      this.maxIdleConnections = maxIdleConnections;
+    }
+
+    public Duration getKeepAlive() {
+      return keepAlive;
+    }
+
+    public void setKeepAlive(Duration keepAlive) {
+      this.keepAlive = keepAlive;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      ConnectionPoolConfig that = (ConnectionPoolConfig) o;
+
+      if (!Objects.equals(maxIdleConnections, that.maxIdleConnections)) return false;
+      return Objects.equals(keepAlive, that.keepAlive);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = maxIdleConnections != null ? maxIdleConnections.hashCode() : 0;
+      result = 31 * result + (keepAlive != null ? keepAlive.hashCode() : 0);
+      return result;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    HttpClientConfig that = (HttpClientConfig) o;
+
+    if (!security.equals(that.security)) return false;
+    if (!connection.equals(that.connection)) return false;
+    return connectionPool.equals(that.connectionPool);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = security.hashCode();
+    result = 31 * result + connection.hashCode();
+    result = 31 * result + connectionPool.hashCode();
+    return result;
+  }
+}

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/HttpClientRegistry.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/HttpClientRegistry.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.api.httpclient;
+
+import com.netflix.spinnaker.kork.annotations.Beta;
+import javax.annotation.Nonnull;
+
+/**
+ * Contains a bucket of configured {@link HttpClient}s for use within an extension.
+ *
+ * <p>There are two categories of HttpClients, one for internal Spinnaker services, and another for
+ * extension-defined http clients.
+ */
+@Beta
+public interface HttpClientRegistry {
+
+  /**
+   * Get an extension-defined {@link HttpClient} by name.
+   *
+   * <p>The client must first be configured before it can be retrieved from the registry.
+   *
+   * @param name The name of the HttpClient
+   * @return The configured HttpClient
+   */
+  @Nonnull
+  HttpClient get(@Nonnull String name);
+
+  /**
+   * Get an internal Spinnaker service {@link HttpClient}.
+   *
+   * @param name The name of the Spinnaker service you want to talk to
+   * @return The internal service client
+   */
+  @Nonnull
+  HttpClient getInternalService(@Nonnull String name);
+
+  /**
+   * Configure a new external {@link HttpClient}.
+   *
+   * <p>An HttpClient must be configured prior to being used.
+   *
+   * @param name A unique name for the client, scoped within an extension
+   * @param baseUrl The base URL of the HTTP client
+   * @param config Additional configuration for the client
+   */
+  void configure(@Nonnull String name, @Nonnull String baseUrl, @Nonnull HttpClientConfig config);
+}

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/Request.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/Request.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.api.httpclient;
+
+import com.netflix.spinnaker.kork.annotations.Beta;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/**
+ * Represents an HTTP request for {@link HttpClient}.
+ *
+ * <p>TODO(rz): Retry config
+ */
+@Beta
+public class Request {
+
+  /** The name of the request, used for tracing purposes. */
+  @Nonnull private String name;
+
+  /** The absolute request URL path. */
+  @Nonnull private String path;
+
+  /** The Content-Type of the request. If undefined, "application/json" will be assumed. */
+  @Nonnull private String contentType = "application/json";
+
+  /**
+   * Any custom headers that should be included in the request.
+   *
+   * <p>Spinnaker may populate additional headers.
+   */
+  @Nonnull private Map<String, String> headers = new HashMap<>();
+
+  /** Any query parameters to attach to the request URL. */
+  @Nonnull private Map<String, String> queryParams = new HashMap<>();
+
+  /** The request body, if any. */
+  private Object body;
+
+  public Request(@Nonnull String name, @Nonnull String path) {
+    this.name = name;
+    this.path = path;
+  }
+
+  @Nonnull
+  public String getName() {
+    return name;
+  }
+
+  @Nonnull
+  public String getPath() {
+    return path;
+  }
+
+  @Nonnull
+  public String getContentType() {
+    return contentType;
+  }
+
+  public Request setContentType(@Nonnull String contentType) {
+    this.contentType = contentType;
+    return this;
+  }
+
+  @Nonnull
+  public Map<String, String> getHeaders() {
+    return headers;
+  }
+
+  public Request setHeaders(@Nonnull Map<String, String> headers) {
+    this.headers = headers;
+    return this;
+  }
+
+  @Nonnull
+  public Map<String, String> getQueryParams() {
+    return queryParams;
+  }
+
+  public Request setQueryParams(@Nonnull Map<String, String> queryParams) {
+    this.queryParams = queryParams;
+    return this;
+  }
+
+  public Object getBody() {
+    return body;
+  }
+
+  public Request setBody(Object body) {
+    this.body = body;
+    return this;
+  }
+}

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/Response.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/Response.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.api.httpclient;
+
+import com.netflix.spinnaker.kork.annotations.Beta;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+/** HTTP Response wrapper. */
+@Beta
+public interface Response {
+
+  /** Get the response body. */
+  InputStream getBody();
+
+  /** Get the response body, casting it into the expected type. */
+  <T> T getBody(@Nonnull Class<T> expectedType);
+
+  /** Get the error exception, if present. */
+  @Nonnull
+  Optional<Exception> getException();
+
+  /** Get the response code. */
+  int getStatusCode();
+
+  /** Get the response headers. */
+  @Nonnull
+  Map<String, String> getHeaders();
+
+  /**
+   * Returns whether or not the request had an error (4xx/5xx response code or underlying
+   * IOException)
+   */
+  default boolean isError() {
+    return getException().isPresent();
+  }
+}

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/HttpClientSdkConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/HttpClientSdkConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory;
+import com.netflix.spinnaker.kork.plugins.sdk.httpclient.HttpClientSdkFactory;
+import com.netflix.spinnaker.kork.plugins.sdk.httpclient.internal.CompositeOkHttpClientFactory;
+import com.netflix.spinnaker.kork.plugins.sdk.httpclient.internal.DefaultOkHttp3ClientFactory;
+import com.netflix.spinnaker.kork.plugins.sdk.httpclient.internal.OkHttp3ClientFactory;
+import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor;
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
+
+@Configuration
+@EnableConfigurationProperties(OkHttpClientConfigurationProperties.class)
+@Import(OkHttpClientComponents.class)
+public class HttpClientSdkConfiguration {
+
+  @Bean
+  public static SdkFactory httpClientSdkFactory(
+      List<OkHttp3ClientFactory> okHttpClientFactories,
+      Environment environment,
+      OkHttpClientConfigurationProperties okHttpClientConfigurationProperties,
+      OkHttp3MetricsInterceptor okHttp3MetricsInterceptor) {
+
+    List<OkHttp3ClientFactory> factories = new ArrayList<>(okHttpClientFactories);
+    factories.add(new DefaultOkHttp3ClientFactory(okHttp3MetricsInterceptor));
+
+    OkHttp3ClientConfiguration config =
+        new OkHttp3ClientConfiguration(
+            okHttpClientConfigurationProperties, okHttp3MetricsInterceptor);
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    return new HttpClientSdkFactory(
+        new CompositeOkHttpClientFactory(okHttpClientFactories), environment, objectMapper, config);
+  }
+}

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -65,7 +65,7 @@ import org.springframework.core.env.Environment;
 
 @Configuration
 @EnableConfigurationProperties(PluginsConfigurationProperties.class)
-@Import({Front50PluginsConfiguration.class})
+@Import({Front50PluginsConfiguration.class, HttpClientSdkConfiguration.class})
 public class PluginsAutoConfiguration {
 
   private static final Logger log = LoggerFactory.getLogger(PluginsAutoConfiguration.class);

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/IdResolver.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/IdResolver.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk
+
+import org.pf4j.PluginWrapper
+
+/**
+ * Resolves an "ID" for an extension, preferring the plugin ID, if it belongs to one.
+ */
+internal object IdResolver {
+
+  fun pluginOrExtensionId(extensionClass: Class<*>, pluginWrapper: PluginWrapper?): String {
+    if (pluginWrapper != null) {
+      return pluginWrapper.pluginId
+    }
+
+    // TODO(rz): Extensions need an ID that isn't coupled to the class name. Ideally we'd move back to using
+    //  a SpinnakerExtension annotation or upstream an ID property on PF4J's Extension annotation.
+    return extensionClass.simpleName
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/PluginSdksImpl.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/PluginSdksImpl.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.kork.plugins.sdk
 
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import com.netflix.spinnaker.kork.plugins.api.PluginSdks
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClientRegistry
 
 /**
  * The implementation of the [PluginSdks] SDK.
@@ -25,12 +26,11 @@ class PluginSdksImpl(
   private val sdkServices: List<Any>
 ) : PluginSdks {
 
-//  fun httpClientProvider(): HttpClientProvider =
-//    service(HttpClientProvider::class.java)
+  override fun http(): HttpClientRegistry =
+    service(HttpClientRegistry::class.java)
 
   private fun <T> service(serviceClass: Class<T>): T =
     sdkServices.filterIsInstance(serviceClass).firstOrNull()
-      // This should never happen: If it does, it means that the [serviceClass] did not get initialized by
-      // [PluginServiceProvider].
+      // This should never happen: If it does, it means that the [serviceClass] did not get initialized.
       ?: throw SystemException("$serviceClass is not configured")
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/HttpClientSdkFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/HttpClientSdkFactory.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk.httpclient
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
+import com.netflix.spinnaker.kork.plugins.sdk.IdResolver
+import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory
+import com.netflix.spinnaker.kork.plugins.sdk.httpclient.internal.CompositeOkHttpClientFactory
+import org.pf4j.PluginWrapper
+import org.springframework.core.env.Environment
+
+/**
+ * Creates [Ok3HttpClientRegistry]s for a given extension.
+ */
+class HttpClientSdkFactory(
+  private val okHttpClientFactory: CompositeOkHttpClientFactory,
+  private val environment: Environment,
+  private val objectMapper: ObjectMapper,
+  private val okHttp3ClientConfiguration: OkHttp3ClientConfiguration
+) : SdkFactory {
+  override fun create(extensionClass: Class<*>, pluginWrapper: PluginWrapper?): Any {
+    return Ok3HttpClientRegistry(
+      IdResolver.pluginOrExtensionId(extensionClass, pluginWrapper),
+      environment,
+      objectMapper,
+      okHttpClientFactory,
+      okHttp3ClientConfiguration
+    )
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClient.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClient.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk.httpclient
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClient
+import com.netflix.spinnaker.kork.plugins.api.httpclient.Request
+import com.netflix.spinnaker.kork.plugins.api.httpclient.Response
+import okhttp3.Headers
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.net.URL
+
+/**
+ * An OkHttp3 [HttpClient] implementation.
+ */
+class Ok3HttpClient(
+  internal val name: String,
+  internal val baseUrl: String,
+  private val client: OkHttpClient,
+  private val objectMapper: ObjectMapper
+) : HttpClient {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  override fun get(request: Request): Response {
+    return doRequest(request) {
+      it.get()
+    }
+  }
+
+  override fun post(request: Request): Response {
+    return doRequest(request) {
+      it.post(request.okHttpRequestBody())
+    }
+  }
+
+  override fun put(request: Request): Response {
+    return doRequest(request) {
+      it.put(request.okHttpRequestBody())
+    }
+  }
+
+  override fun delete(request: Request): Response {
+    return doRequest(request) {
+      if (request.body == null) {
+        it.delete()
+      } else {
+        it.delete(request.okHttpRequestBody())
+      }
+    }
+  }
+
+  override fun patch(request: Request): Response {
+    return doRequest(request) {
+      it.patch(request.okHttpRequestBody())
+    }
+  }
+
+  private fun doRequest(request: Request, builderCallback: (okhttp3.Request.Builder) -> Unit): Response {
+    val okRequest = requestBuilder(request)
+      .apply(builderCallback)
+      .build()
+
+    return try {
+      client.newCall(okRequest).execute().use {
+        it.toGenericResponse()
+      }
+    } catch (io: IOException) {
+      log.error("${okRequest.tag()} request failed", io)
+
+      Ok3Response(
+        objectMapper = objectMapper,
+        body = null,
+        exception = io,
+        statusCode = -1,
+        headers = emptyMap()
+      )
+    }
+  }
+
+  private fun requestBuilder(request: Request): okhttp3.Request.Builder =
+    okhttp3.Request.Builder()
+      .tag("$name.${request.name}")
+      .url(URL(baseUrl + request.path))
+      .headers(Headers.of(request.headers))
+
+  private fun Request.okHttpRequestBody(): RequestBody =
+    RequestBody.create(MediaType.parse(contentType), objectMapper.writeValueAsString(body))
+
+  private fun okhttp3.Response.toGenericResponse(): Response {
+    return Ok3Response(
+      objectMapper = objectMapper,
+      body = body(),
+      exception = null,
+      statusCode = code(),
+      headers = headers().toMultimap().map { it.key to it.value.joinToString(",") }.toMap()
+    )
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistry.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistry.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk.httpclient
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClient
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClientConfig
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClientRegistry
+import com.netflix.spinnaker.kork.plugins.sdk.httpclient.internal.OkHttp3ClientFactory
+import okhttp3.OkHttpClient
+import org.springframework.core.env.Environment
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Configures and provides [HttpClient]s to an extension.
+ */
+class Ok3HttpClientRegistry(
+  private val pluginId: String,
+  private val environment: Environment,
+  private val objectMapper: ObjectMapper,
+  private val okHttp3ClientFactory: OkHttp3ClientFactory,
+  okHttp3ClientConfiguration: OkHttp3ClientConfiguration
+) : HttpClientRegistry {
+
+  private val internalServicesClient = okHttp3ClientConfiguration.create().build()
+  internal val okClients: MutableMap<HttpClientConfig, OkHttpClient> = ConcurrentHashMap()
+  internal val clients: MutableMap<String, Ok3HttpClient> = ConcurrentHashMap()
+
+  override fun configure(name: String, baseUrl: String, config: HttpClientConfig) {
+    clients.computeIfAbsent("$pluginId.$name") {
+      // Try to reduce the number of OkHttpClient instances that are floating around. We'll only create a new client
+      // if the config is different from any other OkHttpClient.
+      val okClient = okClients.computeIfAbsent(config) { okHttp3ClientFactory.create(config) }
+      Ok3HttpClient("$pluginId.$name", baseUrl, okClient, objectMapper)
+    }
+  }
+
+  override fun get(name: String): HttpClient {
+    return clients["$pluginId.$name"] ?: throw IntegrationException("No client configured for '$name'")
+  }
+
+  override fun getInternalService(name: String): HttpClient {
+    return clients.computeIfAbsent("internal.$name") {
+      Ok3HttpClient("internal.$name", findInternalServiceBaseUrl(name), internalServicesClient, objectMapper)
+    }
+  }
+
+  private fun findInternalServiceBaseUrl(name: String): String {
+    val normalized = name.toLowerCase()
+    val paths = baseUrlPaths.map { it.replace(serviceNamePlaceholder, normalized) }
+
+    for (path in paths) {
+      val baseUrl = environment.getProperty(path)
+      if (baseUrl != null) {
+        return baseUrl
+      }
+    }
+
+    throw IntegrationException("Unknown service '$name': No baseUrl config property set for service")
+  }
+
+  companion object {
+    private const val serviceNamePlaceholder = "SERVICE_NAME"
+    private val baseUrlPaths: List<String> = listOf(
+      "$serviceNamePlaceholder.baseUrl",
+      "services.$serviceNamePlaceholder.baseUrl"
+    )
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3Response.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3Response.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk.httpclient
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.plugins.api.httpclient.Response
+import okhttp3.ResponseBody
+import java.io.InputStream
+import java.lang.Exception
+import java.util.Optional
+
+class Ok3Response(
+  private val objectMapper: ObjectMapper,
+  private val body: ResponseBody?,
+  private val exception: Exception?,
+  private val statusCode: Int,
+  private val headers: Map<String, String>
+) : Response {
+  override fun getBody(): InputStream? = body?.byteStream()
+
+  override fun <T : Any> getBody(expectedType: Class<T>): T? {
+    if (body == null) {
+      return null
+    }
+    return objectMapper.convertValue(body.byteStream(), expectedType)
+  }
+
+  override fun getException(): Optional<Exception> =
+    Optional.ofNullable(exception)
+
+  override fun getStatusCode(): Int =
+    statusCode
+
+  override fun getHeaders(): Map<String, String> =
+    headers
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/internal/CompositeOkHttpClientFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/internal/CompositeOkHttpClientFactory.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk.httpclient.internal
+
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClientConfig
+import okhttp3.OkHttpClient
+
+/**
+ * Allows multiple [OkHttp3ClientFactory]s to be used based on an [HttpClientConfig].
+ */
+class CompositeOkHttpClientFactory(
+  private val factories: List<OkHttp3ClientFactory>
+) : OkHttp3ClientFactory {
+
+  override fun supports(config: HttpClientConfig): Boolean = true
+
+  override fun create(config: HttpClientConfig): OkHttpClient {
+    return factories
+      .firstOrNull { it.supports(config) }
+      ?.create(config)
+      ?: throw IntegrationException("Cannot create http client from config: $config")
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/internal/DefaultOkHttp3ClientFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/internal/DefaultOkHttp3ClientFactory.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk.httpclient.internal
+
+import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClientConfig
+import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
+import okhttp3.OkHttpClient
+
+/**
+ * Configures a standard [OkHttpClient].
+ */
+class DefaultOkHttp3ClientFactory(
+  private val okHttpClientHttp3MetricsInterceptor: OkHttp3MetricsInterceptor
+) : OkHttp3ClientFactory {
+  override fun supports(config: HttpClientConfig): Boolean =
+    config.javaClass == HttpClientConfig::class.java
+
+  override fun create(config: HttpClientConfig): OkHttpClient {
+    return OkHttp3ClientConfiguration(
+      OkHttpClientConfigurationProperties().apply {
+        config.connectionPool.keepAlive?.let {
+          connectionPool.keepAliveDurationMs = it.toMillis().toInt()
+        }
+        config.connectionPool.maxIdleConnections?.let {
+          connectionPool.maxIdleConnections = it
+        }
+
+        config.connection.connectTimeout?.let {
+          connectTimeoutMs = it.toMillis()
+        }
+        config.connection.readTimeout?.let {
+          readTimeoutMs = it.toMillis()
+        }
+        retryOnConnectionFailure = config.connection.isRetryOnConnectionFailure
+
+        if (config.security.keyStorePath != null && config.security.trustStorePath != null) {
+          keyStore = config.security.keyStorePath.toFile()
+          keyStoreType = config.security.keyStoreType
+          keyStorePassword = config.security.keyStorePassword
+
+          trustStore = config.security.trustStorePath.toFile()
+          trustStoreType = config.security.trustStoreType
+          trustStorePassword = config.security.trustStorePassword
+
+          tlsVersions = config.security.tlsVersions
+          cipherSuites = config.security.cipherSuites
+        }
+      },
+      // TODO(rz): Add plugin ID to the metrics. Requires refactoring existing metrics interceptor.
+      okHttpClientHttp3MetricsInterceptor
+    ).create().build()
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/internal/OkHttp3ClientFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/internal/OkHttp3ClientFactory.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk.httpclient.internal
+
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClientConfig
+import okhttp3.OkHttpClient
+
+/**
+ * Offers a configuration point to provide custom [OkHttpClient]s.
+ *
+ * In most cases, the [DefaultOkHttp3ClientFactory] will suffice, unless you need to support highly customized
+ * clients (like Netflix and Metatron).
+ */
+interface OkHttp3ClientFactory {
+
+  /**
+   * Returns whether or not the factory supports the provided [config].
+   */
+  fun supports(config: HttpClientConfig): Boolean
+
+  /**
+   * Creates an [OkHttpClient] with the provided [config].
+   */
+  fun create(config: HttpClientConfig): OkHttpClient
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistryTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistryTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk.httpclient
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClientConfig
+import com.netflix.spinnaker.kork.plugins.sdk.httpclient.internal.OkHttp3ClientFactory
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkClass
+import io.mockk.verify
+import okhttp3.OkHttpClient
+import org.springframework.core.env.Environment
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.containsKey
+import strikt.assertions.hasSize
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+
+class Ok3HttpClientRegistryTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    context("configuring clients") {
+      before {
+        every { okHttp3ClientFactory.create(any()) } returns mockkClass(OkHttpClient::class, relaxed = true)
+      }
+
+      test("throws when no client configured") {
+        expectThrows<IntegrationException> {
+          subject.get("unknown")
+        }
+      }
+
+      test("creates a new client") {
+        val config = HttpClientConfig()
+
+        subject.configure("myClient", "https://example.com", config)
+
+        expectThat(subject.clients).and {
+          hasSize(1)
+          containsKey("io.spinnaker.example.myClient")
+        }
+
+        expectThat(subject.okClients).and {
+          hasSize(1)
+          containsKey(config)
+        }
+
+        verify(exactly = 1) { okHttp3ClientFactory.create(eq(config)) }
+      }
+
+      test("get a configured client") {
+        subject.configure("myClient", "https://example.com", HttpClientConfig())
+
+        expectThat(subject.get("myClient"))
+          .isA<Ok3HttpClient>()
+          .and {
+            get { name }.isEqualTo("io.spinnaker.example.myClient")
+            get { baseUrl }.isEqualTo("https://example.com")
+          }
+      }
+    }
+
+    context("internal services") {
+      test("non-existent service") {
+        expectThrows<IntegrationException> {
+          subject.get("unknown")
+        }
+      }
+
+      listOf(
+        "clouddriver.baseUrl",
+        "services.clouddriver.baseUrl"
+      ).forEach { property ->
+        test("configures client for '$property'") {
+          every { environment.getProperty(any()) } returns null
+          every { environment.getProperty(eq(property)) } returns "https://clouddriver.com"
+
+          expectThat(subject.getInternalService("clouddriver"))
+            .isA<Ok3HttpClient>()
+            .and {
+              get { name }.isEqualTo("internal.clouddriver")
+              get { baseUrl }.isEqualTo("https://clouddriver.com")
+            }
+        }
+      }
+    }
+  }
+
+  private inner class Fixture {
+    val environment: Environment = mockk(relaxed = true)
+    val objectMapper: ObjectMapper = mockk(relaxed = true)
+    val okHttp3ClientFactory: OkHttp3ClientFactory = mockk(relaxed = true)
+    val okHttp3ClientConfiguration: OkHttp3ClientConfiguration = mockk(relaxed = true)
+    val internalServicesClient: OkHttpClient = mockk(relaxed = true)
+
+    val subject = Ok3HttpClientRegistry(
+      "io.spinnaker.example",
+      environment,
+      objectMapper,
+      okHttp3ClientFactory,
+      okHttp3ClientConfiguration
+    )
+
+    init {
+      val builder: OkHttpClient.Builder = mockk(relaxed = true)
+      every { builder.build() } returns internalServicesClient
+      every { okHttp3ClientConfiguration.create() } returns builder
+    }
+  }
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk.httpclient
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.plugins.api.httpclient.Request
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.Call
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody
+import strikt.api.expectThat
+import strikt.assertions.containsKey
+import strikt.assertions.isEqualTo
+
+class Ok3HttpClientTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    test("responses are mapped to sdk model") {
+      val call: Call = mockk(relaxed = true)
+      val response = Response.Builder()
+        .request(mockk(relaxed = true))
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .header("Content-Type", "plain/text")
+        .body(ResponseBody.create(MediaType.parse("plain/text"), "hi"))
+        .build()
+
+      every { okHttpClient.newCall(any()) } returns call
+      every { call.execute() } returns response
+
+      val request = Request("hello", "/")
+      expectThat(subject.get(request)).and {
+        get { String(body.readBytes()) }.isEqualTo("hi")
+        get { statusCode }.isEqualTo(200)
+        get { headers }.containsKey("content-type")
+      }
+    }
+  }
+
+  private inner class Fixture {
+    val okHttpClient: OkHttpClient = mockk(relaxed = true)
+    val objectMapper: ObjectMapper = mockk(relaxed = true)
+
+    val subject = Ok3HttpClient("foo", "http://example.net", okHttpClient, objectMapper)
+  }
+}

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttpClientComponents.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttpClientComponents.groovy
@@ -26,8 +26,10 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
+import javax.inject.Provider
+
 @Configuration
-@EnableConfigurationProperties(OkHttpClientConfigurationProperties)
+@EnableConfigurationProperties([OkHttpClientConfigurationProperties, OkHttpMetricsInterceptorProperties])
 class OkHttpClientComponents {
   @Bean
   SpinnakerRequestInterceptor spinnakerRequestInterceptor(OkHttpClientConfigurationProperties okHttpClientConfigurationProperties) {
@@ -36,17 +38,17 @@ class OkHttpClientComponents {
 
   @Bean
   OkHttpMetricsInterceptor okHttpMetricsInterceptor(
-    Registry registry,
-    @Value('${ok-http-client.interceptor.skip-header-check:false}') boolean skipHeaderCheck) {
+    Provider<Registry> registry,
+    OkHttpMetricsInterceptorProperties okHttpMetricsInterceptorProperties) {
 
-    return new OkHttpMetricsInterceptor(registry, skipHeaderCheck)
+    return new OkHttpMetricsInterceptor(registry, okHttpMetricsInterceptorProperties.skipHeaderCheck)
   }
 
   @Bean
   OkHttp3MetricsInterceptor okHttp3MetricsInterceptor(
-    Registry registry,
-    @Value('${ok-http-client.interceptor.skip-header-check:false}') boolean skipHeaderCheck) {
+    Provider<Registry> registry,
+    OkHttpMetricsInterceptorProperties okHttpMetricsInterceptorProperties) {
 
-    return new OkHttp3MetricsInterceptor(registry, skipHeaderCheck)
+    return new OkHttp3MetricsInterceptor(registry, okHttpMetricsInterceptorProperties.skipHeaderCheck)
   }
 }

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttpMetricsInterceptorProperties.java
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttpMetricsInterceptorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.netflix.spinnaker.config;
 
-apply plugin: "java-library"
-apply from: "$rootDir/gradle/kotlin-test.gradle"
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-dependencies {
-  api(platform(project(":spinnaker-dependencies")))
+@ConfigurationProperties("ok-http-client.interceptor")
+public class OkHttpMetricsInterceptorProperties {
 
-  api "javax.annotation:javax.annotation-api"
-  api project(":kork-annotations")
-  api "org.pf4j:pf4j"
+  public boolean skipHeaderCheck = false;
 }

--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/MetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/MetricsInterceptor.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -25,11 +26,11 @@ import org.springframework.util.StringUtils;
  * way out and the interceptor logic will not be necessary long term.
  */
 class MetricsInterceptor {
-  private final Registry registry;
+  private final Provider<Registry> registry;
   private final boolean skipHeaderCheck;
   private final Logger log;
 
-  MetricsInterceptor(Registry registry, boolean skipHeaderCheck) {
+  MetricsInterceptor(Provider<Registry> registry, boolean skipHeaderCheck) {
     this.registry = registry;
     this.skipHeaderCheck = skipHeaderCheck;
     this.log = LoggerFactory.getLogger(getClass());
@@ -104,7 +105,12 @@ class MetricsInterceptor {
       }
 
       recordTimer(
-          registry, url, System.nanoTime() - start, statusCode, wasSuccessful, !missingAuthHeaders);
+          registry.get(),
+          url,
+          System.nanoTime() - start,
+          statusCode,
+          wasSuccessful,
+          !missingAuthHeaders);
     }
   }
 

--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttp3MetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttp3MetricsInterceptor.java
@@ -18,11 +18,12 @@ package com.netflix.spinnaker.okhttp;
 
 import com.netflix.spectator.api.Registry;
 import java.io.IOException;
+import javax.inject.Provider;
 import okhttp3.Response;
 
 public class OkHttp3MetricsInterceptor extends MetricsInterceptor implements okhttp3.Interceptor {
 
-  public OkHttp3MetricsInterceptor(Registry registry, boolean skipHeaderCheck) {
+  public OkHttp3MetricsInterceptor(Provider<Registry> registry, boolean skipHeaderCheck) {
     super(registry, skipHeaderCheck);
   }
 

--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttpMetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/OkHttpMetricsInterceptor.java
@@ -20,10 +20,11 @@ import com.netflix.spectator.api.Registry;
 import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.Response;
 import java.io.IOException;
+import javax.inject.Provider;
 
 public class OkHttpMetricsInterceptor extends MetricsInterceptor
     implements com.squareup.okhttp.Interceptor {
-  public OkHttpMetricsInterceptor(Registry registry, boolean skipHeaderCheck) {
+  public OkHttpMetricsInterceptor(Provider<Registry> registry, boolean skipHeaderCheck) {
     super(registry, skipHeaderCheck);
   }
 


### PR DESCRIPTION
The first actual API for `kork-plugins-api` and one that will be necessary pretty quick here as we at Netflix start getting closer to moving our internal extensions into plugins. This HTTP client is designed to allow plugins to make HTTP requests without directly wiring up & configuring their own HTTP clients, per-se.

An extension could have a constructor dependency on `HttpClientProvider` and with #506, it would be injected and the implementation of the `HttpClient`s themselves would be encapsulated within the service internals, allowing us to iterate the client without forcing transitive dependencies on plugin developers.

**ACTION**: Review the API. I went with _simple_ being the primary guiding light. I explicitly decided not to follow in a pattern like Retrofit despite its nice API because it's not very simple and we'd be stuck with that pattern for a long time. We can always make the API more complex, but it'll be hard to make it simpler as time goes on. Does the API do the trick? Does it make sense?

If we like this, I'll add class docs, tests and make it work and so-on.