### PR TITLE
fix(plugins): Remove state field and add preferred field on SpinnakerPluginRelease

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/internal/SpinnakerPluginInfo.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/internal/SpinnakerPluginInfo.kt
@@ -31,9 +31,5 @@ class SpinnakerPluginInfo : PluginInfo() {
     releases = spinnakerReleases
   }
 
-  data class SpinnakerPluginRelease(val state: State) : PluginRelease() {
-    enum class State {
-      CANDIDATE, RELEASE
-    }
-  }
+  data class SpinnakerPluginRelease(val preferred: Boolean) : PluginRelease()
 }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/repository/Front50UpdateRepositoryTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/repository/Front50UpdateRepositoryTest.kt
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.kork.plugins.update.repository
 import com.netflix.spinnaker.kork.plugins.update.internal.Front50Service
 import com.netflix.spinnaker.kork.plugins.update.internal.SpinnakerPluginInfo
 import com.netflix.spinnaker.kork.plugins.update.internal.SpinnakerPluginInfo.SpinnakerPluginRelease
-import com.netflix.spinnaker.kork.plugins.update.internal.SpinnakerPluginInfo.SpinnakerPluginRelease.State
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
@@ -47,14 +46,12 @@ class Front50UpdateRepositoryTest : JUnit5Minutests {
       expectThat(plugins)
         .isA<MutableMap<String, SpinnakerPluginInfo>>()[pluginId]
         .get { plugin.id }.isEqualTo(pluginId)
-        .get { plugin.getReleases()[0].state == pluginReleaseState }
 
       val plugin = subject.getPlugin(pluginId)
 
       expectThat(plugin)
         .isA<SpinnakerPluginInfo>()
         .get { plugin.id }.isEqualTo(pluginId)
-        .get { plugin.getReleases()[0].state == pluginReleaseState }
     }
 
     test("Response error results in empty plugin list") {
@@ -73,7 +70,6 @@ class Front50UpdateRepositoryTest : JUnit5Minutests {
     val pluginId = "netflix.custom-stage"
     val repositoryName = "front50"
     val front50Url = URL("https://front50.com")
-    val pluginReleaseState = State.CANDIDATE
 
     val subject = Front50UpdateRepository(
             repositoryName,
@@ -87,7 +83,7 @@ class Front50UpdateRepositoryTest : JUnit5Minutests {
     val response: Response<Collection<SpinnakerPluginInfo>> = Response.success(Collections.singletonList(plugin))
 
     init {
-      plugin.setReleases(listOf(SpinnakerPluginRelease(pluginReleaseState)))
+      plugin.setReleases(listOf(SpinnakerPluginRelease(true)))
       plugin.id = pluginId
     }
   }


### PR DESCRIPTION
Still working through some ideas of how to use this (either here in kork or just in front50), but this resolves the `MissingKotlinParameterException` on startup when front50 update repository is enabled. 