### PR TITLE
refactor(dependencies): Reduce transitive dependencies

### DIFF
--- a/kork-secrets-aws/kork-secrets-aws.gradle
+++ b/kork-secrets-aws/kork-secrets-aws.gradle
@@ -8,6 +8,8 @@ dependencies {
 
   implementation "com.amazonaws:aws-java-sdk-s3"
   implementation "com.amazonaws:aws-java-sdk-secretsmanager"
+  implementation "org.apache.commons:commons-lang3"
+  implementation "org.springframework.boot:spring-boot-autoconfigure"
 
   testImplementation "junit:junit"
   testImplementation "org.mockito:mockito-core"

--- a/kork-secrets-gcp/kork-secrets-gcp.gradle
+++ b/kork-secrets-gcp/kork-secrets-gcp.gradle
@@ -24,4 +24,6 @@ dependencies {
 
   implementation 'com.google.apis:google-api-services-storage'
   implementation 'com.google.auth:google-auth-library-oauth2-http'
+  implementation "org.springframework.boot:spring-boot-autoconfigure"
+  implementation "org.slf4j:slf4j-api"
 }

--- a/kork-secrets/kork-secrets.gradle
+++ b/kork-secrets/kork-secrets.gradle
@@ -5,14 +5,11 @@ apply from: "$rootDir/gradle/lombok.gradle"
 dependencies {
   api(platform(project(":spinnaker-dependencies")))
 
-  api "org.springframework.boot:spring-boot-autoconfigure"
-  api "com.github.ben-manes.caffeine:guava"
-  api "org.springframework.boot:spring-boot-starter-actuator"
-  api "com.netflix.spectator:spectator-ext-gc"
-  api "com.netflix.spectator:spectator-ext-jvm"
-  api "com.netflix.spectator:spectator-web-spring"
-  api "org.apache.commons:commons-lang3"
-  api "org.yaml:snakeyaml"
+  implementation "org.springframework.boot:spring-boot-autoconfigure"
+  implementation "org.springframework.boot:spring-boot-starter-actuator"
+  implementation "org.yaml:snakeyaml"
+  implementation "com.google.guava:guava"
+  implementation "org.apache.commons:commons-lang3"
 
   testImplementation "com.hubspot.jinjava:jinjava"
   testImplementation "org.spockframework:spock-core"

--- a/kork-security/kork-security.gradle
+++ b/kork-security/kork-security.gradle
@@ -8,13 +8,9 @@ dependencies {
   api project(":kork-core")
 
   api "org.springframework.security:spring-security-core"
-  api "org.codehaus.groovy:groovy-all"
-  api "com.hubspot.jinjava:jinjava"
-  api "com.fasterxml.jackson.core:jackson-core"
-  api "com.fasterxml.jackson.core:jackson-databind"
   api "com.fasterxml.jackson.core:jackson-annotations"
-  api "org.slf4j:jcl-over-slf4j"
-  api "ch.qos.logback:logback-classic"
+
+  implementation "com.google.guava:guava"
 
   testImplementation "org.spockframework:spock-core"
   testRuntimeOnly "cglib:cglib-nodep"

--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -17,11 +17,11 @@ dependencies {
     transitive = false
   }
   api "com.fasterxml.jackson.core:jackson-annotations"
-  api "com.hubspot.jinjava:jinjava"
   api "com.squareup.okhttp:okhttp"
   api "com.squareup.okhttp3:okhttp"
   api "com.squareup.retrofit:retrofit"
-  api "com.github.ben-manes.caffeine:guava"
+
+  implementation "com.google.guava:guava"
 
   compileOnly "org.springframework.boot:spring-boot-starter-actuator"
 


### PR DESCRIPTION
A number of commonly-used kork modules export their implementation dependencies as api dependencies. In cases where a depdendency is not used in the API of a module and is just an implementation detail, move it to an implementation dependency. (In some cases the dependency could be removed entirely.)

There are definitely many other places in kork where we can clean things up (reducing things on the compile path in all services) but this is just a small thing I could get done quickly.

I've already updated the microservices (or have an open PR) to explicilty add in dependencies in cases where we were depending on an accidental transitive dependency.