### PR TITLE
feat(plugins): Add plugin API Environment SDK; get environment name and region from Spring environment

### DIFF
--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/PluginSdks.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/PluginSdks.java
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.kork.plugins.api;
 
 import com.netflix.spinnaker.kork.annotations.Beta;
+import com.netflix.spinnaker.kork.plugins.api.environment.Environment;
 import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClient;
 import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClientRegistry;
 import com.netflix.spinnaker.kork.plugins.api.serde.SerdeService;
@@ -40,7 +41,13 @@ import javax.annotation.Nonnull;
  * }
  * }</pre>
  */
+@Beta
 public interface PluginSdks {
+
+  /** Get the plugin {@link Environment}. */
+  @Beta
+  @Nonnull
+  Environment environment();
 
   /** Get the {@link HttpClientRegistry}, containing all configured {@link HttpClient}s. */
   @Beta

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/environment/Environment.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/environment/Environment.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.plugins.api.environment;
+
+import com.netflix.spinnaker.kork.annotations.Beta;
+import javax.annotation.Nonnull;
+
+@Beta
+public interface Environment {
+
+  /**
+   * Returns the environment name specified at:
+   *
+   * <pre>{@code spinnaker.extensibility.environment.name}</pre>
+   *
+   * If a name is not specified, returns the last active Spring profile.
+   *
+   * <p>If the environment name is not configured and there are no active spring profiles, returns
+   * the default value.
+   *
+   * @return String
+   */
+  @Nonnull
+  default String getName() {
+    return "default";
+  }
+
+  /**
+   * Return the environment region specified at:
+   *
+   * <pre>{@code spinnaker.extensibility.environment.region}</pre>
+   *
+   * If a region is not specified, an environment variable from which to source the region may be
+   * specified:
+   *
+   * <pre>{@code spinnaker.extensibility.environment.regionVariable}</pre>
+   *
+   * If there is no region environment variable and no specific region configured, returns the
+   * default value.
+   *
+   * @return String
+   */
+  @Nonnull
+  default String getRegion() {
+    return "default";
+  }
+}

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/internal/SpinnakerExtensionPoint.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/internal/SpinnakerExtensionPoint.java
@@ -17,9 +17,11 @@
 
 package com.netflix.spinnaker.kork.plugins.api.internal;
 
+import com.netflix.spinnaker.kork.annotations.Beta;
 import org.pf4j.ExtensionPoint;
 
 /** Designates a Spinnaker interface or abstract class as a PF4J {@link ExtensionPoint}. */
+@Beta
 public interface SpinnakerExtensionPoint extends ExtensionPoint {
 
   /**

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/servicesdk/ServiceSdk.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/servicesdk/ServiceSdk.java
@@ -15,9 +15,12 @@
  */
 package com.netflix.spinnaker.kork.plugins.api.servicesdk;
 
+import com.netflix.spinnaker.kork.annotations.Beta;
+
 /**
  * Marker interface for service-specific SDKs.
  *
  * <p>A service may expose additional SDKs that are specific to itself.
  */
+@Beta
 public interface ServiceSdk {}

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/EnvironmentSdkConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/EnvironmentSdkConfiguration.java
@@ -15,18 +15,19 @@
  *
  */
 
-package com.netflix.spinnaker.kork.plugins.api.internal;
+package com.netflix.spinnaker.config;
 
-import com.netflix.spinnaker.kork.annotations.Beta;
-import java.lang.reflect.InvocationHandler;
+import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory;
+import com.netflix.spinnaker.kork.plugins.sdk.environment.EnvironmentSdkFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
-/**
- * When proxying an extension class, implement this interface to provide a mechanism to obtain the
- * underlying proxied class.
- */
-@Beta
-public interface ExtensionInvocationHandler extends InvocationHandler {
+@Configuration
+public class EnvironmentSdkConfiguration {
 
-  /** Get the proxy target class. */
-  Class<? extends SpinnakerExtensionPoint> getTargetClass();
+  @Bean
+  public static SdkFactory environment(Environment environment) {
+    return new EnvironmentSdkFactory(environment);
+  }
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/PluginSdksImpl.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/PluginSdksImpl.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.kork.plugins.sdk
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import com.netflix.spinnaker.kork.plugins.api.PluginSdks
+import com.netflix.spinnaker.kork.plugins.api.environment.Environment
 import com.netflix.spinnaker.kork.plugins.api.httpclient.HttpClientRegistry
 import com.netflix.spinnaker.kork.plugins.api.serde.SerdeService
 import com.netflix.spinnaker.kork.plugins.api.servicesdk.ServiceSdk
@@ -29,6 +30,9 @@ import com.netflix.spinnaker.kork.plugins.api.yaml.YamlResourceLoader
 class PluginSdksImpl(
   private val sdkServices: List<Any>
 ) : PluginSdks {
+
+  override fun environment(): Environment =
+    service(Environment::class.java)
 
   override fun http(): HttpClientRegistry =
     service(HttpClientRegistry::class.java)

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/environment/EnvironmentImpl.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/environment/EnvironmentImpl.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.plugins.sdk.environment
+
+import com.netflix.spinnaker.kork.plugins.api.environment.Environment
+import org.springframework.core.env.Environment as SpringEnvironment
+
+class EnvironmentImpl(
+  private val springEnvironment: SpringEnvironment
+) : Environment {
+
+  override fun getName(): String {
+    val envFromConfig = springEnvironment.getProperty(extensibilityConfigEnvName)
+    val activeProfiles = springEnvironment.activeProfiles
+
+    return if (!envFromConfig.isNullOrEmpty()) {
+      envFromConfig
+    } else if (!activeProfiles.isNullOrEmpty()) {
+      activeProfiles.last()
+    } else {
+      super.getName()
+    }
+  }
+
+  override fun getRegion(): String {
+    val configuredRegion = springEnvironment.getProperty(extensibilityConfigEnvRegion)
+    val regionEnvVariable = springEnvironment.getProperty(extensibilityConfigEnvRegionVariable)
+
+    return if (!configuredRegion.isNullOrEmpty()) {
+      configuredRegion
+    } else if (!regionEnvVariable.isNullOrEmpty()) {
+      springEnvironment.getProperty(regionEnvVariable) ?: super.getRegion()
+    } else {
+      super.getRegion()
+    }
+  }
+
+  private companion object {
+    const val extensibilityConfigEnvName = "spinnaker.extensibility.environment.name"
+    const val extensibilityConfigEnvRegionVariable = "spinnaker.extensibility.environment.regionVariable"
+    const val extensibilityConfigEnvRegion = "spinnaker.extensibility.environment.region"
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/environment/EnvironmentSdkFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/environment/EnvironmentSdkFactory.kt
@@ -1,0 +1,15 @@
+package com.netflix.spinnaker.kork.plugins.sdk.environment
+
+import com.netflix.spinnaker.kork.plugins.api.environment.Environment
+import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory
+import org.pf4j.PluginWrapper
+import org.springframework.core.env.Environment as SpringEnvironment
+
+class EnvironmentSdkFactory(
+  private val springEnvironment: SpringEnvironment
+) : SdkFactory {
+
+  override fun create(extensionClass: Class<*>, pluginWrapper: PluginWrapper?): Environment {
+    return EnvironmentImpl(springEnvironment)
+  }
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/environment/EnvironmentImplTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/environment/EnvironmentImplTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.plugins.sdk.environment
+
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.core.env.Environment as SpringEnvironment
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class EnvironmentImplTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    context("Environment data") {
+
+      test("Gets name from config") {
+        every { springEnvironment.getProperty(extensibilityConfigEnvName) } returns "staging"
+        expectThat(subject.name).isEqualTo("staging")
+      }
+
+      test("Gets name from last active spring profile") {
+        every { springEnvironment.activeProfiles } returns arrayOf("spinnaker", "prod", "staging")
+        expectThat(subject.name).isEqualTo("staging")
+      }
+
+      test("Favors explicitly configured env name") {
+        every { springEnvironment.getProperty(extensibilityConfigEnvName) } returns "local"
+        every { springEnvironment.activeProfiles } returns arrayOf("spinnaker", "prod", "staging")
+        expectThat(subject.name).isEqualTo("local")
+      }
+
+      test("Gets region from configured environment variable") {
+        every { springEnvironment.getProperty(extensibilityConfigEnvRegionVariable) } returns "REGION"
+        every { springEnvironment.getProperty("REGION") } returns "us-west-2"
+        expectThat(subject.region).isEqualTo("us-west-2")
+      }
+
+      test("Gets region from configured region") {
+        every { springEnvironment.getProperty(extensibilityConfigEnvRegion) } returns "us-west-2"
+        expectThat(subject.region).isEqualTo("us-west-2")
+      }
+
+      test("Favors explicitly configured region") {
+        every { springEnvironment.getProperty(extensibilityConfigEnvRegion) } returns "us-east-1"
+        every { springEnvironment.getProperty(extensibilityConfigEnvRegionVariable) } returns "REGION"
+        every { springEnvironment.getProperty("REGION") } returns "us-west-2"
+        expectThat(subject.region).isEqualTo("us-east-1")
+      }
+
+      test("Name and region return unknown when nothing configured") {
+        every { springEnvironment.getProperty(any()) } returns null
+        every { springEnvironment.activeProfiles } returns emptyArray()
+        expectThat(subject.name).isEqualTo("default")
+        expectThat(subject.region).isEqualTo("default")
+      }
+    }
+  }
+
+  private inner class Fixture {
+    val springEnvironment: SpringEnvironment = mockk(relaxed = true)
+    val subject = EnvironmentImpl(springEnvironment)
+
+    val extensibilityConfigEnvName = "spinnaker.extensibility.environment.name"
+    val extensibilityConfigEnvRegionVariable = "spinnaker.extensibility.environment.regionVariable"
+    val extensibilityConfigEnvRegion = "spinnaker.extensibility.environment.region"
+  }
+}


### PR DESCRIPTION
This supports the potential use case wherein a plugin developer wants to load specific configuration for a Spinnaker environment.