### PR TITLE
fix(ssl): pass TrustManager to okHttp SSL socketfactory for JDK9+

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.config
 
+import static com.google.common.base.Preconditions.checkState
 import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import com.netflix.spinnaker.okhttp.OkHttpMetricsInterceptor
@@ -100,7 +101,10 @@ class OkHttp3ClientConfiguration {
     }
 
     sslContext.init(keyManagerFactory.keyManagers, trustManagerFactory.trustManagers, secureRandom)
-    okHttpClientBuilder.sslSocketFactory(sslContext.socketFactory, (X509TrustManager) trustManagerFactory.getTrustManagers().first())
+    def trustManagers = trustManagerFactory.getTrustManagers()
+    checkState(trustManagers.length == 1, "Found multiple trust managers; don't know which one to use")
+    checkState(trustManagers.first() instanceof X509TrustManager, "Configured TrustManager is a %s, not an X509TrustManager; don't know how to configure it", trustManagers.first().class.getName())
+    okHttpClientBuilder.sslSocketFactory(sslContext.socketFactory, (X509TrustManager) trustManagers.first())
 
     return applyConnectionSpecs(okHttpClientBuilder)
   }

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
 import java.security.KeyStore
 import java.security.NoSuchAlgorithmException
 import java.security.SecureRandom
@@ -99,7 +100,7 @@ class OkHttp3ClientConfiguration {
     }
 
     sslContext.init(keyManagerFactory.keyManagers, trustManagerFactory.trustManagers, secureRandom)
-    okHttpClientBuilder.sslSocketFactory(sslContext.socketFactory)
+    okHttpClientBuilder.sslSocketFactory(sslContext.socketFactory, (X509TrustManager) trustManagerFactory.getTrustManagers().first())
 
     return applyConnectionSpecs(okHttpClientBuilder)
   }


### PR DESCRIPTION
We recently encountered a crash loop using the igor 1.18.X codeline
when enabling SSL with a local truststore. The error being thrown is
```
Failed to instantiate [com.jakewharton.retrofit.Ok3Client]: Factory method
'ok3Client' threw exception; nested exception is java.lang.UnsupportedOperationException:
 clientBuilder.sslSocketFactory(SSLSocketFactory) not supported on JDK 9+
```
The stack trace allowed me to trace it back to kork's instantiation of the okHttpClient
which wasn't updated to pass in the TrustManager with the update of that JDK.

This only shows up if you are terminating SSL with your own truststore in the pod
so we may have been the first ones to come across this issue in the wild.