### PR TITLE
refactor(security): refactor AuthenticatedRequest to support generic UserDetails

### DIFF
--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AllowedAccountsAuthorities.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AllowedAccountsAuthorities.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class AllowedAccountsAuthorities {
+  public static final String PREFIX = "ALLOWED_ACCOUNT_";
+
+  public static Collection<GrantedAuthority> getAllowedAccountAuthorities(UserDetails userDetails) {
+    if (userDetails == null
+        || userDetails.getAuthorities() == null
+        || userDetails.getAuthorities().isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    return userDetails.getAuthorities().stream()
+        .filter(a -> a.getAuthority().startsWith(PREFIX))
+        .collect(Collectors.toSet());
+  }
+
+  @SuppressWarnings("deprecation")
+  public static Collection<String> getAllowedAccounts(UserDetails userDetails) {
+    if (userDetails instanceof User) {
+      return ((User) userDetails).getAllowedAccounts();
+    }
+    return getAllowedAccountAuthorities(userDetails).stream()
+        .map(a -> a.getAuthority().substring(PREFIX.length()))
+        .sorted()
+        .collect(Collectors.toList());
+  }
+
+  public static Collection<GrantedAuthority> buildAllowedAccounts(Collection<String> accounts) {
+    if (accounts == null || accounts.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    return accounts.stream()
+        .filter(Objects::nonNull)
+        .filter(s -> !s.isEmpty())
+        .map(String::toLowerCase)
+        .map(s -> PREFIX + s)
+        .map(SimpleGrantedAuthority::new)
+        .collect(Collectors.toSet());
+  }
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java
@@ -20,7 +20,13 @@ import static java.lang.String.format;
 
 import com.google.common.base.Preconditions;
 import com.netflix.spinnaker.kork.common.Header;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.SneakyThrows;

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/User.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/User.java
@@ -29,7 +29,19 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.StringUtils;
 
-/** User implements UserDetails in order to properly hook into the Spring Security framework. */
+/**
+ * A UserDetails implementation to hook into Spring Security framework.
+ *
+ * <p>User exists to propagate the allowedAccounts.
+ *
+ * <p>This class is deprecated in favor of encoding allowed accounts as granted authorities, and
+ * using the spring frameworks built in User object and preferring the UserDetails interface when
+ * interacting.
+ *
+ * @deprecated use org.springframework.security.core.userdetails.User and AllowedAccountsAuthorities
+ *     to encode allowed accounts callers should program against UserDetails interface
+ */
+@Deprecated
 public class User implements UserDetails {
 
   public static final long serialVersionUID = 7392392099262597885L;

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/User.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/User.java
@@ -39,7 +39,8 @@ import org.springframework.util.StringUtils;
  * interacting.
  *
  * @deprecated use org.springframework.security.core.userdetails.User and AllowedAccountsAuthorities
- *     to encode allowed accounts callers should program against UserDetails interface
+ *     to encode allowed accounts callers should program against UserDetails interface use runAs on
+ *     AuthenticatedRequest to switch users rather than supplying a principal directly.
  */
 @Deprecated
 public class User implements UserDetails {

--- a/kork-security/src/test/groovy/com/netflix/spinnaker/security/AllowedAccountsAuthoritiesSpec.groovy
+++ b/kork-security/src/test/groovy/com/netflix/spinnaker/security/AllowedAccountsAuthoritiesSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security
+
+import org.hamcrest.Matchers
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import spock.lang.Specification
+
+import static com.netflix.spinnaker.security.AllowedAccountsAuthorities.PREFIX
+
+class AllowedAccountsAuthoritiesSpec extends Specification {
+  def "extracts allowed accounts from granted authorities"() {
+    expect:
+    AllowedAccountsAuthorities.getAllowedAccounts(userDetails) == expected
+
+    where:
+    userDetails               || expected
+    null                      || []
+    u("foo")                  || []
+    u("foo", ["a", "c", "b"]) || ["a", "b", "c"]
+  }
+
+  def "builds normalized granted authorities"() {
+    expect:
+    Matchers.containsInAnyOrder(expected.toArray()).matches(AllowedAccountsAuthorities.buildAllowedAccounts(accounts))
+
+    where:
+    accounts                       || expected
+    ["A", null, "", "b", "b", "C"] || [a(PREFIX + "a"), a(PREFIX + "b"), a(PREFIX + "c")]
+  }
+
+  private static GrantedAuthority a(String name) {
+    return new SimpleGrantedAuthority(name)
+  }
+
+  private static org.springframework.security.core.userdetails.User u(String name, Collection<String> accounts = []) {
+    new org.springframework.security.core.userdetails.User(name, "", accounts.collect { a(PREFIX + it) })
+  }
+}

--- a/kork-security/src/test/groovy/com/netflix/spinnaker/security/AuthenticatedRequestSpec.groovy
+++ b/kork-security/src/test/groovy/com/netflix/spinnaker/security/AuthenticatedRequestSpec.groovy
@@ -29,6 +29,7 @@ class AuthenticatedRequestSpec extends Specification {
     then:
     AuthenticatedRequest.getSpinnakerUser().get() == "spinnaker-user"
     AuthenticatedRequest.getSpinnakerUser(new User([email: "spinnaker-other"])).get() == "spinnaker-other"
+    AuthenticatedRequest.getSpinnakerUser(new org.springframework.security.core.userdetails.User("spinnaker-other", "", [])).get() == "spinnaker-other"
   }
 
   void "should extract allowed account details by priority (Principal > MDC"() {
@@ -39,6 +40,11 @@ class AuthenticatedRequestSpec extends Specification {
     then:
     AuthenticatedRequest.getSpinnakerAccounts().get() == "account1,account2"
     AuthenticatedRequest.getSpinnakerAccounts(new User(allowedAccounts: ["account3", "account4"])).get() == "account3,account4"
+    AuthenticatedRequest.getSpinnakerAccounts(
+      new org.springframework.security.core.userdetails.User(
+        "username",
+        "",
+        AllowedAccountsAuthorities.buildAllowedAccounts(["account3", "account4"]))).get() == "account3,account4"
   }
 
   void "should have no user/allowed account details if no MDC or Principal available"() {

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/filters/AuthenticatedRequestFilter.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/filters/AuthenticatedRequestFilter.groovy
@@ -17,11 +17,12 @@
 package com.netflix.spinnaker.filters
 
 import com.netflix.spinnaker.kork.common.Header
+import com.netflix.spinnaker.security.AllowedAccountsAuthorities
 import com.netflix.spinnaker.security.AuthenticatedRequest
-import com.netflix.spinnaker.security.User
 import groovy.util.logging.Slf4j
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.context.SecurityContextImpl
+import org.springframework.security.core.userdetails.UserDetails
 
 import javax.servlet.Filter
 import javax.servlet.FilterChain
@@ -78,9 +79,9 @@ class AuthenticatedRequestFilter implements Filter {
       }
 
       def principal = securityContext?.authentication?.principal
-      if (principal && principal instanceof User) {
+      if (principal && principal instanceof UserDetails) {
         spinnakerUser = principal.username
-        spinnakerAccounts = principal.allowedAccounts.join(",")
+        spinnakerAccounts = AllowedAccountsAuthorities.getAllowedAccounts(principal).join(",")
       }
     } catch (Exception e) {
       log.error("Unable to extract spinnaker user and account information", e)


### PR DESCRIPTION
deprecates User and updates interactions to support UserDetails instead of User.
adds support for encoding allowedAccounts as granted authorities