### PR TITLE
feat(dependencies): adds kork-runtime module

### DIFF
--- a/kork-runtime/README.md
+++ b/kork-runtime/README.md
@@ -1,0 +1,10 @@
+# kork-runtime
+
+This module serves as a collection of th runtime dependencies in the kork
+project that should be added to the service module for a standard Spinnaker
+service.
+
+As we add new or refactor existing runtime only dependencies we can collect
+the dependencies here so that as we autobump out kork releases services will
+pick up those changes.
+

--- a/kork-runtime/kork-runtime.gradle
+++ b/kork-runtime/kork-runtime.gradle
@@ -1,0 +1,8 @@
+dependencies {
+  runtimeOnly(project(":kork-core"))
+  runtimeOnly(project(":kork-web"))
+  runtimeOnly(project(":kork-secrets-aws"))
+  runtimeOnly(project(":kork-secrets-gcp"))
+  runtimeOnly(project(":kork-stackdriver"))
+  runtimeOnly(project(":kork-swagger"))
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,7 @@ include(
   "kork-proto",
   "kork-pubsub",
   "kork-pubsub-aws",
+  "kork-runtime",
   "kork-secrets",
   "kork-secrets-aws",
   "kork-secrets-gcp",


### PR DESCRIPTION
kork-runtime serves as a grouping of the runtime modules within kork for a
Spinnaker service (similar to a spring-boot-starter style module).

By collecting these opinions here, we can more easily refactor existing or
introduce new runtime opinions and propagate those to all the consuming
services.

This is specifically intended for modules that expose AutoConfiguration
or com.netflix.spinnaker.config style scanned Configuration classes and
are expected to be present in a running system, but aren't needed as a
compile time dependency.