### PR TITLE
fix(plugins): Rework ServiceVersion bean wiring

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/PlatformComponents.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/PlatformComponents.java
@@ -30,6 +30,7 @@ import io.github.resilience4j.retry.RetryRegistry;
 import java.util.List;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -47,6 +48,7 @@ import org.springframework.context.annotation.Import;
       CircuitBreakersHealthIndicatorAutoConfiguration.class,
       RateLimitersHealthIndicatorAutoConfiguration.class
     })
+@EnableConfigurationProperties(ManifestVersionResolver.Properties.class)
 public class PlatformComponents {
   @Bean
   public EurekaStatusListener eurekaStatusListener() {
@@ -54,14 +56,16 @@ public class PlatformComponents {
   }
 
   @Bean
+  @ConditionalOnMissingBean(ServiceVersion.class)
   ServiceVersion serviceVersion(
       ApplicationContext applicationContext, List<VersionResolver> versionResolvers) {
     return new ServiceVersion(applicationContext, versionResolvers);
   }
 
   @Bean
-  VersionResolver manifestVersionResolver() {
-    return new ManifestVersionResolver();
+  @ConditionalOnMissingBean(ManifestVersionResolver.class)
+  VersionResolver manifestVersionResolver(ManifestVersionResolver.Properties properties) {
+    return new ManifestVersionResolver(properties.useOssVersionManifestAttribute);
   }
 
   @Bean

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/version/ManifestVersionResolver.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/version/ManifestVersionResolver.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Resolves a service version from scanning MANIFEST.MF files in the service artifacts.
@@ -116,5 +117,14 @@ public class ManifestVersionResolver implements VersionResolver {
   @Override
   public int getOrder() {
     return 0;
+  }
+
+  @ConfigurationProperties("service-version")
+  public static class Properties {
+    /**
+     * If set to true, "Implementation-OSS-Version" will be read instead of
+     * "Implementation-Version".
+     */
+    public boolean useOssVersionManifestAttribute = false;
   }
 }

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/version/ServiceVersion.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/version/ServiceVersion.java
@@ -25,7 +25,7 @@ import org.springframework.context.ApplicationContext;
 @Slf4j
 public class ServiceVersion {
 
-  private static final String UNKNOWN_VERSION = "unknown";
+  public static final String UNKNOWN_VERSION = "unknown";
 
   private final List<VersionResolver> resolvers;
   private final ApplicationContext applicationContext;

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.kork.plugins.loaders.SpinnakerDevelopmentPluginLoad
 import com.netflix.spinnaker.kork.plugins.loaders.SpinnakerJarPluginLoader
 import com.netflix.spinnaker.kork.plugins.repository.PluginRefPluginRepository
 import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory
-import com.netflix.spinnaker.kork.version.VersionResolver
+import com.netflix.spinnaker.kork.version.ServiceVersion
 import org.pf4j.CompoundPluginLoader
 import org.pf4j.CompoundPluginRepository
 import org.pf4j.DefaultPluginManager
@@ -48,7 +48,7 @@ import java.nio.file.Path
  */
 @Beta
 open class SpinnakerPluginManager(
-  private val systemVersionResolver: VersionResolver,
+  private val serviceVersion: ServiceVersion,
   val spinnakerVersionManager: VersionManager,
   val statusProvider: PluginStatusProvider,
   configFactory: ConfigFactory,
@@ -85,7 +85,13 @@ open class SpinnakerPluginManager(
   override fun getSystemVersion(): String {
     // TODO(jonsie): For now this is ok, but eventually we will want to throw an exception if the
     // system version is null.
-    return systemVersionResolver.resolve(serviceName) ?: "0.0.0"
+    return serviceVersion.resolve().let {
+      if (it == ServiceVersion.UNKNOWN_VERSION) {
+        "0.0.0"
+      } else {
+        it
+      }
+    }
   }
 
   override fun createExtensionFactory(): ExtensionFactory = ExtensionFactoryDelegate()


### PR DESCRIPTION
Some problems with `ServiceVersion` wiring after adding it to the plugin framework.

- There are potentially multiple `VersionResolver`s; `ServiceVersion` should be used by the codebases.
- The plugin framework initializes before normal Spring wiring, so beans wired up by other areas of kork or an application will not be available yet.

Also moved the config to a more general location (`service-version`, instead of `spinnaker.extensibility`, since `ServiceVersion` is not part of the plugin framework itself.