### PR TITLE
feat(okhttp): support for dispatcher max-conn tuning

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.config
 
+import okhttp3.Dispatcher
+
 import static com.google.common.base.Preconditions.checkState
 import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
@@ -60,10 +62,15 @@ class OkHttp3ClientConfiguration {
    * @return OkHttpClient w/ <optional> key and trust stores
    */
   OkHttpClient.Builder create() {
+    Dispatcher dispatcher = new Dispatcher()
+    dispatcher.setMaxRequests(okHttpClientConfigurationProperties.maxRequests)
+    dispatcher.setMaxRequestsPerHost(okHttpClientConfigurationProperties.maxRequestsPerHost)
+
     OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
       .connectTimeout(okHttpClientConfigurationProperties.connectTimeoutMs, TimeUnit.MILLISECONDS)
       .readTimeout(okHttpClientConfigurationProperties.readTimeoutMs, TimeUnit.MILLISECONDS)
       .retryOnConnectionFailure(okHttpClientConfigurationProperties.retryOnConnectionFailure)
+      .dispatcher(dispatcher)
       .connectionPool(new ConnectionPool(
         okHttpClientConfigurationProperties.connectionPool.maxIdleConnections,
         okHttpClientConfigurationProperties.connectionPool.keepAliveDurationMs,

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
@@ -29,6 +29,8 @@ import org.springframework.core.annotation.AliasFor
 class OkHttpClientConfigurationProperties {
   long connectTimeoutMs = 15000
   long readTimeoutMs = 20000
+  int maxRequests = 64
+  int maxRequestsPerHost = 5
 
   boolean propagateSpinnakerHeaders = true
 


### PR DESCRIPTION
I noticed that `okhttp3`'s async dispatcher implements a queue in order to enforce a maximum number of in-flight requests per hostname, with a default of 5. since we’ve seen its queues block and since keel attempts to support lots of concurrent resource checks which all require clouddriver calls (a single hostname), I think the ability to tune this would be nice.