### PR TITLE
refactor(artifacts): Shallow copy artifact metadata

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/Artifact.java
@@ -70,7 +70,9 @@ public final class Artifact {
     this.version = version;
     this.location = location;
     this.reference = reference;
-    this.metadata = Optional.ofNullable(metadata).orElseGet(HashMap::new);
+    // Shallow copy the metadata map so changes to the input map after creating the artifact
+    // don't affect its metadata.
+    this.metadata = Optional.ofNullable(metadata).map(HashMap::new).orElseGet(HashMap::new);
     this.artifactAccount = artifactAccount;
     this.provenance = provenance;
     this.uuid = uuid;
@@ -161,7 +163,7 @@ public final class Artifact {
   public static class ArtifactBuilder {
     @Nonnull private Map<String, Object> metadata = new HashMap<>();
 
-    public Artifact.ArtifactBuilder metadata(@Nullable Map<String, Object> metadata) {
+    public ArtifactBuilder metadata(@Nullable Map<String, Object> metadata) {
       this.metadata = Optional.ofNullable(metadata).orElseGet(HashMap::new);
       return this;
     }

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ArtifactTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ArtifactTest.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 
@@ -210,6 +212,23 @@ final class ArtifactTest {
     // Ensure that there is no exception reading an artifact with null metadata.
     Artifact artifact = objectMapper.readValue(json, Artifact.class);
     assertThat(artifact.getMetadata("abc")).isNull();
+  }
+
+  @Test
+  void immutableMetadata() throws IOException {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("key1", "before");
+
+    Artifact artifact = Artifact.builder().metadata(metadata).build();
+
+    assertThat(artifact.getMetadata("key1")).isEqualTo("before");
+    assertThat(artifact.getMetadata("key2")).isNull();
+
+    metadata.put("key1", "after");
+    metadata.put("key2", "something");
+
+    assertThat(artifact.getMetadata("key1")).isEqualTo("before");
+    assertThat(artifact.getMetadata("key2")).isNull();
   }
 
   private String fullArtifactJson() {


### PR DESCRIPTION
As part of making Artifact immutable, we also want to make the contents of metadata shallowly immutable.  (We can't enforce deep immutability as it can contain arbitrary Objects.)

We've already deprecated (and removed from calling code) any way for consumers to directly modify the metadata map (or even for them to know that we are storing this as a Map).

That being said, there is still the loophole of clients passing in a Map, then keeping around a reference and modifying it. Let's close that loophole my making a shallow copy of the map before storing it on the Artifact.

Also, remove an unecessary qualified reference to Artifact.ArtifactBuilder.