### PR TITLE
fix(spel): Fix flattening of nested arrays in SpEL evaluation

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionTransform.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionTransform.java
@@ -132,7 +132,7 @@ public class ExpressionTransform {
       if (obj instanceof Map) {
         result.add(transformMap((Map<String, Object>) obj, evaluationContext, summary));
       } else if (obj instanceof List) {
-        result.addAll(transformList((List) obj, evaluationContext, summary, additionalContext));
+        result.add(transformList((List) obj, evaluationContext, summary, additionalContext));
       } else {
         result.add(transform(obj, evaluationContext, summary, additionalContext));
       }

--- a/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionTransformTest.java
+++ b/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionTransformTest.java
@@ -97,10 +97,7 @@ class ExpressionTransformTest {
         new ExpressionTransform(parserContext, parser, Function.identity())
             .transformList(input, new StandardEvaluationContext(), summary, Collections.emptyMap());
 
-    // TODO(ezimanyi): This appears incorrect; expression evaluation should not be flattening nested
-    // lists. Instead, the output should be exactly equal to the input.
-    List<Object> expectedResult = Collections.singletonList("value");
-    assertThat(evaluated).isEqualTo(expectedResult);
+    assertThat(evaluated).isEqualTo(input);
   }
 
   @Test

--- a/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionTransformTest.java
+++ b/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionTransformTest.java
@@ -2,6 +2,9 @@ package com.netflix.spinnaker.kork.expressions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -30,6 +33,89 @@ class ExpressionTransformTest {
 
     assertThat(evaluated).isEqualTo("group:artifact:100");
     assertThat(summary.getFailureCount()).isEqualTo(0);
+  }
+
+  @Test
+  void evaluateMap() {
+    Map<String, Object> input = Collections.singletonMap("key", "value");
+
+    Map<String, Object> evaluated =
+        new ExpressionTransform(parserContext, parser, Function.identity())
+            .transformMap(
+                input, new StandardEvaluationContext(), new ExpressionEvaluationSummary());
+
+    assertThat(evaluated).isEqualTo(input);
+  }
+
+  @Test
+  void evaluateNestedMap() {
+    Map<String, Object> input =
+        Collections.singletonMap("key", Collections.singletonMap("inner", "value"));
+
+    Map<String, Object> evaluated =
+        new ExpressionTransform(parserContext, parser, Function.identity())
+            .transformMap(
+                input, new StandardEvaluationContext(), new ExpressionEvaluationSummary());
+
+    assertThat(evaluated).isEqualTo(input);
+  }
+
+  @Test
+  void evaluateMapWithNestedList() {
+    Map<String, Object> input = Collections.singletonMap("key", Collections.singletonList("value"));
+
+    Map<String, Object> evaluated =
+        new ExpressionTransform(parserContext, parser, Function.identity())
+            .transformMap(
+                input, new StandardEvaluationContext(), new ExpressionEvaluationSummary());
+
+    assertThat(evaluated).isEqualTo(input);
+  }
+
+  @Test
+  void evaluateList() {
+    List<Object> input = Collections.singletonList("value");
+
+    List<?> evaluated =
+        new ExpressionTransform(parserContext, parser, Function.identity())
+            .transformList(
+                input,
+                new StandardEvaluationContext(),
+                new ExpressionEvaluationSummary(),
+                Collections.emptyMap());
+
+    assertThat(evaluated).isEqualTo(input);
+  }
+
+  @Test
+  void evaluateNestedList() {
+    ExpressionEvaluationSummary summary = new ExpressionEvaluationSummary();
+
+    List<Object> input = Collections.singletonList(Collections.singletonList("value"));
+
+    List<?> evaluated =
+        new ExpressionTransform(parserContext, parser, Function.identity())
+            .transformList(input, new StandardEvaluationContext(), summary, Collections.emptyMap());
+
+    // TODO(ezimanyi): This appears incorrect; expression evaluation should not be flattening nested
+    // lists. Instead, the output should be exactly equal to the input.
+    List<Object> expectedResult = Collections.singletonList("value");
+    assertThat(evaluated).isEqualTo(expectedResult);
+  }
+
+  @Test
+  void evaluateListWithNestedMap() {
+    List<Object> input = Collections.singletonList(Collections.singletonMap("key", "value"));
+
+    List<?> evaluated =
+        new ExpressionTransform(parserContext, parser, Function.identity())
+            .transformList(
+                input,
+                new StandardEvaluationContext(),
+                new ExpressionEvaluationSummary(),
+                Collections.emptyMap());
+
+    assertThat(evaluated).isEqualTo(input);
   }
 
   @AllArgsConstructor


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5865.

* test(spel): Add tests on ExpressionTransform

  The next commit will fix a bug in ExpressionTransform; first add some tests to document the current behavior. In particular, test the behavior in handling nested maps and nested lists.

* fix(spel): Fix flattening of nested arrays in SpEL evaluation

  Currently nested lists are being flattened when evaluating expressions. This is incorrect, as expression evaluation should not affect the shape of the data structure; it should only handle evaluating expressions in the components of that data structure.

  There are some situations in the Kubernetes provider where we need a list of lists in the context; this currently breaks because upon evaluating expressions these lists get flattened.