### PR TITLE
fix(core): Add method to change internal discovery status

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/discovery/NoDiscoveryStatusPublisher.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/discovery/NoDiscoveryStatusPublisher.java
@@ -37,8 +37,16 @@ public class NoDiscoveryStatusPublisher
   @Override
   public void onApplicationEvent(ContextRefreshedEvent event) {
     log.warn("No service discovery client is available, assuming application is UP");
+    setInstanceStatus(InstanceStatus.UP);
+  }
+
+  public void setInstanceEnabled(boolean enabled) {
+    setInstanceStatus(enabled ? InstanceStatus.UP : InstanceStatus.OUT_OF_SERVICE);
+  }
+
+  private void setInstanceStatus(InstanceStatus instanceStatus) {
     eventPublisher.publishEvent(
         new RemoteStatusChangedEvent(
-            new DiscoveryStatusChangeEvent(InstanceStatus.UNKNOWN, InstanceStatus.UP)));
+            new DiscoveryStatusChangeEvent(InstanceStatus.UNKNOWN, instanceStatus)));
   }
 }


### PR DESCRIPTION
Used by Orca -- although unsure if it's actually _used_ by anyone.