### PR TITLE
fix(plugins): Disable HttpClientSdkConfiguration

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/HttpClientSdkConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/HttpClientSdkConfiguration.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Provider;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.annotation.Bean;
@@ -35,6 +36,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
 @Configuration
+@ConditionalOnExpression("false")
 public class HttpClientSdkConfiguration {
 
   @Bean


### PR DESCRIPTION
There are downstream failures due to this config being enabled by default, and honestly I just want to fix other bugs and move on and not deal with this problem right now.