### PR TITLE
fix(artifacts): Fix incorrect non-null annotation

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -20,12 +20,12 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.netflix.spinnaker.kork.annotations.MethodsReturnNonnullByDefault;
 import com.netflix.spinnaker.kork.annotations.NullableByDefault;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNullableByDefault;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -49,7 +49,6 @@ public final class Artifact {
   private String uuid;
 
   @Builder(toBuilder = true)
-  @ParametersAreNullableByDefault
   private Artifact(
       String type,
       boolean customKind,
@@ -134,6 +133,7 @@ public final class Artifact {
 
   @JsonIgnoreProperties("kind")
   @JsonPOJOBuilder(withPrefix = "")
+  @MethodsReturnNonnullByDefault
   public static class ArtifactBuilder {
     @Nonnull private Map<String, Object> metadata = new HashMap<>();
 

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -139,8 +139,9 @@ public final class Artifact {
 
     // Add extra, unknown data to the metadata map:
     @JsonAnySetter
-    public void putMetadata(String key, Object value) {
+    public ArtifactBuilder putMetadata(String key, Object value) {
       metadata.put(key, value);
+      return this;
     }
   }
 }


### PR DESCRIPTION
* fix(artifacts): Fix incorrect non-null annotation

  Adding NullableByDefault to the Artifact class is also marking the builder methods as Nullable which is incorrect, and annoying as the generaly pattern is to chain calls. This is causing all calls like Artifact.builder().name("abc").build() to have every call in the chain be highlighted by editors that are aware of these annotations.

  Add a MethodsReturnNonnullByDefault to the builder class, as it will always return non-null from its methods. (Also remove the ParametersAreNullableByDefault that is implied by the top-level annotation on the class.)

* fix(artifacts): Return this from builder putMetadata

  This is a minor improvement to the builder API; all the auto-generated builder functions return this so you can chain them, but I forgot to do this for putMetadata.