### PR TITLE
fix(ssl): pass TrustManager to okHttp SSL socketfactory for JDK9+ (#540)

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.config
 
+import static com.google.common.base.Preconditions.checkState
 import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import com.netflix.spinnaker.okhttp.OkHttpMetricsInterceptor
@@ -31,6 +32,7 @@ import org.springframework.stereotype.Component
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
 import java.security.KeyStore
 import java.security.NoSuchAlgorithmException
 import java.security.SecureRandom
@@ -92,7 +94,10 @@ class OkHttp3ClientConfiguration {
     }
 
     sslContext.init(keyManagerFactory.keyManagers, trustManagerFactory.trustManagers, secureRandom)
-    okHttpClientBuilder.sslSocketFactory(sslContext.socketFactory)
+    def trustManagers = trustManagerFactory.getTrustManagers()
+    checkState(trustManagers.length == 1, "Found multiple trust managers; don't know which one to use")
+    checkState(trustManagers.first() instanceof X509TrustManager, "Configured TrustManager is a %s, not an X509TrustManager; don't know how to configure it", trustManagers.first().class.getName())
+    okHttpClientBuilder.sslSocketFactory(sslContext.socketFactory, (X509TrustManager) trustManagers.first())
 
     return applyConnectionSpecs(okHttpClientBuilder)
   }


### PR DESCRIPTION
Cherrypicked from `master` to `release-1.18.x`