### PR TITLE
fix(metrics): don't publish a metric with a `name` tag

### DIFF
--- a/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/SNSPublisher.java
+++ b/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/SNSPublisher.java
@@ -57,8 +57,7 @@ public class SNSPublisher implements PubsubPublisher {
     this.isEnabled = isEnabled;
     this.registry = registry;
     this.topicARN = new ARN(subscription.getTopicARN());
-    this.successCounter =
-        registry.counter("pubsub.amazon.published", "name", getName(), "topic", getTopicName());
+    this.successCounter = registry.counter("pubsub.amazon.published", "topic", getTopicName());
     this.retrySupport = retrySupport;
 
     initializeTopic();


### PR DESCRIPTION
Turns out, it can override the actual metric name