### PR TITLE
fix(misc): Upgrade okhttp3 client lib

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -14,7 +14,7 @@ ext {
     jschAgentProxy : "0.0.9",
     protobuf       : "3.9.1",
     okhttp         : "2.7.0",
-    okhttp3        : "3.14.2",
+    okhttp3        : "3.14.9",
     resilience4j   : "1.0.0",
     retrofit       : "1.9.0",
     retrofit2      : "2.8.1",


### PR DESCRIPTION
Bumping to latest version of OkHttp3 to resolve platform-specific TLS bugs.