### PR TITLE
fix(plugins): Disable invocationproxy, remove reified fun optimization

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
@@ -18,9 +18,7 @@ package com.netflix.spinnaker.kork.plugins
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
 import com.netflix.spinnaker.kork.plugins.events.ExtensionLoaded
-import com.netflix.spinnaker.kork.plugins.proxy.ExtensionInvocationProxy
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationAspect
-import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationState
 import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
 import com.netflix.spinnaker.kork.plugins.update.release.PluginInfoReleaseProvider
 import kotlin.jvm.javaClass
@@ -107,10 +105,14 @@ class ExtensionBeanDefinitionRegistryPostProcessor(
           throw IntegrationException("Could not find extension class '$it' for plugin '${plugin.pluginId}'", e)
         }
 
-        val bean = ExtensionInvocationProxy.proxy(
-          pluginManager.extensionFactory.create(extensionClass),
-          invocationAspects as List<InvocationAspect<InvocationState>>,
-          plugin.descriptor as SpinnakerPluginDescriptor)
+        // TODO(rz): Major issues with using an InvocationProxy in extensions today. A lot of services are written
+        //  expecting beans to not be proxied and some extension points wind up getting serialized, which proxies
+        //  do not handle well. This functionality is very valuable, but we need to think this problem through more.
+//        val bean = ExtensionInvocationProxy.proxy(
+//          pluginManager.extensionFactory.create(extensionClass),
+//          invocationAspects as List<InvocationAspect<InvocationState>>,
+//          plugin.descriptor as SpinnakerPluginDescriptor)
+        val bean = pluginManager.extensionFactory.create(extensionClass)
 
         val beanName = "${plugin.pluginId.replace(".", "")}${extensionClass.simpleName.capitalize()}"
 

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/internal/CompositeOkHttpClientFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/internal/CompositeOkHttpClientFactory.kt
@@ -29,16 +29,17 @@ class CompositeOkHttpClientFactory(
 
   override fun supports(baseUrl: String): Boolean = true
 
-  override fun normalizeBaseUrl(baseUrl: String): String =
-    withFactory(baseUrl) { normalizeBaseUrl(baseUrl) }
-
-  override fun create(baseUrl: String, config: HttpClientConfig): OkHttpClient =
-    withFactory(baseUrl) { create(baseUrl, config) }
-
-  private inline fun <reified T> withFactory(baseUrl: String, callback: (OkHttp3ClientFactory) -> T): T {
+  override fun normalizeBaseUrl(baseUrl: String): String {
     return factories
       .firstOrNull { it.supports(baseUrl) }
-      ?.let(callback)
+      ?.normalizeBaseUrl(baseUrl)
+      ?: throw IntegrationException("No HttpClientFactory supports the provided baseUrl: $baseUrl")
+  }
+
+  override fun create(baseUrl: String, config: HttpClientConfig): OkHttpClient {
+    return factories
+      .firstOrNull { it.supports(baseUrl) }
+      ?.create(baseUrl, config)
       ?: throw IntegrationException("No HttpClientFactory supports the provided baseUrl: $baseUrl")
   }
 }


### PR DESCRIPTION
Disables `ExtensionInvocationProxy`. While working on Orca, I discovered that it doesn't handle proxied stage tasks well (at all) during serialization/deserialization. Rather than try to work on a hack that will get things to work, I'm disabling this code path for the time being while we work on MVP functionality. I think there's a solution here to support using the invocation proxy, or similar, but it will need more diligent effort than what we're willing to take on for the time being.

This PR also removes some reified code that was causing stackoverflow errors for some reason.