### PR TITLE
chore(GHA): sleep for 5 minutes before running bumpdeps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         draft: false
         prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
     - name: Pause before dependency bump
-      run: sleep 90
+      run: sleep 300
     - name: Trigger dependency bump workflow
       uses: peter-evans/repository-dispatch@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,64 +10,64 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: git fetch --prune --unshallow
-      # Install Java 8 for cross-compilation support. Setting it up before
-      # Java 11 means it comes later in $PATH (because of how setup-java works)
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - uses: actions/cache@v1
-        with:
-          path: ~/.gradle
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: Assemble release info
-        id: release_info
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          . .github/workflows/release_info.sh ${{ github.event.repository.name }}
-          echo ::set-output name=CHANGELOG::$(echo -e "${CHANGELOG}")
-          echo ::set-output name=SKIP_RELEASE::${SKIP_RELEASE}
-          echo ::set-output name=IS_CANDIDATE::${IS_CANDIDATE}
-      - name: Candidate build
-        if: steps.release_info.outputs.IS_CANDIDATE == 'true'
-        env:
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-          GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-        run: |
-          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
-      - name: Release build
-        if: steps.release_info.outputs.IS_CANDIDATE == 'false'
-        env:
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-          GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-        run: |
-          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
-      - name: Create release
-        if: steps.release_info.outputs.SKIP_RELEASE == 'false'
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-           tag_name: ${{ github.ref }}
-           release_name: ${{ github.event.repository.name }} ${{ github.ref }}
-           body: |
-            ${{ steps.release_info.outputs.CHANGELOG }}
-           draft: false
-           prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
-      - name: Pause before dependency bump
-        run: sleep 90
-      - name: Trigger dependency bump workflow
-        uses: peter-evans/repository-dispatch@v1
-        with:
-         token: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}
-         event-type: bump-dependencies
-         client-payload: '{"ref": "${{ github.ref }}"}'
+    - uses: actions/checkout@v2
+    - run: git fetch --prune --unshallow
+    # Install Java 8 for cross-compilation support. Setting it up before
+    # Java 11 means it comes later in $PATH (because of how setup-java works)
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - uses: actions/cache@v1
+      with:
+        path: ~/.gradle
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Assemble release info
+      id: release_info
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        . .github/workflows/release_info.sh ${{ github.event.repository.name }}
+        echo ::set-output name=CHANGELOG::$(echo -e "${CHANGELOG}")
+        echo ::set-output name=SKIP_RELEASE::${SKIP_RELEASE}
+        echo ::set-output name=IS_CANDIDATE::${IS_CANDIDATE}
+    - name: Candidate build
+      if: steps.release_info.outputs.IS_CANDIDATE == 'true'
+      env:
+        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+        BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+        GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
+      run: |
+        ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
+    - name: Release build
+      if: steps.release_info.outputs.IS_CANDIDATE == 'false'
+      env:
+        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+        BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+        GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
+      run: |
+        ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
+    - name: Create release
+      if: steps.release_info.outputs.SKIP_RELEASE == 'false'
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.event.repository.name }} ${{ github.ref }}
+        body: |
+          ${{ steps.release_info.outputs.CHANGELOG }}
+        draft: false
+        prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
+    - name: Pause before dependency bump
+      run: sleep 90
+    - name: Trigger dependency bump workflow
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}
+        event-type: bump-dependencies
+        client-payload: '{"ref": "${{ github.ref }}"}'


### PR DESCRIPTION
On the last kork bump, 4 of the 14 builds failed because the new artifact wasn't available yet. I don't think speed for the bumps is generally that critical, so let's just play it safe and use five minutes?

Aslo: fix the indentation, which was kinda all over the place in this file.