### PR TITLE
fix(plugins): Use Jackson to convert PF4J PluginInfo to SpinnakerPluginInfo

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/internal/SpinnakerPluginInfo.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/internal/SpinnakerPluginInfo.kt
@@ -31,5 +31,10 @@ class SpinnakerPluginInfo : PluginInfo() {
     releases = spinnakerReleases
   }
 
-  data class SpinnakerPluginRelease(val preferred: Boolean) : PluginRelease()
+  /**
+   * It is not guaranteed that the [org.pf4j.update.UpdateRepository] implementation returns a
+   * SpinnakerPluginInfo object.  Therefore, additional fields defined here must provide a default
+   * value.
+   */
+  data class SpinnakerPluginRelease(val preferred: Boolean = false) : PluginRelease()
 }


### PR DESCRIPTION
The cast was a poor choice - it never would succeed.  The reason we didn't see this bug is because we were only testing with front50's update repository, which returns a `SpinnakerPluginInfo` object.  This supports any PF4J compatible update repository (though the `preferred` field is only supported if using the front50 update repository).