### PR TITLE
fix(plugins): Clarify error when no httpclientfactory exists supporting baseurl

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/internal/CompositeOkHttpClientFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/internal/CompositeOkHttpClientFactory.kt
@@ -33,6 +33,8 @@ class CompositeOkHttpClientFactory(
     return factories
       .firstOrNull { it.supports(baseUrl) }
       ?.create(baseUrl, config)
-      ?: throw IntegrationException("Cannot create http client ($baseUrl) from config: $config")
+      ?: throw IntegrationException(
+        "Cannot create HttpClient for '$baseUrl': No HttpClientFactory found supporting this base URL"
+      )
   }
 }


### PR DESCRIPTION
This error message really threw me for a loop until I realized the `MetatronHttpClientFactory` only supports baseUrls with a scheme of `metatron://`. 🤦‍♂ 