### PR TITLE
chore(moniker): Allow for moniker autobumps

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 kotlinVersion=1.3.72
 org.gradle.parallel=true
 spinnakerGradleVersion=8.1.1
+monikerVersion=0.3.3

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -87,7 +87,7 @@ dependencies {
     api("com.netflix.spectator:spectator-web-spring:${versions.spectator}")
     api("com.netflix.spectator:spectator-reg-micrometer:${versions.spectator}")
     api("com.netflix.spinnaker.embedded-redis:embedded-redis:0.8.0")
-    api("com.netflix.spinnaker.moniker:moniker:0.3.3")
+    api("com.netflix.spinnaker.moniker:moniker:$monikerVersion")
     api("com.nhaarman.mockitokotlin2:mockito-kotlin:1.5.0")
     api("com.nhaarman:mockito-kotlin:1.5.0")
     api("com.ninja-squad:springmockk:2.0.1")


### PR DESCRIPTION
Looks like everyone just gets this dependency from kork. I guess we can't really do this with `fiatVersion`, since it would be a circular dependency...

So it's kinda weird that this is different than how we handle all the other cross-repo dependencies, but I'm inclined to leave it. What do you think?