### PR TITLE
fix(plugins): handle extension method with void return type

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/ExtensionInvocationProxy.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/ExtensionInvocationProxy.kt
@@ -42,11 +42,11 @@ class ExtensionInvocationProxy(
     return target.javaClass
   }
 
-  override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any {
+  override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
     val invocationStates: MutableSet<InvocationState> = mutableSetOf()
     invocationStates.before(proxy, method, args)
 
-    val result: Any
+    val result: Any?
     try {
       result = method.invoke(target, *(args ?: arrayOfNulls<Any>(0)))
       invocationStates.after()


### PR DESCRIPTION
EventListener.processEvent(Event) does not return a value (void), which results in null being returned here. But result can't be null, so there is a runtime exception. This causes an error in the log and invocationStates.after() does not get executed.