### PR TITLE
feat(plugins): Allow metrics on private methods annotated with @Metered

### DIFF
--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/MetricInvocationAspectTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/MetricInvocationAspectTest.kt
@@ -76,7 +76,7 @@ class MetricInvocationAspectTest : JUnit5Minutests {
         }
     }
 
-    test("Skips public method that is not annotated") {
+    test("Skips method that is not annotated") {
       val state = subject.before(target, proxy, createNotAnnotatedPublicMethod(), args, spinnakerPluginDescriptor)
 
       expectThat(state).isA<MetricInvocationState>()
@@ -84,14 +84,6 @@ class MetricInvocationAspectTest : JUnit5Minutests {
           get { startTimeMs }.isA<Long>()
           get { timingId }.isNull()
           get { extensionName }.isA<String>().isEqualTo(target.javaClass.simpleName.toString())
-        }
-    }
-
-    test("Private method is not instrumented with meters") {
-      val state = subject.before(target, proxy, privateMethod, args, spinnakerPluginDescriptor)
-      expectThat(state).isA<MetricInvocationState>()
-        .and {
-          get { timingId }.isNull()
         }
     }
 
@@ -129,7 +121,6 @@ class MetricInvocationAspectTest : JUnit5Minutests {
     val target: SpinnakerExtensionPoint = SomeExtension()
     val proxy: Any = mockk(relaxed = true)
     val method: Method = createMethod()
-    val privateMethod: Method = createPrivateMethod()
     val args: Array<out Any> = arrayOf()
     val spinnakerPluginDescriptor: SpinnakerPluginDescriptor = createPluginDescriptor(pluginId, pluginVersion)
 

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/utils.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/utils.kt
@@ -64,11 +64,4 @@ internal class SomeExtension : SpinnakerExtensionPoint {
   fun notAnnotatedPublicMethod(): String {
     return "Not annotated public method"
   }
-
-  /**
-   * Private helloWorld method, exists to test private method instrumentation (or lack thereof).
-   */
-  private fun privateHelloWorld(): String {
-    return "Hello Private World!"
-  }
 }


### PR DESCRIPTION
I was reviewing a plugin that @dreynaud wrote and saw that he annotated a private method on an extension point with `@Metered`.  I then realized that our logic to skip private methods was basically pointless since we require the `@Metered` annotation (the logic to skip private methods was originally there when we automatically metered all extension methods - we no longer do that).