### PR TITLE
fix(plugins): Lookup method from target class when instrumenting extension point method invocation with timing metric

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/MetricInvocationAspect.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/MetricInvocationAspect.kt
@@ -121,7 +121,7 @@ class MetricInvocationAspect(
     if (!MethodInstrumentation.isMethodAllowed(method)) {
       return null
     } else {
-      return this.get(method) { m ->
+      return this.get(target.javaClass.getMethod(method.name, *method.parameterTypes)) { m ->
         m.declaredAnnotations
           .find { it is Metered }
           .let { metered ->

--- a/kork-telemetry/src/main/java/com/netflix/spinnaker/kork/telemetry/MethodInstrumentation.java
+++ b/kork-telemetry/src/main/java/com/netflix/spinnaker/kork/telemetry/MethodInstrumentation.java
@@ -35,7 +35,7 @@ public class MethodInstrumentation {
     return
     // Only instrument public methods
     Modifier.isPublic(method.getModifiers())
-        ||
+        &&
         // Ignore any methods from the root Object class
         Arrays.stream(Object.class.getDeclaredMethods())
             .noneMatch(m -> m.getName().equals(method.getName()));


### PR DESCRIPTION
Typically the concrete target class will not be invoked directly, instead the invocation will occur on the type (like `Task#execute` for example) -- in that instance we would fail to lookup the `Metered` annotation because the interface/abstract class methods do not and should not contain the `Metered` annotation. 