### PR TITLE
fix(plugins): Allow normalization of baseurls from OkHttp3ClientFactories

### DIFF
--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/HttpClientConfig.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/HttpClientConfig.java
@@ -180,10 +180,10 @@ public class HttpClientConfig {
   public static class ConnectionConfig {
 
     /** Network connection timeout. */
-    private Duration connectTimeout;
+    private Duration connectTimeout = Duration.ofSeconds(10);
 
     /** Response timeout. */
-    private Duration readTimeout;
+    private Duration readTimeout = Duration.ofSeconds(30);
 
     /** Whether or not to retry on a network connection failure. Defaults to true. */
     private boolean retryOnConnectionFailure = true;
@@ -238,10 +238,10 @@ public class HttpClientConfig {
 
   public static class ConnectionPoolConfig {
     /** Max number of idle connections to keep in memory. */
-    private Integer maxIdleConnections;
+    private Integer maxIdleConnections = 5;
 
     /** The amount of time to keep a connection alive. */
-    private Duration keepAlive;
+    private Duration keepAlive = Duration.ofSeconds(60);
 
     public Integer getMaxIdleConnections() {
       return maxIdleConnections;

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistry.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistry.kt
@@ -45,7 +45,12 @@ class Ok3HttpClientRegistry(
       // Try to reduce the number of OkHttpClient instances that are floating around. We'll only create a new client
       // if the config is different from any other OkHttpClient.
       val okClient = okClients.computeIfAbsent(config) { okHttp3ClientFactory.create(baseUrl, config) }
-      Ok3HttpClient("$pluginId.$name", baseUrl, okClient, objectMapper)
+      Ok3HttpClient(
+        "$pluginId.$name",
+        okHttp3ClientFactory.normalizeBaseUrl(baseUrl),
+        okClient,
+        objectMapper
+      )
     }
   }
 

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/OkHttp3ClientFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/OkHttp3ClientFactory.kt
@@ -32,6 +32,16 @@ interface OkHttp3ClientFactory {
   fun supports(baseUrl: String): Boolean
 
   /**
+   * Allows custom client factories to modify the base URL before being used by the client.
+   *
+   * This can be handy for when you want to filter [OkHttp3ClientFactory] instances based on a custom (but fake)
+   * HTTP scheme, and normalize it back to a URL that will actually work. For example, Netflix uses a custom
+   * "metatron://my.base.url" format for differentiating between Metatron-secured instances and regular HTTP
+   * services. This method is then used to change the scheme back to "https://".
+   */
+  fun normalizeBaseUrl(baseUrl: String): String = baseUrl
+
+  /**
    * Creates an [OkHttpClient] with the provided [config].
    */
   fun create(baseUrl: String, config: HttpClientConfig): OkHttpClient

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistryTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistryTest.kt
@@ -71,6 +71,8 @@ class Ok3HttpClientRegistryTest : JUnit5Minutests {
       }
 
       test("get a configured client") {
+        every { okHttp3ClientFactory.normalizeBaseUrl(eq("https://example.com")) } returns "https://example.com"
+
         subject.configure("myClient", "https://example.com", HttpClientConfig())
 
         expectThat(subject.get("myClient"))


### PR DESCRIPTION
Since we're storing metatron URLs as "metatron://my-service", we need a way to normalize them back into real URLs.

... Also squeaked in some defaults to help guard against NPEs.