### PR TITLE
fix(plugins): allow for plugin configs on all services

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -3,3 +3,5 @@ style:
     active: false
   MaxLineLength:
     active: false
+  TooManyFunctions:
+    active: false

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.kork.plugins.ExtensionBeanDefinitionRegistryPostPro
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager;
 import com.netflix.spinnaker.kork.plugins.SpinnakerServiceVersionManager;
 import com.netflix.spinnaker.kork.plugins.SpringPluginStatusProvider;
+import com.netflix.spinnaker.kork.plugins.bundle.PluginBundleExtractor;
 import com.netflix.spinnaker.kork.plugins.config.ConfigFactory;
 import com.netflix.spinnaker.kork.plugins.config.ConfigResolver;
 import com.netflix.spinnaker.kork.plugins.config.RepositoryConfigCoordinates;
@@ -129,7 +130,7 @@ public class PluginsAutoConfiguration {
       ApplicationContext applicationContext,
       ConfigFactory configFactory,
       List<SdkFactory> sdkFactories,
-      Environment environment) {
+      PluginBundleExtractor pluginBundleExtractor) {
     return new SpinnakerPluginManager(
         serviceVersion,
         versionManager,
@@ -144,7 +145,12 @@ public class PluginsAutoConfiguration {
                 .getProperty(
                     PluginsConfigurationProperties.ROOT_PATH_CONFIG,
                     PluginsConfigurationProperties.DEFAULT_ROOT_PATH)),
-        environment);
+        pluginBundleExtractor);
+  }
+
+  @Bean
+  public static PluginBundleExtractor pluginBundleExtractor(Environment environment) {
+    return new PluginBundleExtractor(environment);
   }
 
   @Bean

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -128,7 +128,8 @@ public class PluginsAutoConfiguration {
       PluginStatusProvider pluginStatusProvider,
       ApplicationContext applicationContext,
       ConfigFactory configFactory,
-      List<SdkFactory> sdkFactories) {
+      List<SdkFactory> sdkFactories,
+      Environment environment) {
     return new SpinnakerPluginManager(
         serviceVersion,
         versionManager,
@@ -142,7 +143,8 @@ public class PluginsAutoConfiguration {
                 .getEnvironment()
                 .getProperty(
                     PluginsConfigurationProperties.ROOT_PATH_CONFIG,
-                    PluginsConfigurationProperties.DEFAULT_ROOT_PATH)));
+                    PluginsConfigurationProperties.DEFAULT_ROOT_PATH)),
+        environment);
   }
 
   @Bean

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -138,9 +138,11 @@ open class SpinnakerPluginManager(
   override fun loadPlugin(pluginPath: Path?): String? {
     require(!(pluginPath == null || Files.notExists(pluginPath))) { "Specified plugin '$pluginPath' does not exist!" }
     log.debug("Loading plugin from '{}'", pluginPath)
-    val pluginWrapper = loadPluginFromPath(pluginPath) ?: return null
-    // try to resolve  the loaded plugin together with other possible plugins that depend on this plugin
-    resolvePlugins()
-    return pluginWrapper!!.descriptor.pluginId
+    return loadPluginFromPath(pluginPath)
+      ?.let {
+        // try to resolve  the loaded plugin together with other possible plugins that depend on this plugin
+        resolvePlugins()
+        it.descriptor.pluginId
+      }
   }
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -136,7 +136,7 @@ open class SpinnakerPluginManager(
 
   // TODO (link108): remove this override, once plugin deployments via halyard are fixed
   override fun loadPlugin(pluginPath: Path?): String? {
-    require(!(pluginPath == null || Files.notExists(pluginPath))) { String.format("Specified plugin %s does not exist!", pluginPath) }
+    require(!(pluginPath == null || Files.notExists(pluginPath))) { "Specified plugin '$pluginPath' does not exist!" }
     log.debug("Loading plugin from '{}'", pluginPath)
     val pluginWrapper = loadPluginFromPath(pluginPath) ?: return null
     // try to resolve  the loaded plugin together with other possible plugins that depend on this plugin

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -40,7 +40,6 @@ import org.pf4j.PluginStatusProvider
 import org.pf4j.PluginWrapper
 import org.pf4j.VersionManager
 import org.slf4j.LoggerFactory
-import org.springframework.core.env.Environment
 
 /**
  * The primary entry-point to the plugins system from a provider-side (services, libs, CLIs, and so-on).
@@ -57,9 +56,9 @@ open class SpinnakerPluginManager(
   val statusProvider: PluginStatusProvider,
   configFactory: ConfigFactory,
   sdkFactories: List<SdkFactory>,
-  val serviceName: String,
+  private val serviceName: String,
   pluginsRoot: Path,
-  private val environment: Environment
+  private val pluginBundleExtractor: PluginBundleExtractor
 ) : DefaultPluginManager(pluginsRoot) {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -69,7 +68,6 @@ open class SpinnakerPluginManager(
     configFactory,
     sdkFactories
   )
-  private val bundleExtractor = PluginBundleExtractor(environment)
 
   private val spinnakerPluginFactory = SpinnakerPluginFactory(sdkFactories, configFactory)
 
@@ -120,7 +118,7 @@ open class SpinnakerPluginManager(
     SpinnakerPluginDescriptorFinder(this.getRuntimeMode())
 
   override fun loadPluginFromPath(pluginPath: Path): PluginWrapper? {
-    val extractedPath = bundleExtractor.extractService(pluginPath, serviceName) ?: return null
+    val extractedPath = pluginBundleExtractor.extractService(pluginPath, serviceName) ?: return null
     return super.loadPluginFromPath(extractedPath)
   }
 

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -40,6 +40,7 @@ import org.pf4j.PluginStatusProvider
 import org.pf4j.PluginWrapper
 import org.pf4j.VersionManager
 import org.slf4j.LoggerFactory
+import org.springframework.core.env.Environment
 
 /**
  * The primary entry-point to the plugins system from a provider-side (services, libs, CLIs, and so-on).
@@ -57,7 +58,8 @@ open class SpinnakerPluginManager(
   configFactory: ConfigFactory,
   sdkFactories: List<SdkFactory>,
   val serviceName: String,
-  pluginsRoot: Path
+  pluginsRoot: Path,
+  private val environment: Environment
 ) : DefaultPluginManager(pluginsRoot) {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -67,7 +69,7 @@ open class SpinnakerPluginManager(
     configFactory,
     sdkFactories
   )
-  private val bundleExtractor = PluginBundleExtractor()
+  private val bundleExtractor = PluginBundleExtractor(environment)
 
   private val spinnakerPluginFactory = SpinnakerPluginFactory(sdkFactories, configFactory)
 

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.kork.plugins.loaders.SpinnakerJarPluginLoader
 import com.netflix.spinnaker.kork.plugins.repository.PluginRefPluginRepository
 import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory
 import com.netflix.spinnaker.kork.version.ServiceVersion
+import java.nio.file.Files
 import java.nio.file.Path
 import org.pf4j.CompoundPluginLoader
 import org.pf4j.CompoundPluginRepository
@@ -38,6 +39,7 @@ import org.pf4j.PluginRepository
 import org.pf4j.PluginStatusProvider
 import org.pf4j.PluginWrapper
 import org.pf4j.VersionManager
+import org.slf4j.LoggerFactory
 
 /**
  * The primary entry-point to the plugins system from a provider-side (services, libs, CLIs, and so-on).
@@ -54,9 +56,11 @@ open class SpinnakerPluginManager(
   val statusProvider: PluginStatusProvider,
   configFactory: ConfigFactory,
   sdkFactories: List<SdkFactory>,
-  private val serviceName: String,
+  val serviceName: String,
   pluginsRoot: Path
 ) : DefaultPluginManager(pluginsRoot) {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   private val springExtensionFactory: ExtensionFactory = SpinnakerExtensionFactory(
     this,
@@ -114,7 +118,7 @@ open class SpinnakerPluginManager(
     SpinnakerPluginDescriptorFinder(this.getRuntimeMode())
 
   override fun loadPluginFromPath(pluginPath: Path): PluginWrapper? {
-    val extractedPath = bundleExtractor.extractService(pluginPath, serviceName)
+    val extractedPath = bundleExtractor.extractService(pluginPath, serviceName) ?: return null
     return super.loadPluginFromPath(extractedPath)
   }
 
@@ -127,4 +131,14 @@ open class SpinnakerPluginManager(
     .add(super.createPluginRepository())
 
   override fun getPluginFactory(): PluginFactory = spinnakerPluginFactory
+
+  // TODO (link108): remove this override, once plugin deployments via halyard are fixed
+  override fun loadPlugin(pluginPath: Path?): String? {
+    require(!(pluginPath == null || Files.notExists(pluginPath))) { String.format("Specified plugin %s does not exist!", pluginPath) }
+    log.debug("Loading plugin from '{}'", pluginPath)
+    val pluginWrapper = loadPluginFromPath(pluginPath) ?: return null
+    // try to resolve  the loaded plugin together with other possible plugins that depend on this plugin
+    resolvePlugins()
+    return pluginWrapper!!.descriptor.pluginId
+  }
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractor.kt
@@ -15,7 +15,6 @@
  */
 package com.netflix.spinnaker.kork.plugins.bundle
 
-import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import java.nio.file.Path
 import org.pf4j.util.FileUtils
 import org.slf4j.LoggerFactory
@@ -43,7 +42,7 @@ class PluginBundleExtractor {
   /**
    * Extract a specific service from a bundle.
    */
-  fun extractService(bundlePath: Path, service: String): Path {
+  fun extractService(bundlePath: Path, service: String): Path? {
     val extractedPath = extractBundle(bundlePath)
     if (!looksLikeBundle(extractedPath)) {
       log.debug("Plugin path does not appear to be a bundle, using as-is: {}", bundlePath)
@@ -55,10 +54,12 @@ class PluginBundleExtractor {
       return FileUtils.expandIfZip(servicePluginZipPath)
     }
 
+    // TODO (link108): make this throw an exception, instead of log, once plugin deployments via halyard are fixed
     // If thrown, this is an indicator that either: A) There's a bug in the plugin framework resolving which plugin
     // bundles should actually be downloaded, or B) The plugin author incorrectly identified this [service] as one
     // that the plugin extends (via the PluginInfo `requires` list).
-    throw IntegrationException("Downloaded plugin bundle does not have plugin for service '$service'")
+    log.warn("Downloaded plugin bundle: {}, does not have plugin for service: {}", bundlePath.fileName, service)
+    return null
   }
 
   /**

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractor.kt
@@ -64,7 +64,7 @@ class PluginBundleExtractor(
       // that the plugin extends (via the PluginInfo `requires` list).
       throw IntegrationException("Downloaded plugin bundle does not have plugin for service '$service'")
     } else {
-      log.warn("Downloaded plugin bundle: {}, does not have plugin for service: {}", bundlePath.fileName, service)
+      log.warn("Downloaded plugin bundle '{}' does not have plugin for service: {}", bundlePath.fileName, service)
       return null
     }
   }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt
@@ -41,7 +41,8 @@ class SpinnakerPluginManagerTest : JUnit5Minutests {
         mockk(),
         listOf(),
         "kork",
-        Paths.get("plugins")
+        Paths.get("plugins"),
+        mockk()
       )
     }
 

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractorTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractorTest.kt
@@ -15,8 +15,11 @@
  */
 package com.netflix.spinnaker.kork.plugins.bundle
 
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -27,14 +30,16 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import org.springframework.core.env.ConfigurableEnvironment
 import strikt.api.expect
 import strikt.api.expectThat
+import strikt.api.expectThrows
 import strikt.assertions.isTrue
 
 class PluginBundleExtractorTest : JUnit5Minutests {
 
   fun tests() = rootContext<PluginBundleExtractor> {
-    fixture { PluginBundleExtractor() }
+    fixture { PluginBundleExtractor(environment) }
 
     before {
       // Creates 3 zips: Two service plugin zips, and then a bundle zip containing the service plugin zips
@@ -80,8 +85,15 @@ class PluginBundleExtractorTest : JUnit5Minutests {
         expectThat(ZipBuilder.workspace.resolve("bundle/deck/index.js").toFile()).get { exists() }.isTrue()
       }
 
-      test("throws if bundle is missing expected service plugin") {
+      test("return null if bundle is missing expected service plugin") {
         expectThat(extractService(ZipBuilder.workspace.resolve("bundle.zip"), "clouddriver")).equals(null)
+      }
+
+      test("throws if bundle is missing expected service plugin in strict configuration") {
+        every { environment.getProperty("spinnaker.extensibility.strict-plugin-loading") } returns "true"
+        expectThrows<IntegrationException> {
+          extractService(ZipBuilder.workspace.resolve("bundle.zip"), "clouddriver")
+        }
       }
     }
 
@@ -92,6 +104,7 @@ class PluginBundleExtractorTest : JUnit5Minutests {
     }
   }
 
+  val environment: ConfigurableEnvironment = mockk(relaxed = true)
   private class ZipBuilder(
     private val sourceRootPath: Path,
     private val zipFilename: String,

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractorTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/bundle/PluginBundleExtractorTest.kt
@@ -15,7 +15,6 @@
  */
 package com.netflix.spinnaker.kork.plugins.bundle
 
-import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import java.io.File
@@ -30,7 +29,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import strikt.api.expect
 import strikt.api.expectThat
-import strikt.api.expectThrows
 import strikt.assertions.isTrue
 
 class PluginBundleExtractorTest : JUnit5Minutests {
@@ -83,9 +81,7 @@ class PluginBundleExtractorTest : JUnit5Minutests {
       }
 
       test("throws if bundle is missing expected service plugin") {
-        expectThrows<IntegrationException> {
-          extractService(ZipBuilder.workspace.resolve("bundle.zip"), "clouddriver")
-        }
+        expectThat(extractService(ZipBuilder.workspace.resolve("bundle.zip"), "clouddriver")).equals(null)
       }
     }
 

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManagerTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManagerTest.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.kork.plugins.update
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager
 import com.netflix.spinnaker.kork.plugins.SpinnakerServiceVersionManager
+import com.netflix.spinnaker.kork.plugins.bundle.PluginBundleExtractor
 import com.netflix.spinnaker.kork.plugins.internal.PluginZip
 import com.netflix.spinnaker.kork.plugins.testplugin.TestPluginBuilder
 import com.netflix.spinnaker.kork.plugins.update.release.PluginInfoRelease
@@ -130,7 +131,7 @@ class SpinnakerUpdateManagerTest : JUnit5Minutests {
       listOf(),
       "orca",
       paths.plugins,
-      mockk(relaxed = true)
+      PluginBundleExtractor(mockk(relaxed = true))
     )
 
     val repositories = listOf(DefaultUpdateRepository("testing",

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManagerTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManagerTest.kt
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.kork.plugins.testplugin.TestPluginBuilder
 import com.netflix.spinnaker.kork.plugins.update.release.PluginInfoRelease
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import io.mockk.MockKSettings.relaxed
 import io.mockk.mockk
 import java.io.File
 import java.nio.file.Files
@@ -128,7 +129,8 @@ class SpinnakerUpdateManagerTest : JUnit5Minutests {
       mockk(relaxed = true),
       listOf(),
       "orca",
-      paths.plugins
+      paths.plugins,
+      mockk(relaxed = true)
     )
 
     val repositories = listOf(DefaultUpdateRepository("testing",


### PR DESCRIPTION
Halyard does not currently have knowledge of which plugins should be placed onto each spinnaker service. For now, we can log a warning if there are plugin configs placed onto services that are not required for the plugin to function, so that halyard can successfully deploy plugins to Spinnaker.
Currently Spinnaker throws an error if plugin configs are laid down upon a service that does not require it