### PR TITLE
fix(kork-spring-api): explicitly depend on spinnaker-dependencies

### DIFF
--- a/kork-plugins-spring-api/kork-plugins-spring-api.gradle
+++ b/kork-plugins-spring-api/kork-plugins-spring-api.gradle
@@ -18,6 +18,8 @@ apply plugin: "java-library"
 apply from: "${project.rootDir}/gradle/kotlin-test.gradle"
 
 dependencies {
+  implementation(platform(project(":spinnaker-dependencies")))
+
   api project(":kork-plugins-api")
   api "org.springframework.boot:spring-boot-starter"
 


### PR DESCRIPTION
After https://github.com/spinnaker/spinnaker-gradle-project/pull/135, I can't depend on `kork-plugins-spring-api` from my plugin because it doesn't know how to resolve the version for `spring-boot-starter`. 

I think the package was previously pulling it transitively from `kork-plugins-api` but can no longer do so because of the gradle plugin change. @cfieber ?

In any case this package should probably depend on spinnaker-dependencies explicitly.