### PR TITLE
chore(aws): bump aws-sdk version to 1.11.802

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -6,7 +6,7 @@ javaPlatform {
 
 ext {
   versions = [
-    aws            : "1.11.764",
+    aws            : "1.11.802",
     bouncycastle   : "1.61",
     groovy         : "2.5.11", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
     jsch           : "0.1.54",


### PR DESCRIPTION
Updating the aws-sdk version to use 1.11.802 to support new ecs task definition properties using the latest aws-sdk-java version as per https://github.com/aws/aws-sdk-java/releases

**Note: Do not merge until https://github.com/Netflix/AWSObjectMapper/pull/86 has been released**