### PR TITLE
refactor(artifacts): Improve null-safety of Artifact class

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -21,16 +21,21 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.common.base.Strings;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import java.util.Optional;
+import javax.annotation.ParametersAreNullableByDefault;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Data
-@Builder(toBuilder = true)
+@Getter
+@ToString
+@EqualsAndHashCode
+@NonnullByDefault
 @JsonDeserialize(builder = Artifact.ArtifactBuilder.class)
 public class Artifact {
   @JsonProperty("type")
@@ -62,6 +67,99 @@ public class Artifact {
 
   @JsonProperty("uuid")
   private String uuid;
+
+  @Builder(toBuilder = true)
+  @ParametersAreNullableByDefault
+  private Artifact(
+      String type,
+      boolean customKind,
+      String name,
+      String version,
+      String location,
+      String reference,
+      Map<String, Object> metadata,
+      String artifactAccount,
+      String provenance,
+      String uuid) {
+    this.type = Strings.nullToEmpty(type);
+    this.customKind = customKind;
+    this.name = Strings.nullToEmpty(name);
+    this.version = Strings.nullToEmpty(version);
+    this.location = Strings.nullToEmpty(location);
+    this.reference = Strings.nullToEmpty(reference);
+    this.metadata = Optional.ofNullable(metadata).orElseGet(HashMap::new);
+    this.artifactAccount = Strings.nullToEmpty(artifactAccount);
+    this.provenance = Strings.nullToEmpty(provenance);
+    this.uuid = Strings.nullToEmpty(uuid);
+  }
+
+  // All setters for this class are deprecated. In general, artifacts are passed around the pipeline
+  // context and are liberally serialized and deserialized, which makes mutating them fraught with
+  // peril (because you might or might not actually be operating on a copy of the artifact you
+  // actually want to mutate). In order to remove this cause of subtle bugs, this class will soon
+  // become immutable and these setters will be removed.
+
+  // The encouraged pattern for adding a field to an artifact is:
+  // Artifact newArtifact = artifact.toBuilder().artifactAccount("my-account").build()
+
+  @Deprecated
+  @ParametersAreNullableByDefault
+  public void setType(String type) {
+    this.type = Strings.nullToEmpty(type);
+  }
+
+  @Deprecated
+  public void setCustomKind(boolean customKind) {
+    this.customKind = customKind;
+  }
+
+  @Deprecated
+  @ParametersAreNullableByDefault
+  public void setName(String name) {
+    this.name = Strings.nullToEmpty(name);
+  }
+
+  @Deprecated
+  @ParametersAreNullableByDefault
+  public void setVersion(String version) {
+    this.version = Strings.nullToEmpty(version);
+  }
+
+  @Deprecated
+  @ParametersAreNullableByDefault
+  public void setLocation(String location) {
+    this.location = Strings.nullToEmpty(location);
+  }
+
+  @Deprecated
+  @ParametersAreNullableByDefault
+  public void setReference(String reference) {
+    this.reference = Strings.nullToEmpty(reference);
+  }
+
+  @Deprecated
+  @ParametersAreNullableByDefault
+  public void setMetadata(Map<String, Object> metadata) {
+    this.metadata = Optional.ofNullable(metadata).orElseGet(HashMap::new);
+  }
+
+  @Deprecated
+  @ParametersAreNullableByDefault
+  public void setArtifactAccount(String artifactAccount) {
+    this.artifactAccount = Strings.nullToEmpty(artifactAccount);
+  }
+
+  @Deprecated
+  @ParametersAreNullableByDefault
+  public void setProvenance(String provenance) {
+    this.provenance = Strings.nullToEmpty(provenance);
+  }
+
+  @Deprecated
+  @ParametersAreNullableByDefault
+  public void setUuid(String uuid) {
+    this.uuid = Strings.nullToEmpty(uuid);
+  }
 
   @JsonIgnoreProperties("kind")
   @JsonPOJOBuilder(withPrefix = "")

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -36,7 +36,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 @NonnullByDefault
 @JsonDeserialize(builder = Artifact.ArtifactBuilder.class)
-public class Artifact {
+public final class Artifact {
   private String type;
   private boolean customKind;
   private String name;

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -144,14 +144,11 @@ public class Artifact {
   @JsonIgnoreProperties("kind")
   @JsonPOJOBuilder(withPrefix = "")
   public static class ArtifactBuilder {
-    private Map<String, Object> metadata;
+    private Map<String, Object> metadata = new HashMap<>();
 
     // Add extra, unknown data to the metadata map:
     @JsonAnySetter
     public void putMetadata(String key, Object value) {
-      if (metadata == null) {
-        metadata = new HashMap<>();
-      }
       metadata.put(key, value);
     }
   }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -63,17 +63,6 @@ public class Artifact {
   @JsonProperty("uuid")
   private String uuid;
 
-  // This function existed to support deserialization; now that deserialization uses the inner
-  // builder class, we no longer need to support it on the outer class.  This function will be
-  // removed in a future release of kork.
-  @Deprecated
-  public void putMetadata(String key, Object value) {
-    if (metadata == null) {
-      metadata = new HashMap<>();
-    }
-    metadata.put(key, value);
-  }
-
   @JsonIgnoreProperties("kind")
   @JsonPOJOBuilder(withPrefix = "")
   public static class ArtifactBuilder {

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.kork.artifacts.model;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.base.Strings;
@@ -38,34 +37,15 @@ import lombok.ToString;
 @NonnullByDefault
 @JsonDeserialize(builder = Artifact.ArtifactBuilder.class)
 public class Artifact {
-  @JsonProperty("type")
   private String type;
-
-  @JsonProperty("customKind")
   private boolean customKind;
-
-  @JsonProperty("name")
   private String name;
-
-  @JsonProperty("version")
   private String version;
-
-  @JsonProperty("location")
   private String location;
-
-  @JsonProperty("reference")
   private String reference;
-
-  @JsonProperty("metadata")
   private Map<String, Object> metadata;
-
-  @JsonProperty("artifactAccount")
   private String artifactAccount;
-
-  @JsonProperty("provenance")
   private String provenance;
-
-  @JsonProperty("uuid")
   private String uuid;
 
   @Builder(toBuilder = true)

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -18,17 +18,16 @@ package com.netflix.spinnaker.kork.artifacts.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import javax.annotation.ParametersAreNullableByDefault;
 import lombok.Builder;
 import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder(toBuilder = true)
 @JsonDeserialize(builder = ExpectedArtifact.ExpectedArtifactBuilder.class)
 @NonnullByDefault
 @Value
@@ -39,6 +38,24 @@ public final class ExpectedArtifact {
   @Nullable private final Artifact defaultArtifact;
   private final String id; // UUID to use this ExpectedArtifact by reference in Pipelines.
   @Nullable private final Artifact boundArtifact;
+
+  @Builder(toBuilder = true)
+  @ParametersAreNullableByDefault
+  private ExpectedArtifact(
+      Artifact matchArtifact,
+      boolean usePriorArtifact,
+      boolean useDefaultArtifact,
+      Artifact defaultArtifact,
+      String id,
+      Artifact boundArtifact) {
+    this.matchArtifact =
+        Optional.ofNullable(matchArtifact).orElseGet(() -> Artifact.builder().build());
+    this.usePriorArtifact = usePriorArtifact;
+    this.useDefaultArtifact = useDefaultArtifact;
+    this.defaultArtifact = defaultArtifact;
+    this.id = Strings.nullToEmpty(id);
+    this.boundArtifact = boundArtifact;
+  }
 
   /**
    * Decide if the "matchArtifact" matches the incoming artifact. Any fields not specified in the

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNullableByDefault;
 import lombok.Builder;
 import lombok.Value;
-import org.apache.commons.lang3.StringUtils;
 
 @JsonDeserialize(builder = ExpectedArtifact.ExpectedArtifactBuilder.class)
 @NonnullByDefault
@@ -100,8 +99,8 @@ public final class ExpectedArtifact {
     return true;
   }
 
-  private boolean matches(@Nullable String us, @Nullable String other) {
-    return StringUtils.isEmpty(us) || (other != null && patternMatches(us, other));
+  private boolean matches(String us, String other) {
+    return us.isEmpty() || patternMatches(us, other);
   }
 
   private boolean patternMatches(String us, String other) {


### PR DESCRIPTION
* fix(artifacts): Improve null safety of expected artifact 

  The ExpectedArtifact class is annotated such that id and matchArtifact are not null, but this is not actually enforced anywhere.

  First, explicitly write out the AllArgsConstructor that was generated by lombok, and move the Builder annotation to it (so the builder uses that constructor when finally creating the object).

  Then update the constructor to have a ParametersAreNullable annotation as we can't control what gets passed to the constructor, and handle when we are passed a null id or matchArtifact.

  For the id case, we'll just translate to an empty string. For the matchArtifact case, we'll create an empty matchArtifact. As the point of a matchArtifact is to contain filters that determine whether a given artifact matches this expected artifact; by defaulting to no filters seems like a reasonable behavior here.

* refactor(artifacts): Remove deprecated putMetadata 

  Last time I updated this class (a few months ago) I added the Deprecated annotation to this function, which is not used anywhere in Spinnaker. Removing it now.

* refactor(artifacts): Improve null-safety of Artifact class 

  The Artifact class contains a number of strings that are often null. To make the class more null-safe, annotate it with NonnullByDefault and translate any null values into the empty string in the constructor and in setters.

  In order to do this null -> empty translation, we need to explicitly write out the constructor and the setters that were generated by lombok.

  We rarely mutate artifacts; when we do it often leads to confusing and fragile logic because we often pass these many levels down in the call stack, and also sometimes convert to/from Map<> meaning that it's not always clear if you're operating on the same artifact or a copy. To greatly simplify this, I'd like to make this class immutable. Based on my analysis of where we mutate artifacts, the few places can all be replaced by either (1) fully specifying the artifact up-front or
  (2) returning a copy of the artifact with the desired mutations.

  To start this process of making Artifact immutable, I've annotated all of the setters as Deprecated. Once all of the places where we call these are updated, I'll come back and actually remove the setters.

* refactor(artifacts): Remove redundant JsonProperty 

  These are just explicitly specifying the default values (and in any case we're using the builder to deserialize).

* refactor(artifacts): Clean up metadata creation 

  This is a tiny refactor to simplify creating the metadata in an Artifact builder; rather than check if the Map is null every time we add a key, just initialize it.

* refactor(artifacts): Make Artifact final

  If we want the class to truly be immutable in the future, it will need to be final. We don't currently extend this anywhere, so let's make it final.