### PR TITLE
feat(exceptions): add retrofit handler and exceptions

### DIFF
--- a/kork-exceptions/kork-exceptions.gradle
+++ b/kork-exceptions/kork-exceptions.gradle
@@ -4,6 +4,10 @@ apply from: "$rootDir/gradle/lombok.gradle"
 
 dependencies {
   api(platform(project(":spinnaker-dependencies")))
+
+  implementation project(":kork-annotations")
+  implementation "com.squareup.retrofit:retrofit"
+  implementation "org.springframework.boot:spring-boot-starter-web"
   api "com.google.code.findbugs:jsr305"
 
   testImplementation "org.codehaus.groovy:groovy-all"

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import lombok.Getter;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+/**
+ * An exception that exposes the {@link Response} of a given HTTP {@link RetrofitError} and a detail
+ * message that extracts useful information from the {@link Response}.
+ */
+@Getter
+@NonnullByDefault
+public final class SpinnakerHttpException extends SpinnakerServerException {
+  private final Response response;
+
+  SpinnakerHttpException(RetrofitError e) {
+    super(e);
+    this.response = e.getResponse();
+  }
+
+  @Override
+  public String getMessage() {
+    return String.format(
+        "Status: %s, URL: %s, Message: %s",
+        response.getStatus(), response.getUrl(), getRawMessage());
+  }
+}

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import retrofit.RetrofitError;
+
+/** Wraps an exception of kind {@link RetrofitError.Kind} NETWORK. */
+@NonnullByDefault
+public final class SpinnakerNetworkException extends SpinnakerServerException {
+  SpinnakerNetworkException(RetrofitError e) {
+    super(e);
+  }
+}

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandler.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import org.springframework.http.HttpStatus;
+import retrofit.ErrorHandler;
+import retrofit.RetrofitError;
+
+/**
+ * An error handler to be registered with a {@link retrofit.RestAdapter}. Allows clients to catch
+ * more specific {@link NotFoundException}, {@link SpinnakerHttpException}, or {@link
+ * SpinnakerNetworkException} depending on the properties of the {@link RetrofitError}.
+ */
+@NonnullByDefault
+public final class SpinnakerRetrofitErrorHandler implements ErrorHandler {
+  private SpinnakerRetrofitErrorHandler() {}
+
+  /**
+   * Returns an instance of a {@link SpinnakerRetrofitErrorHandler}.
+   *
+   * @return An instance of {@link SpinnakerRetrofitErrorHandler}
+   */
+  public static SpinnakerRetrofitErrorHandler getInstance() {
+    return new SpinnakerRetrofitErrorHandler();
+  }
+
+  /**
+   * Returns a more specific {@link Throwable} depending on properties of the caught {@link
+   * RetrofitError}.
+   *
+   * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
+   * @return A more informative {@link Throwable}
+   */
+  @Override
+  public Throwable handleError(RetrofitError e) {
+    switch (e.getKind()) {
+      case HTTP:
+        if (e.getResponse().getStatus() == HttpStatus.NOT_FOUND.value()) {
+          return new NotFoundException(e);
+        }
+        return new SpinnakerHttpException(e);
+      case NETWORK:
+        return new SpinnakerNetworkException(e);
+      default:
+        return new SpinnakerServerException(e);
+    }
+  }
+}

--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import java.util.Optional;
+import lombok.Getter;
+import retrofit.RetrofitError;
+
+/** An exception that exposes the message of a {@link RetrofitError}. */
+@NonnullByDefault
+public class SpinnakerServerException extends SpinnakerException {
+  private final String rawMessage;
+
+  /**
+   * Parses the message from the {@link RetrofitErrorResponseBody} of a {@link RetrofitError}.
+   *
+   * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
+   */
+  SpinnakerServerException(RetrofitError e) {
+    super(e.getCause());
+    RetrofitErrorResponseBody body =
+        (RetrofitErrorResponseBody) e.getBodyAs(RetrofitErrorResponseBody.class);
+    this.rawMessage =
+        Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse("");
+  }
+
+  @Override
+  public String getMessage() {
+    return rawMessage;
+  }
+
+  final String getRawMessage() {
+    return rawMessage;
+  }
+
+  @Getter
+  private static final class RetrofitErrorResponseBody {
+    private final String message;
+
+    @JsonCreator
+    RetrofitErrorResponseBody(@JsonProperty("message") String message) {
+      this.message = message;
+    }
+  }
+}


### PR DESCRIPTION
Part of https://github.com/spinnaker/spinnaker/issues/5473

Adds `SpinnakerRetrofitErrorHandler`, `SpinnakerServerException`, `SpinnakerNetworkException`, and `SpinnakerHttpException` to `kork-exceptions`.

Once this is merged and a new version of kork is released, I will replace the now-duplicated classes added to Clouddriver in [this PR](https://github.com/spinnaker/clouddriver/pull/4325).