### PR TITLE
fix(metrics): Reverts deletion of SpectatorMeterRegistry and enables opt in of breaking change to prometheus metrics/dashboards through the monitoring daemon.

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/metrics/SpectatorMeterRegistry.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/metrics/SpectatorMeterRegistry.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.metrics;
+
+import com.netflix.spectator.api.Registry;
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class SpectatorMeterRegistry extends SimpleMeterRegistry {
+
+  private Registry spectatorRegistry;
+
+  public SpectatorMeterRegistry(Registry spectatorRegistry) {
+    this.spectatorRegistry = spectatorRegistry;
+  }
+
+  @Override
+  public List<Meter> getMeters() {
+    return Stream.concat(
+            spectatorRegistry.stream().map(this::convertMeter), super.getMeters().stream())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void forEachMeter(Consumer<? super Meter> consumer) {
+    Stream.concat(spectatorRegistry.stream().map(this::convertMeter), super.getMeters().stream())
+        .forEach(consumer);
+  }
+
+  public Meter convertMeter(com.netflix.spectator.api.Meter meter) {
+    final Meter.Id id = getId(meter);
+    return new Meter() {
+
+      @Override
+      public Iterable<Measurement> measure() {
+        Iterator<Measurement> measurements =
+            StreamSupport.stream(meter.measure().spliterator(), false)
+                .map(m -> new Measurement(m::value, Statistic.UNKNOWN))
+                .iterator();
+        return () -> measurements;
+      }
+
+      @Override
+      public Id getId() {
+        return id;
+      }
+    };
+  }
+
+  private Meter.Id getId(com.netflix.spectator.api.Meter meter) {
+    Iterator<Tag> tags =
+        StreamSupport.stream(meter.id().tags().spliterator(), false)
+            .map(t -> Tag.of(t.key(), t.value()))
+            .iterator();
+    return new Meter.Id(meter.id().name(), Tags.of(() -> tags), null, "", getMeterType(meter));
+  }
+
+  private Meter.Type getMeterType(com.netflix.spectator.api.Meter meter) {
+    if (meter instanceof Counter) {
+      return Meter.Type.COUNTER;
+    } else if (meter instanceof Gauge) {
+      return Meter.Type.GAUGE;
+    } else if (meter instanceof LongTaskTimer) {
+      return Meter.Type.LONG_TASK_TIMER;
+    } else if (meter instanceof Timer) {
+      return Meter.Type.TIMER;
+    } else if (meter instanceof DistributionSummary) {
+      return Meter.Type.DISTRIBUTION_SUMMARY;
+    } else {
+      return Meter.Type.OTHER;
+    }
+  }
+}


### PR DESCRIPTION
In PR #592 the default Spectator registry was changed from the default Spectator registry to a Spectator Micrometer registry.
Having the micrometer registry is nice because it enables things such as including Micrometer registries on the classpath and having them just work, or creating plugins to configure micrometer such as the [Armory Observability Plugin](https://github.com/armory-plugins/armory-observability-plugin)

However: The [Micrometer Registry L50](https://github.com/Netflix/spectator/blob/master/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerMeter.java#L50) adds a statistic tag to all Metrics.

[The monitoring daemon appends `__value` to all metrics that contain the tag `statistic`](
https://github.com/spinnaker/spinnaker-monitoring/blob/master/spinnaker-monitoring-daemon/spinnaker-monitoring/spectator_client.py#L354-L355)

These 2 things in combination mean that `1.20` introduced a *BREAKING* change that broke the existing Prometheus dashboards and alerting when using the monitoring daemon, as it changed the name of almost all metrics being reporting to Prometheus and potentially other metric integrations.

This PR partially reverts #592 and makes it opt-in by supplying `spectator.micrometerRegistry.enabled: true` as a Springboot prop.

I also tried to get fancy with making spring conditionally configure micrometer vs the default reg when custom Micrometer registries were supplied without any luck and had to add the explicit feature flag `spectator.micrometerRegistry.enabled:`

cc: @Aloren