### PR TITLE
Avoid trying to truncate DB views

### DIFF
--- a/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
+++ b/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
@@ -197,7 +197,8 @@ public class SqlTestUtil {
     context.meta().getTables().stream()
         .filter(
             table ->
-                table.getSchema().getName().equals(schema)
+                table.getType().isTable()
+                    && table.getSchema().getName().equals(schema)
                     && !table.getName().equals(configuration.getDatabaseChangeLogTableName())
                     && !table.getName().equals(configuration.getDatabaseChangeLogLockTableName()))
         .forEach(


### PR DESCRIPTION
Turns out `DatabaseMetadata.getTables()` will include views as well as tables. If you then try to truncate those, it esplode.