### PR TITLE
feat(redis): EmbeddedRedis implements AutoCloseable

### DIFF
--- a/kork-jedis-test/src/main/java/com/netflix/spinnaker/kork/jedis/EmbeddedRedis.java
+++ b/kork-jedis-test/src/main/java/com/netflix/spinnaker/kork/jedis/EmbeddedRedis.java
@@ -9,7 +9,7 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.util.Pool;
 import redis.embedded.RedisServer;
 
-public class EmbeddedRedis {
+public class EmbeddedRedis implements AutoCloseable {
 
   private final URI connection;
   private final RedisServer redisServer;
@@ -27,6 +27,11 @@ public class EmbeddedRedis {
             .setting("databases 1")
             .build();
     this.redisServer.start();
+  }
+
+  @Override
+  public void close() {
+    destroy();
   }
 
   public void destroy() {


### PR DESCRIPTION
A lot of tests use EmbeddedRedis; it's a lot easier for tests to clean up this redis if it implements AutoCloseable as then they can use a try-with-resources construct.

Add a close() method that just calls the existing destroy().