### PR TITLE
fix(artifacts): Fix NPE deserializing artifacts

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -161,6 +161,11 @@ public final class Artifact {
   public static class ArtifactBuilder {
     @Nonnull private Map<String, Object> metadata = new HashMap<>();
 
+    public Artifact.ArtifactBuilder metadata(@Nullable Map<String, Object> metadata) {
+      this.metadata = Optional.ofNullable(metadata).orElseGet(HashMap::new);
+      return this;
+    }
+
     // Add extra, unknown data to the metadata map:
     @JsonAnySetter
     public ArtifactBuilder putMetadata(String key, Object value) {

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ArtifactTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ArtifactTest.java
@@ -203,6 +203,15 @@ final class ArtifactTest {
     assertThat(testData).isEqualTo(ImmutableMap.of("nested", "abc"));
   }
 
+  @Test
+  void deserializeNullMetadata() throws IOException {
+    String json = jsonFactory.objectNode().set("metadata", jsonFactory.nullNode()).toString();
+
+    // Ensure that there is no exception reading an artifact with null metadata.
+    Artifact artifact = objectMapper.readValue(json, Artifact.class);
+    assertThat(artifact.getMetadata("abc")).isNull();
+  }
+
   private String fullArtifactJson() {
     return jsonFactory
         .objectNode()


### PR DESCRIPTION
It turns out that the Nonnull annotation I added to metadata caused lombok to insert an overzealous null-check in the .metdata() function in the artifact builder, which breaks deserializing artifacts with the metadata explicitly set to null.

Let's explicitly write out the Lombok-generated function, and instead of throwing an NPE, just translate the null value to an empty Hashmap.

The added test failed before this change and passes after.