### PR TITLE
refactor(swagger): Remove groovy dependency from kork-swagger

### DIFF
--- a/kork-swagger/kork-swagger.gradle
+++ b/kork-swagger/kork-swagger.gradle
@@ -6,5 +6,4 @@ dependencies {
   api "org.springframework.boot:spring-boot-autoconfigure"
   api "io.springfox:springfox-swagger2"
   api "io.springfox:springfox-swagger-ui"
-  implementation "org.codehaus.groovy:groovy"
 }


### PR DESCRIPTION
This is either the best idea or the worst idea I've had in a while...

After submitting the last PR, I realized that there is a way to exclude groovy from Swagger annotations without forcing it as a dependency.

In general I'm not a fan of reflection as it makes it really hard to perform static analysis and is hard to maintain. But this may be the one time in my life where it is actually the right solution to the problem.