### PR TITLE
feat(sql): Add a feature flag for liquibase migrations

### DIFF
--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -64,13 +64,13 @@ class DefaultSqlConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(SpringLiquibase::class)
-  fun liquibase(properties: SqlProperties): SpringLiquibase =
-    SpringLiquibaseProxy(properties.migration)
+  fun liquibase(properties: SqlProperties, @Value("\${sql.read-only:false}") sqlReadOnly: Boolean): SpringLiquibase =
+    SpringLiquibaseProxy(properties.migration, sqlReadOnly)
 
   @Bean
   @ConditionalOnProperty("sql.secondary-migration.jdbc-url")
-  fun secondaryLiquibase(properties: SqlProperties): SpringLiquibase =
-    SpringLiquibaseProxy(properties.secondaryMigration)
+  fun secondaryLiquibase(properties: SqlProperties, @Value("\${sql.read-only:false}") sqlReadOnly: Boolean): SpringLiquibase =
+    SpringLiquibaseProxy(properties.secondaryMigration, sqlReadOnly)
 
   @Suppress("ReturnCount", "ThrowsCount")
   @DependsOn("liquibase")

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt
@@ -34,6 +34,7 @@ import org.springframework.jdbc.datasource.SingleConnectionDataSource
  */
 class SpringLiquibaseProxy(
   private val sqlMigrationProperties: SqlMigrationProperties,
+  private val sqlReadOnly: Boolean,
   private val korkAdditionalChangelogs: List<String> = listOf("db/healthcheck.yml")
 ) : SpringLiquibase() {
 
@@ -57,6 +58,7 @@ class SpringLiquibaseProxy(
           changeLog = "classpath:$it"
           dataSource = createDataSource()
           resourceLoader = this@SpringLiquibaseProxy.resourceLoader
+          shouldRun = !sqlReadOnly
         }
       }
       .forEach {


### PR DESCRIPTION
Right now it is hard to run e.g. a read-only clouddriver cluster towards a read-only database, because there's no way to disable the migrations (which will cause Clouddriver to fail on startup if it can't write to the DB).
I'm piggybacking on the `sql.read-only` feature flag.

This is take 2 of this PR, after #712 had to be reverted due to Spring startup issues. See #718. I think this way of disabling the migration is less intrusive, because the liquibase beans will still be present in the context.