### PR TITLE
fix(plugins): don't blow up if plugin config does not exist and plugi…

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolver.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolver.kt
@@ -61,7 +61,7 @@ class SpringEnvironmentConfigResolver(
     .registerModules(KotlinModule())
 
   override fun <T> resolve(coordinates: ConfigCoordinates, expectedType: Class<T>): T =
-    resolveInternal(coordinates, { expectedType.newInstance() }) {
+    resolveInternal(coordinates, { mapper.convertValue(emptyMap<Any, Any>(), expectedType) }) {
       mapper.readValue(it, expectedType)
     }
 
@@ -75,7 +75,7 @@ class SpringEnvironmentConfigResolver(
         //  with HashMap instead of Map.
         throw SystemConfigException("Expected type must be a concrete class, interface given")
       }
-      type.newInstance() as T
+      mapper.convertValue(emptyMap<Any, Any>(), type)
     }) {
       mapper.readValue(it, expectedType)
     }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolverTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolverTest.kt
@@ -25,6 +25,7 @@ import java.net.URL
 import org.springframework.core.env.ConfigurableEnvironment
 import org.springframework.core.env.MapPropertySource
 import org.springframework.core.env.MutablePropertySources
+import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.assertions.hasSize
 import strikt.assertions.isA
@@ -32,6 +33,7 @@ import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
+import strikt.assertions.succeeded
 
 class SpringEnvironmentConfigResolverTest : JUnit5Minutests {
 
@@ -64,6 +66,21 @@ class SpringEnvironmentConfigResolverTest : JUnit5Minutests {
           get { somelist }.hasSize(1)
             .get { first().hello }.isEqualTo("Future Rob")
         }
+    }
+
+    test("plugin extension where config properties are not present and the config class does not have a no-arg constructor") {
+      expectCatching {
+        subject.resolve(
+          ExtensionConfigCoordinates("netflix.sweet-plugin", "config.nonexistent"),
+          MissingNoArgConstructor::class.java
+        )
+      }.succeeded()
+
+      expectThat(subject.resolve(
+        ExtensionConfigCoordinates("netflix.sweet-plugin", "config.nonexistent"),
+        MissingNoArgConstructor::class.java
+      ))
+        .isA<MissingNoArgConstructor>()
     }
 
     test("plugin extension with expanded path") {
@@ -133,6 +150,8 @@ class SpringEnvironmentConfigResolverTest : JUnit5Minutests {
     var optional: String? = null,
     var somelist: List<NestedConfig> = listOf()
   )
+
+  internal class MissingNoArgConstructor(var param: Any?)
 
   internal class NestedConfig(
     var hello: String


### PR DESCRIPTION
…n config class does not have no-args constructor.

Reasonable-looking config classes (https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/blob/master/random-wait-orca/src/main/kotlin/io/armory/plugin/stage/wait/random/RandomWaitConfig.kt) don't load if you don't specify any config.