### PR TITLE
fix(naming): use better naming for expressions allow list

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
@@ -19,11 +19,11 @@ package com.netflix.spinnaker.kork.expressions;
 import static java.lang.String.format;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.kork.expressions.whitelisting.FilteredMethodResolver;
-import com.netflix.spinnaker.kork.expressions.whitelisting.FilteredPropertyAccessor;
-import com.netflix.spinnaker.kork.expressions.whitelisting.MapPropertyAccessor;
-import com.netflix.spinnaker.kork.expressions.whitelisting.ReturnTypeRestrictor;
-import com.netflix.spinnaker.kork.expressions.whitelisting.WhitelistTypeLocator;
+import com.netflix.spinnaker.kork.expressions.allowlist.AllowListTypeLocator;
+import com.netflix.spinnaker.kork.expressions.allowlist.FilteredMethodResolver;
+import com.netflix.spinnaker.kork.expressions.allowlist.FilteredPropertyAccessor;
+import com.netflix.spinnaker.kork.expressions.allowlist.MapPropertyAccessor;
+import com.netflix.spinnaker.kork.expressions.allowlist.ReturnTypeRestrictor;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,7 +49,7 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 /**
  * Provides utility support for SpEL integration Supports registering SpEL functions, ACLs to
- * classes (via whitelisting)
+ * classes (via allow list)
  */
 public class ExpressionsSupport {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExpressionsSupport.class);
@@ -133,7 +133,7 @@ public class ExpressionsSupport {
    *
    * @param rootObject the root object to transform
    * @param allowUnknownKeys flag to control what helper functions are available
-   * @return an evaluation context hooked with helper functions and correct ACL via whitelisting
+   * @return an evaluation context hooked with helper functions and correct ACL via allow list
    */
   public StandardEvaluationContext buildEvaluationContext(
       Object rootObject, boolean allowUnknownKeys) {
@@ -150,7 +150,7 @@ public class ExpressionsSupport {
     ReturnTypeRestrictor returnTypeRestrictor = new ReturnTypeRestrictor(allowedReturnTypes);
 
     StandardEvaluationContext evaluationContext = new StandardEvaluationContext(rootObject);
-    evaluationContext.setTypeLocator(new WhitelistTypeLocator());
+    evaluationContext.setTypeLocator(new AllowListTypeLocator());
     evaluationContext.setMethodResolvers(
         Collections.singletonList(new FilteredMethodResolver(returnTypeRestrictor)));
     evaluationContext.setPropertyAccessors(

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/AllowListTypeLocator.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/AllowListTypeLocator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.expressions.whitelisting;
+package com.netflix.spinnaker.kork.expressions.allowlist;
 
 import org.springframework.expression.EvaluationException;
 import org.springframework.expression.TypeLocator;
@@ -22,7 +22,7 @@ import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelMessage;
 import org.springframework.expression.spel.support.StandardTypeLocator;
 
-public class WhitelistTypeLocator implements TypeLocator {
+public class AllowListTypeLocator implements TypeLocator {
   private final InstantiationTypeRestrictor instantiationTypeRestrictor =
       new InstantiationTypeRestrictor();
   private final TypeLocator delegate = new StandardTypeLocator();

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/FilteredMethodResolver.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/FilteredMethodResolver.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.expressions.whitelisting;
+package com.netflix.spinnaker.kork.expressions.allowlist;
 
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/FilteredPropertyAccessor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/FilteredPropertyAccessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.expressions.whitelisting;
+package com.netflix.spinnaker.kork.expressions.allowlist;
 
 import static java.lang.String.format;
 

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/InstantiationTypeRestrictor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/InstantiationTypeRestrictor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.expressions.whitelisting;
+package com.netflix.spinnaker.kork.expressions.allowlist;
 
 import java.net.URLEncoder;
 import java.text.SimpleDateFormat;

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/MapPropertyAccessor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/MapPropertyAccessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.expressions.whitelisting;
+package com.netflix.spinnaker.kork.expressions.allowlist;
 
 import org.springframework.context.expression.MapAccessor;
 import org.springframework.expression.AccessException;

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/ReturnTypeRestrictor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/ReturnTypeRestrictor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.expressions.whitelisting;
+package com.netflix.spinnaker.kork.expressions.allowlist;
 
 import java.util.Set;
 


### PR DESCRIPTION
This refactor should not affect the current consumers of the
kork-expressions dependency since the configuration of the
allow list is handled in this library and at least for now
those classes are effectively an implementation detail.