### PR TITLE
fix(misc): Move to new client provider for plugin downloads

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/Front50PluginsConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/Front50PluginsConfiguration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.module.kotlin.KotlinModule;
 import com.netflix.spinnaker.config.PluginsConfigurationProperties.PluginRepositoryProperties;
+import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.kork.plugins.update.EnvironmentServerGroupLocationResolver;
 import com.netflix.spinnaker.kork.plugins.update.EnvironmentServerGroupNameResolver;
 import com.netflix.spinnaker.kork.plugins.update.ServerGroupLocationResolver;
@@ -76,13 +77,13 @@ public class Front50PluginsConfiguration {
   @Bean
   public static Front50FileDownloader front50FileDownloader(
       Environment environment,
-      PluginOkHttpClientProvider pluginsOkHttpClientProvider,
+      OkHttpClientProvider okHttpClientProvider,
       Map<String, PluginRepositoryProperties> pluginRepositoriesConfig) {
     PluginRepositoryProperties front50RepositoryProps =
         pluginRepositoriesConfig.get(PluginsConfigurationProperties.FRONT5O_REPOSITORY);
 
     URL front50Url = getFront50Url(environment, front50RepositoryProps);
-    return new Front50FileDownloader(pluginsOkHttpClientProvider.getOkHttpClient(), front50Url);
+    return new Front50FileDownloader(okHttpClientProvider, front50Url);
   }
 
   @Bean

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/Front50FileDownloader.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/Front50FileDownloader.kt
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.kork.plugins.update.downloader
 
+import com.netflix.spinnaker.config.DefaultServiceEndpoint
+import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import io.github.resilience4j.retry.Retry
 import java.net.URL
@@ -28,12 +30,14 @@ import okhttp3.Request
  * Downloads plugin binaries from Front50.
  */
 class Front50FileDownloader(
-  private val okHttpClient: OkHttpClient,
+  private val okHttpClientProvider: OkHttpClientProvider,
   private val front50BaseUrl: URL
 ) : SupportingFileDownloader {
 
   override fun supports(url: URL): Boolean =
     url.host == front50BaseUrl.host
+
+  private val okHttpClient: OkHttpClient = okHttpClientProvider.getClient(DefaultServiceEndpoint("front50", front50BaseUrl.toString()))
 
   override fun downloadFile(fileUrl: URL): Path {
     val request = Request.Builder()

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/Front50FileDownloaderTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/Front50FileDownloaderTest.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.kork.plugins.update.downloader
 
+import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
@@ -57,15 +58,16 @@ class Front50FileDownloaderTest : JUnit5Minutests {
   }
 
   private inner class Fixture {
+    private val okHttpClientProvider: OkHttpClientProvider = mockk(relaxed = true)
     private val okHttpClient: OkHttpClient = mockk(relaxed = true)
     private val call: Call = mockk(relaxed = true)
     val response: Response = mockk(relaxed = true)
-
-    val subject: Front50FileDownloader = Front50FileDownloader(okHttpClient, URL("https://front50.com"))
-
+    val subject: Front50FileDownloader
     init {
       every { okHttpClient.newCall(any()) } returns call
+      every { okHttpClientProvider.getClient(any()) } returns okHttpClient
       every { call.execute() } returns response
+      subject = Front50FileDownloader(okHttpClientProvider, URL("http://front50.com"))
     }
   }
 }


### PR DESCRIPTION
- Set Front50 plugin downloader to use new provider implementation that allows us to swap underlying clients to custom impls. 