### PR TITLE
fix(build): Dispatch bump workflow with Spinnaker github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,5 +63,5 @@ jobs:
       - name: Trigger dependency bump workflow
         uses: peter-evans/repository-dispatch@v1
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+         token: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}
          event-type: bump-dependencies


### PR DESCRIPTION
https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token