### PR TITLE
fix(eureka): ensure archaius config happens before eureka config

### DIFF
--- a/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaAutoConfiguration.java
+++ b/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaAutoConfiguration.java
@@ -23,14 +23,12 @@ import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.eventbus.impl.EventBusImpl;
 import com.netflix.eventbus.spi.EventBus;
-import com.netflix.spinnaker.kork.archaius.ArchaiusAutoConfiguration;
 import com.netflix.spinnaker.kork.discovery.DiscoveryAutoConfiguration;
 import java.util.Map;
 import java.util.Objects;
 import javax.inject.Provider;
 import org.springframework.boot.actuate.health.HealthAggregator;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -41,7 +39,6 @@ import org.springframework.context.annotation.*;
 @ConditionalOnProperty("eureka.enabled")
 @EnableConfigurationProperties(EurekaConfigurationProperties.class)
 @AutoConfigureBefore(DiscoveryAutoConfiguration.class)
-@AutoConfigureAfter(ArchaiusAutoConfiguration.class)
 public class EurekaAutoConfiguration {
 
   @Bean
@@ -49,9 +46,9 @@ public class EurekaAutoConfiguration {
     return new EventBusImpl();
   }
 
+  /** @deprecated use EurekaClient rather than DiscoveryClient */
   @Bean
-  @Deprecated // prefer to use EurekaClient interface rather than directly depending on
-  // DiscoveryClient
+  @Deprecated
   public DiscoveryClient discoveryClient(
       ApplicationInfoManager applicationInfoManager,
       EurekaClientConfig eurekaClientConfig,


### PR DESCRIPTION
This moves archaius config back to being a BeanPostProcessor to ensure it happens early in the lifecycle.

I had made some bad assumptions around autoconfig ordering via the annotations that were clarified here:
https://github.com/spring-projects/spring-boot/issues/22337