### PR TITLE
wip(models): Concept of shared models

### DIFF
--- a/kork-api/README.md
+++ b/kork-api/README.md
@@ -1,0 +1,5 @@
+# kork-api
+
+A module for shared models across the Spinnaker services.
+Most, if not all, models in this module should be represented first via protobuf in `kork-proto`:
+This module is mostly for adapting generated proto code into something easier to work with.

--- a/kork-api/kork-api.gradle
+++ b/kork-api/kork-api.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+apply from: "$rootDir/gradle/kotlin.gradle"
+
+dependencies {
+  implementation project(":kork-annotations")
+  implementation project(":kork-exceptions")
+  implementation project(":kork-proto")
+
+  implementation "com.google.protobuf:protobuf-java"
+
+  implementation "javax.validation:validation-api"
+  implementation "org.hibernate.validator:hibernate-validator"
+  implementation "com.github.zafarkhaja:java-semver:0.9.0" // BOM
+}

--- a/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/PluginInfo.kt
+++ b/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/PluginInfo.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.models
+
+import com.netflix.spinnaker.kork.models.validation.constraints.PluginId
+import com.netflix.spinnaker.kork.proto.plugins.PluginInfo as PluginInfoProto
+import java.util.SortedSet
+import javax.validation.Valid
+import javax.validation.constraints.NotEmpty
+
+/**
+ * Represents a single plugin within Spinnaker.
+ */
+interface PluginInfo : ProtoModel<PluginInfoProto> {
+  /**
+   * The plugin ID.
+   */
+  @get:PluginId
+  val id: String
+
+  /**
+   * The name of the plugin. This can be whatever meaningful name you'd like
+   * to assign it.
+   */
+  @get:NotEmpty
+  val name: String
+
+  /**
+   * A description of what the plugin does.
+   */
+  @get:NotEmpty
+  val description: String
+
+  /**
+   * Who the provider of the plugin is. This should typically be an email
+   * address that users can contact the plugin authors with.
+   */
+  @get:NotEmpty
+  val provider: String
+
+  /**
+   * The plugin homepage, or link to the plugin repository.
+   */
+  @get:NotEmpty
+  val projectUrl: String
+
+  /**
+   * A set of plugin releases, sorted by version.
+   */
+  @get:Valid
+  val releases: SortedSet<PluginRelease>
+}

--- a/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/PluginRelease.kt
+++ b/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/PluginRelease.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.models
+
+import com.netflix.spinnaker.kork.models.validation.constraints.SemVer
+import com.netflix.spinnaker.kork.proto.plugins.PluginRelease
+import java.time.Instant
+import javax.validation.constraints.NotEmpty
+
+/**
+ * Represents a single [PluginInfo]'s versioned release, including all information that may be necessary
+ * for downloading the plugin.
+ */
+interface PluginRelease : ProtoModel<PluginRelease> {
+  /**
+   * The SemVer-compatible version for the release.
+   */
+  @get:SemVer
+  val version: String
+
+  /**
+   * The date time the plugin was released.
+   */
+  val date: Instant
+
+  /**
+   * A comma-delimited list of SemVer constraint expressions.
+   */
+  @get:NotEmpty
+  val requires: String
+
+  /**
+   * The URL where the plugin release binary can be found.
+   */
+  @get:NotEmpty
+  val url: String
+
+  /**
+   * The SHA-512 checksum of the release binary.
+   */
+  @get:NotEmpty
+  val sha512sum: String
+
+  /**
+   * Designates whether or not this release is the preferred release to install.
+   */
+  val preferred: Boolean
+}

--- a/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/ProtoModel.kt
+++ b/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/ProtoModel.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.models
+
+/**
+ * A common interface for types that use an underlying proto model to convert back to the proto type.
+ *
+ * @param T The generated proto
+ */
+interface ProtoModel<T> {
+
+  /**
+   * Convert this model into the proto [T].
+   */
+  fun toProto(): T
+}

--- a/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/helpers.kt
+++ b/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/helpers.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.models
+
+import com.google.protobuf.StringValue
+import com.google.protobuf.Timestamp
+import java.time.Instant
+
+/**
+ * Converts a [Timestamp] into an [Instant].
+ */
+fun Timestamp.toInstant(): Instant =
+  Instant.ofEpochSecond(seconds, nanos.toLong())
+
+/**
+ * Converts an [Instant] into a [Timestamp].
+ */
+fun Instant.toTimestamp(): Timestamp =
+  Timestamp.newBuilder()
+    .setSeconds(epochSecond)
+    .setNanos(nano)
+    .build()
+
+/**
+ * Converts a [String] to the Nullable Type [StringValue].
+ */
+fun String.toProto(): StringValue =
+  StringValue.of(this)

--- a/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/impl/PluginInfoImpl.kt
+++ b/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/impl/PluginInfoImpl.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.models.impl
+
+import com.netflix.spinnaker.kork.models.PluginInfo
+import com.netflix.spinnaker.kork.models.PluginRelease
+import com.netflix.spinnaker.kork.models.toProto
+import com.netflix.spinnaker.kork.proto.plugins.PluginInfo as PluginInfoProto
+import java.util.SortedSet
+
+data class PluginInfoImpl(
+  override val id: String,
+  override val name: String,
+  override val description: String,
+  override val provider: String,
+  override val projectUrl: String,
+  override val releases: SortedSet<PluginRelease> = sortedSetOf()
+) : PluginInfo {
+
+  constructor(proto: PluginInfoProto) : this(
+    id = proto.id.value,
+    name = proto.name.value,
+    description = proto.description.value,
+    provider = proto.provider.value,
+    projectUrl = proto.projectUrl.value,
+    releases = proto.releasesList
+      .map { PluginReleaseImpl(it) }
+      .toSortedSet(Comparator { o1, o2 -> o1.date.compareTo(o2.date) })
+  )
+
+  override fun toProto(): PluginInfoProto =
+    PluginInfoProto.newBuilder()
+      .setId(id.toProto())
+      .setName(name.toProto())
+      .setDescription(description.toProto())
+      .setProvider(provider.toProto())
+      .setProjectUrl(projectUrl.toProto())
+      .addAllReleases(releases.map { it.toProto() })
+      .build()
+}
+
+/**
+ * Converts a [PluginInfoProto] into a [PluginInfo] model.
+ */
+fun PluginInfoProto.toModel(): PluginInfo =
+  PluginInfoImpl(this)

--- a/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/impl/PluginReleaseImpl.kt
+++ b/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/impl/PluginReleaseImpl.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.models.impl
+
+import com.netflix.spinnaker.kork.models.PluginRelease
+import com.netflix.spinnaker.kork.models.toInstant
+import com.netflix.spinnaker.kork.models.toProto
+import com.netflix.spinnaker.kork.models.toTimestamp
+import com.netflix.spinnaker.kork.proto.plugins.PluginRelease as PluginReleaseProto
+import java.time.Instant
+
+data class PluginReleaseImpl(
+  override val version: String,
+  override val date: Instant,
+  override val requires: String,
+  override val url: String,
+  override val sha512sum: String,
+  override val preferred: Boolean = false
+) : PluginRelease {
+
+  constructor(proto: PluginReleaseProto) : this(
+    version = proto.version.value,
+    date = proto.date.toInstant(),
+    requires = proto.requires.value,
+    url = proto.url.value,
+    sha512sum = proto.sha512Sum.value,
+    preferred = proto.preferred
+  )
+
+  override fun toProto(): PluginReleaseProto =
+    PluginReleaseProto.newBuilder()
+      .setVersion(version.toProto())
+      .setDate(date.toTimestamp())
+      .setRequires(requires.toProto())
+      .setUrl(url.toProto())
+      .setSha512Sum(sha512sum.toProto())
+      .setPreferred(preferred)
+      .build()
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as PluginRelease
+
+    if (version != other.version) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    return version.hashCode()
+  }
+}
+
+/**
+ * Converts a [PluginReleaseProto] into a [PluginRelease] model.
+ */
+fun PluginReleaseProto.toModel(): PluginRelease =
+  PluginReleaseImpl(this)

--- a/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/validation/PluginIdValidator.kt
+++ b/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/validation/PluginIdValidator.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.models.validation
+
+import com.netflix.spinnaker.kork.models.validation.constraints.PluginId
+import java.util.regex.Pattern
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+/**
+ * Validates that a [String] value conforms to the canonical [PluginId] format.
+ */
+class PluginIdValidator : ConstraintValidator<PluginId, String> {
+  override fun isValid(value: String, context: ConstraintValidatorContext): Boolean {
+    return pattern.matcher(value).let { matcher ->
+      if (!matcher.matches()) {
+        context
+          .buildConstraintViolationWithTemplate("Plugin IDs must follow a '{namespace}.{id}' format ($pattern)")
+          .addConstraintViolation()
+        false
+      } else {
+        true
+      }
+    }
+  }
+
+  companion object {
+    private val pattern = Pattern.compile("^(?<namespace>[\\w\\-.])+\\.(?<id>[\\w\\-]+)$")
+  }
+}

--- a/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/validation/SemVerValidator.kt
+++ b/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/validation/SemVerValidator.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.models.validation
+
+import com.github.zafarkhaja.semver.Version
+import com.netflix.spinnaker.kork.models.validation.constraints.SemVer
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+/**
+ * Validates that a version follows SemVer formatting.
+ */
+class SemVerValidator : ConstraintValidator<SemVer, String> {
+  override fun isValid(value: String, context: ConstraintValidatorContext): Boolean {
+    return try {
+      Version.valueOf(value)
+      true
+    } catch (e: Exception) {
+      context.buildConstraintViolationWithTemplate(e.message)
+        .addConstraintViolation()
+      false
+    }
+  }
+}

--- a/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/validation/constraints/PluginId.kt
+++ b/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/validation/constraints/PluginId.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.models.validation.constraints
+
+import com.netflix.spinnaker.kork.models.validation.PluginIdValidator
+import javax.validation.Constraint
+import javax.validation.Payload
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [PluginIdValidator::class])
+annotation class PluginId(
+  val message: String = "Invalid plugin ID",
+  val groups: Array<KClass<*>> = [],
+  val payload: Array<KClass<in Payload>> = []
+)

--- a/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/validation/constraints/SemVer.kt
+++ b/kork-api/src/main/kotlin/com/netflix/spinnaker/kork/models/validation/constraints/SemVer.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.models.validation.constraints
+
+import com.netflix.spinnaker.kork.models.validation.SemVerValidator
+import javax.validation.Constraint
+import javax.validation.Payload
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [SemVerValidator::class])
+annotation class SemVer(
+  val message: String = "Version is not a valid SemVer",
+  val groups: Array<KClass<*>> = [],
+  val payload: Array<KClass<in Payload>> = []
+)

--- a/kork-core/kork-core.gradle
+++ b/kork-core/kork-core.gradle
@@ -7,7 +7,9 @@ dependencies {
   implementation project(":kork-exceptions")
 
   api project(":kork-annotations")
+  api project(":kork-api")
   api project(":kork-exceptions")
+
   api "org.springframework.boot:spring-boot-autoconfigure"
   api "org.springframework.boot:spring-boot-starter-aop"
   api "org.springframework.boot:spring-boot-starter-actuator"

--- a/kork-proto/kork-proto.gradle
+++ b/kork-proto/kork-proto.gradle
@@ -7,6 +7,7 @@ dependencies {
   api(platform(project(":spinnaker-dependencies")))
 
   implementation "com.google.protobuf:protobuf-java"
+  implementation "com.google.api.grpc:proto-google-common-protos:1.3.0"
 }
 
 protobuf {

--- a/kork-proto/src/main/proto/plugins/plugininfo.proto
+++ b/kork-proto/src/main/proto/plugins/plugininfo.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package io.spinnaker.proto.plugins;
+
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "com.netflix.spinnaker.kork.proto.plugins";
+option java_outer_classname = "SpinnakerProto";
+option java_multiple_files = true;
+
+message PluginInfo {
+  string id = 1;
+  string name = 2;
+  string description = 3;
+  string provider = 4;
+  string projectUrl = 5;
+  repeated PluginRelease releases = 6;
+}
+
+message PluginRelease {
+  string version = 1;
+  google.protobuf.Timestamp date = 2;
+  string requires = 3;
+  string url = 4;
+  string sha512sum = 5;
+  bool preferred = 6;
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,7 @@ if (spinnakerGradleVersion.endsWith('-SNAPSHOT')) {
 include(
   "spinnaker-dependencies",
   "kork-annotations",
+  "kork-api",
   "kork-artifacts",
   "kork-aws",
   "kork-bom",


### PR DESCRIPTION
Proofing out shared models.

The problem that I'm trying to solve for is that we have _basically_ the same model definitions in each service for various models. These models typically drift a little bit from each other, or worse, are just represented as haphazard, recursive `M<S, O>` objects. These models are strewn about our various services, written slightly differently, represented with slightly different (and sometimes incompatible) types that need service-to-service massaging. It's a time vampire.

This PR targets just `PluginInfo` and `PluginRelease`, which are used by kork as well as gate, front50, orca, echo and igor.

This PR has two parts:

1. All models are firstly defined as protos in `kork-proto`. These models would also be sent across the wire as binary (we can just use `jackson-datatype-binary` for this purpose without going full-in on gRPC yet). Any shared model that is going across the wire *MUST* be defined as a proto.
1. A `kork-api` module that depends on `kork-proto`, which wraps defined protos in models that are more ergonomic. This module also defines any and all common validation for these models' fields. Like any other `-api` module, dependencies added to this module should be limited.

Each service is bound to have its own data that it needs to add to a model, which can be done via decoration:

```kotlin
class PluginInfo // from kork-api

class Front50PluginInfo(
  private val korkPluginInfo: PluginInfo, 
  val myAdditionalData: Any
) : PluginInfo by korkPluginInfo
```

Notes:

- I chose Kotlin for this adventure because it's a hell of a lot easier to write and read than Java. Choosing Kotlin would be a total lean-in on Kotlin (since we'd be exposing it as an API). Do we want to risk this dependency? I suspect `kork-api` would find its way into all `service-api` modules at some point or another.
- I'm currently of the mind that each service should define its own protos and models for domains it owns. This PR is in kork because kork owns the plugin codebase: It's not an endorsement for co-locating all models into kork. Is this something we want? Advantage of everything in kork is that dependency bumps are more easily managed, which is not something to disregard...

Future enhancements:

- Documentation generator: Dokka export to Jekyll format and commit into `developer.spinnaker.github.io` repository under a `kork` sub-path. Other services would publish their own `-api` modules here in their own namespaced section. This would be fairly straight forward to do with Github Actions.

**Is this something that we want**