### PR TITLE
chore(guava): upgrade guava

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -74,7 +74,7 @@ dependencies {
     api("com.google.apis:google-api-services-monitoring:v3-rev477-1.25.0")
     api("com.google.apis:google-api-services-storage:v1-rev141-1.25.0")
     api("com.google.code.findbugs:jsr305:3.0.2")
-    api("com.google.guava:guava:28.1-jre")
+    api("com.google.guava:guava:28.2-jre")
     api("com.hubspot.jinjava:jinjava:2.2.3") // DO NOT CHANGE: MPTv1 strongly depends on this version of Jinjava
     api("com.jcraft.jsch:${versions.jsch}")
     api("com.jcraft:jsch.agentproxy.connector-factory:${versions.jschAgentProxy}")


### PR DESCRIPTION
This should fix the breakage caused by spinnaker/clouddriver#4373

Specifically, the library upgrade there depends on guava 28.2, so Maven sucks in `28.2-android`, which doesn't have `ImmutableMap#toImmutableMap`.

The error happens at runtime because at compile time it's using `28.1-jre`, but that gets overridden in the distribution by the android version.