### PR TITLE
fix(artifacts): Fix non-null annotation

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -114,6 +115,25 @@ public final class Artifact {
   @Deprecated
   public void setMetadata(Map<String, Object> metadata) {
     this.metadata = Optional.ofNullable(metadata).orElseGet(HashMap::new);
+  }
+
+  /**
+   * This function is deprecated in favor of using {@link Artifact#getMetadata(String)} to get the
+   * particular key of interest.
+   *
+   * <p>The reason is that we would like the metadata to be (at least shallowly) immutable, and it
+   * is much easier to safely enforce that by avoiding giving callers access to the raw map in the
+   * first place.
+   */
+  @Deprecated
+  @Nonnull
+  public Map<String, Object> getMetadata() {
+    return metadata;
+  }
+
+  @Nullable
+  public Object getMetadata(String key) {
+    return metadata.get(key);
   }
 
   @Deprecated

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.netflix.spinnaker.kork.annotations.FieldsAreNullableByDefault;
 import com.netflix.spinnaker.kork.annotations.MethodsReturnNonnullByDefault;
-import com.netflix.spinnaker.kork.annotations.NullableByDefault;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -34,7 +34,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @EqualsAndHashCode
-@NullableByDefault
+@FieldsAreNullableByDefault
 @JsonDeserialize(builder = Artifact.ArtifactBuilder.class)
 public final class Artifact {
   private String type;

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ArtifactTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ArtifactTest.java
@@ -21,9 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -57,7 +54,7 @@ final class ArtifactTest {
         ImmutableMap.<String, String>builder().put("id", "123").put("name", "my-artifact").build();
 
     Artifact deserializedArtifact = objectMapper.convertValue(originalArtifact, Artifact.class);
-    assertThat(deserializedArtifact.getMetadata()).containsEntry("id", "123");
+    assertThat(deserializedArtifact.getMetadata("id")).isEqualTo("123");
   }
 
   @Test
@@ -69,8 +66,6 @@ final class ArtifactTest {
             .build();
 
     Artifact deserializedArtifact = objectMapper.convertValue(originalArtifact, Artifact.class);
-    Map<String, Object> metadata =
-        Optional.ofNullable(deserializedArtifact.getMetadata()).orElseGet(HashMap::new);
-    assertThat(metadata).doesNotContainKey("kind");
+    assertThat(deserializedArtifact.getMetadata("kind")).isNull();
   }
 }


### PR DESCRIPTION
There's still one annoying thing that I didn't properly fix in the last commit. Because the whole Artifact class is annotated as NullableByDefault, we get a warning every time we call .toBuilder() which *is* guaranteed to return non-null. We can't directly annotate it as it's generated by Lombok; let's fix this by using FieldsAreNullableByDefault so that it doesn't affect method values.

At first I wanted to affect method return values because the fact that the fields are nullable means the accessors are also nullable. But after testing, marking the fields as Nullable does cause the lombok-generated accessors to be marked nullable, so marking the fields nullable is enough.