### PR TITLE
chore(test): Bump test dependencies

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -53,7 +53,7 @@ dependencies {
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
-  api(platform("org.junit:junit-bom:5.6.0"))
+  api(platform("org.junit:junit-bom:5.6.2"))
   api(platform("com.fasterxml.jackson:jackson-bom:2.10.3"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
@@ -140,7 +140,7 @@ dependencies {
     api("net.logstash.logback:logstash-logback-encoder:4.11")
     api("org.apache.commons:commons-exec:1.3")
     api("org.apache.commons:commons-lang3:3.9")
-    api("org.assertj:assertj-core:3.11.1")
+    api("org.assertj:assertj-core:3.15.0")
     api("org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}")
     api("org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}")
     api("org.codehaus.groovy:groovy-all:${versions.groovy}")


### PR DESCRIPTION
There are new versions of both junit and assertj; let's pull those in. I tested the full test suite of clouddriver and orca with these new dependencies, and all tests passed in both.