### PR TITLE
chore(dependencies): resolve CVEs issues

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -83,7 +83,7 @@ dependencies {
     api("com.netflix.archaius:archaius-core:0.7.5")
     api("com.netflix.awsobjectmapper:awsobjectmapper:${versions.aws}")
     api("com.netflix.dyno:dyno-jedis:1.7.2")
-    api("com.netflix.eureka:eureka-client:1.9.2")
+    api("com.netflix.eureka:eureka-client:1.9.18")
     api("com.netflix.frigga:frigga:0.20.0")
     api("com.netflix.hystrix:hystrix-core:${versions.hystrix}")
     api("com.netflix.hystrix:hystrix-javanica:${versions.hystrix}")


### PR DESCRIPTION
Upgrade eureka version.
Fix CVE-2019-10173 caused by xstream dependency from following services:
- clouddriver
- echo
- fiat
- front50
- gate
- halyard
- igor
- kayenta
- orca
- rosco