### PR TITLE
fix(plugins): Use Jackson to convert PF4J PluginRelease to SpinnakerPluginRelease

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/LatestPluginInfoReleaseSource.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/LatestPluginInfoReleaseSource.kt
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.kork.plugins.update.release.source
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
 import com.netflix.spinnaker.kork.plugins.update.internal.SpinnakerPluginInfo
 import com.netflix.spinnaker.kork.plugins.update.release.PluginInfoRelease
@@ -44,7 +45,8 @@ class LatestPluginInfoReleaseSource(
 
     return if (latestRelease != null) {
       log.info("Latest release version '{}' for plugin '{}'", latestRelease.version, pluginInfo.id)
-      PluginInfoRelease(pluginInfo.id, latestRelease as SpinnakerPluginInfo.SpinnakerPluginRelease)
+      PluginInfoRelease(pluginInfo.id,
+        objectMapper.convertValue(latestRelease, SpinnakerPluginInfo.SpinnakerPluginRelease::class.java))
     } else {
       log.info("Latest release version not found for plugin '{}'", pluginInfo.id)
       null
@@ -56,4 +58,8 @@ class LatestPluginInfoReleaseSource(
    * [com.netflix.spinnaker.kork.plugins.update.release.provider.AggregatePluginInfoReleaseProvider]
    */
   override fun getOrder(): Int = HIGHEST_PRECEDENCE
+
+  companion object {
+    private val objectMapper = jacksonObjectMapper()
+  }
 }


### PR DESCRIPTION
I missed another bad cast (this is the last one) in `LatestPluginInfoReleaseSource`. 