### PR TITLE
fix(artifacts): Ensure consistent serialization

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.kork.artifacts.model;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.netflix.spinnaker.kork.annotations.FieldsAreNullableByDefault;
 import com.netflix.spinnaker.kork.annotations.MethodsReturnNonnullByDefault;
@@ -37,6 +38,8 @@ import lombok.ToString;
 @EqualsAndHashCode
 @FieldsAreNullableByDefault
 @JsonDeserialize(builder = Artifact.ArtifactBuilder.class)
+// Use camelCase regardless of the ObjectMapper configuration. (Detailed comment in ArtifactTest.)
+@JsonNaming
 public final class Artifact {
   private String type;
   private boolean customKind;
@@ -154,6 +157,7 @@ public final class Artifact {
   @JsonIgnoreProperties("kind")
   @JsonPOJOBuilder(withPrefix = "")
   @MethodsReturnNonnullByDefault
+  @JsonNaming
   public static class ArtifactBuilder {
     @Nonnull private Map<String, Object> metadata = new HashMap<>();
 


### PR DESCRIPTION
The earlier commit to remove the (at one time thought superfluous) JsonProperty annotations broke the Bake manifest workflow.

This is because when preparing a Bake request, orca uses an ObjectMapper configured to use snake_case. Rosco does not always use a similarly-configured ObjectMapper to deserialize (at least in bake manifest workflows where artifacts are important). This meant that orca was serializing artifacts in snake_case, but rosco was deserializing expecting camelCase.

Probably this is something that should be addressed in and of itself, but it will probably be difficult to find all workflows where we are using a differently-configured ObjectMapper on an artifact given they are ubiquitous across our microservices. Thus to fix the issue, let's just restore the earlier behavior which is that artifacts have a well-defined set of JSON property names independent of the ObjectMapper, and add tests to enforce that. In particular, add a test that serializes with a snake_case ObjectMapper and deserialized with a camelCase one, to replicate the exact bug.

Instead of individually annotating all properties, we can just annotate the class and the builder with JsonNaming, which set the naming strategy to the default of camelCase. (Annotating Artifact affects serialization, and annotating ArtifactBuidler affects deserialization.)