### PR TITLE
fix(plugins): Configured ObjectMapper and better respoonse body handling

### DIFF
--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/HttpClientConfig.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/httpclient/HttpClientConfig.java
@@ -34,6 +34,8 @@ public class HttpClientConfig {
   /** Connection pool-related configuration options. */
   private final ConnectionPoolConfig connectionPool = new ConnectionPoolConfig();
 
+  private final LoggingConfig logging = new LoggingConfig();
+
   public SecurityConfig getSecurity() {
     return security;
   }
@@ -44,6 +46,10 @@ public class HttpClientConfig {
 
   public ConnectionPoolConfig getConnectionPool() {
     return connectionPool;
+  }
+
+  public LoggingConfig getLogging() {
+    return logging;
   }
 
   public static class SecurityConfig {
@@ -275,6 +281,40 @@ public class HttpClientConfig {
       int result = maxIdleConnections != null ? maxIdleConnections.hashCode() : 0;
       result = 31 * result + (keepAlive != null ? keepAlive.hashCode() : 0);
       return result;
+    }
+  }
+
+  public static class LoggingConfig {
+    public enum LoggingLevel {
+      NONE,
+      BASIC,
+      HEADERS,
+      BODY
+    }
+
+    private LoggingLevel level = LoggingLevel.BASIC;
+
+    public LoggingLevel getLevel() {
+      return level;
+    }
+
+    public void setLevel(LoggingLevel level) {
+      this.level = level;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      LoggingConfig that = (LoggingConfig) o;
+
+      return level == that.level;
+    }
+
+    @Override
+    public int hashCode() {
+      return level != null ? level.hashCode() : 0;
     }
   }
 

--- a/kork-plugins/kork-plugins.gradle
+++ b/kork-plugins/kork-plugins.gradle
@@ -17,6 +17,7 @@ dependencies {
   implementation project(":kork-web")
   implementation("com.squareup.retrofit2:retrofit")
   implementation("com.squareup.retrofit2:converter-jackson")
+  implementation("com.squareup.okhttp3:logging-interceptor")
 
   implementation "org.pf4j:pf4j"
   implementation "org.pf4j:pf4j-update"
@@ -33,6 +34,7 @@ dependencies {
   testImplementation("org.mockito:mockito-core")
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
+  testImplementation("com.github.tomakehurst:wiremock:2.15.0")
 
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClient.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClient.kt
@@ -87,10 +87,8 @@ class Ok3HttpClient(
 
       Ok3Response(
         objectMapper = objectMapper,
-        body = null,
-        exception = io,
-        statusCode = -1,
-        headers = emptyMap()
+        response = null,
+        exception = io
       )
     }
   }
@@ -98,7 +96,7 @@ class Ok3HttpClient(
   private fun requestBuilder(request: Request): okhttp3.Request.Builder =
     okhttp3.Request.Builder()
       .tag("$name.${request.name}")
-      .url(URL(baseUrl + request.path))
+      .url(URL((baseUrl + request.path).replace("//", "/")))
       .headers(Headers.of(request.headers))
 
   private fun Request.okHttpRequestBody(): RequestBody =
@@ -107,10 +105,8 @@ class Ok3HttpClient(
   private fun okhttp3.Response.toGenericResponse(): Response {
     return Ok3Response(
       objectMapper = objectMapper,
-      body = body(),
-      exception = null,
-      statusCode = code(),
-      headers = headers().toMultimap().map { it.key to it.value.joinToString(",") }.toMap()
+      response = this,
+      exception = null
     )
   }
 }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientIntegrationTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientIntegrationTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.sdk.httpclient
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.configureFor
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import com.netflix.spinnaker.kork.plugins.api.httpclient.Request
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import okhttp3.OkHttpClient
+import strikt.api.expectThat
+import strikt.assertions.containsKey
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isNotNull
+
+class Ok3HttpClientIntegrationTest : JUnit5Minutests {
+
+  fun test() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    before {
+      wiremock.start()
+      configureFor(wiremock.port())
+      configure()
+    }
+
+    test("can read response") {
+      stubFor(get("/hello")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody("{\"message\": \"hello world!\"}")
+        ))
+
+      expectThat(subject.get(Request("helloworld", "/hello")))
+        .and {
+          get { isError }.isFalse()
+          get { statusCode }.isEqualTo(200)
+          get { headers }.and {
+            containsKey("content-type")
+            get { get("content-type") }.isEqualTo("application/json")
+          }
+          get { getBody(Response::class.java) }.and {
+            isNotNull()
+            get { message }.isEqualTo("hello world!")
+          }
+        }
+    }
+  }
+
+  private data class Response(@JsonProperty("message") val message: String)
+
+  private inner class Fixture {
+    val wiremock = WireMockServer(options().dynamicPort())
+
+    lateinit var subject: Ok3HttpClient
+
+    fun configure() {
+      subject = Ok3HttpClient(
+        "test",
+        wiremock.url(""),
+        OkHttpClient(),
+        ObjectMapper().apply {
+          registerModule(KotlinModule())
+        }
+      )
+    }
+  }
+}


### PR DESCRIPTION
Had two problems today. First, the ObjectMapper wasn't configured, oops. Second, `Ok3HttpClient` was closing responses before user-land code would have the opportunity to read response bodies, so I changed all that around.

Also added an integration test for the httpclient, since obviously the unit tests didn't catch it.