### PR TITLE
Revert "feat(sql): Add a feature flag for liquibase migrations"

### DIFF
--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.BeanCreationException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
@@ -65,13 +64,11 @@ class DefaultSqlConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(SpringLiquibase::class)
-  @ConditionalOnExpression("\${sql.read-only:false} == false")
   fun liquibase(properties: SqlProperties): SpringLiquibase =
     SpringLiquibaseProxy(properties.migration)
 
   @Bean
   @ConditionalOnProperty("sql.secondary-migration.jdbc-url")
-  @ConditionalOnExpression("\${sql.read-only:false} == false")
   fun secondaryLiquibase(properties: SqlProperties): SpringLiquibase =
     SpringLiquibaseProxy(properties.secondaryMigration)
 


### PR DESCRIPTION
Reverts spinnaker/kork#712

I'm seeing an issue with this change and read-only mode where things fail due to some unsatisfied dependencies

there is an `@DependsOn("liquibase")` on the data source class and it seems like with read-only set that is either blocking a whole chain of components from initializing or introducing a circular dependency (because there is another bean named liquibase that this ends up dependant on)

the purpose of the dependsOn annotation was to block the context from continuing to initialize while the migrations are running, so if we can find another way to do that we should be good to get this change back in

alternatively could we just set spring.liquibase.enabled=false .. that stops liquibase autoconfiguration (that probably blows something else up... heh)
