### PR TITLE
feat(plugins): Support refactoring out core code

### DIFF
--- a/kork-plugins/kork-plugins.gradle
+++ b/kork-plugins/kork-plugins.gradle
@@ -20,7 +20,8 @@ dependencies {
   implementation("com.squareup.retrofit2:converter-jackson")
   implementation("com.squareup.okhttp3:logging-interceptor")
 
-  implementation "org.pf4j:pf4j"
+  // Needs to be api because SpinnakerPluginManager extends DefaultPluginManager.
+  api "org.pf4j:pf4j"
   implementation "org.pf4j:pf4j-update"
 
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationAspect;
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationState;
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.LogInvocationAspect;
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.MetricInvocationAspect;
+import com.netflix.spinnaker.kork.plugins.refactor.PluginRefactorService;
 import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory;
 import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager;
 import com.netflix.spinnaker.kork.plugins.update.downloader.CompositeFileDownloader;
@@ -259,12 +260,21 @@ public class PluginsAutoConfiguration {
   }
 
   @Bean
+  public static PluginRefactorService pluginRefactorService(
+    ApplicationContext applicationContext,
+    SpinnakerPluginManager pluginManager
+  ) {
+    return new PluginRefactorService(applicationContext, pluginManager);
+  }
+
+  @Bean
   public static ExtensionBeanDefinitionRegistryPostProcessor pluginBeanPostProcessor(
       SpinnakerPluginManager pluginManager,
       SpinnakerUpdateManager updateManager,
       PluginInfoReleaseProvider pluginInfoReleaseProvider,
       SpringPluginStatusProvider springPluginStatusProvider,
       ApplicationEventPublisher applicationEventPublisher,
+      PluginRefactorService pluginRefactorService,
       List<InvocationAspect<? extends InvocationState>> invocationAspects) {
     return new ExtensionBeanDefinitionRegistryPostProcessor(
         pluginManager,
@@ -272,6 +282,7 @@ public class PluginsAutoConfiguration {
         pluginInfoReleaseProvider,
         springPluginStatusProvider,
         applicationEventPublisher,
+        pluginRefactorService,
         invocationAspects);
   }
 

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -144,6 +144,9 @@ open class SpinnakerPluginManager(
       }
   }
 
+  fun hasPlugin(pluginId: String): Boolean =
+    plugins.containsKey(pluginId)
+
   init {
     systemVersion = getSystemVersion()
   }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/refactor/MissingPlugin.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/refactor/MissingPlugin.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.refactor
+
+/**
+ * @param pluginId The plugin ID that is missing.
+ * @param message An operator-friendly message describing why we think the plugin is missing.
+ * @param ignoreKey A configuration key operators can set to permanently ignore a missing plugin.
+ * @param source The [PluginRefactorRule] that originated this missing plugin.
+ * @param minimumVersion The minimum plugin version that must be used.
+ */
+data class MissingPlugin(
+  val pluginId: String,
+  val message: String,
+  val ignoreKey: String,
+  val source: PluginRefactorRule,
+  val minimumVersion: String? = null
+) {
+  fun toMessage(): String =
+    "${source.javaClass.simpleName} has detected plugin '${pluginId}'${minVersionMessage()} is missing: ${message.trim('.')}. " +
+      "If you know this plugin's capabilities are satisfied another way, you may ignore this rule by setting " +
+      "'${ignoreConfig(ignoreKey)}' to 'true'"
+
+  private fun minVersionMessage(): String =
+    if (minimumVersion == null) "" else " (>=$minimumVersion)"
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/refactor/MissingRequiredPluginException.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/refactor/MissingRequiredPluginException.kt
@@ -5,19 +5,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
-apply plugin: "java-library"
+package com.netflix.spinnaker.kork.plugins.refactor
 
-dependencies {
-  api(platform(project(":spinnaker-dependencies")))
+import com.netflix.spinnaker.kork.exceptions.SystemException
 
-  implementation project(':kork-core')
-  implementation project(":kork-plugins")
-}
+/**
+ * Thrown when a required plugin is missing.
+ */
+class MissingRequiredPluginException(message: String) : SystemException(message)

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/refactor/PluginRefactorRule.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/refactor/PluginRefactorRule.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.refactor
+
+import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager
+import org.springframework.core.env.Environment
+
+/**
+ * Helps core services and libraries break existing functionality out into plugins by helping operators detect
+ * removed functionality.
+ */
+interface PluginRefactorRule {
+  /**
+   * Checks the [environment] for configuration or other state that singals an expected feature is no longer provided
+   * by core functionality and is instead found in a (likely official) plugin.
+   *
+   * @return A set of plugin IDs that are missing.
+   */
+  fun checkForMissingPlugins(environment: Environment, pluginManager: SpinnakerPluginManager): Set<MissingPlugin>
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/refactor/PluginRefactorService.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/refactor/PluginRefactorService.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.refactor
+
+import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager
+import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.env.Environment
+import org.springframework.core.type.filter.AssignableTypeFilter
+import org.springframework.util.ClassUtils
+
+/**
+ * Provides a standard utility for Spinnaker services to refactor core functionality out into plugins.
+ *
+ * Services can define a [PluginRefactorRule] that can evaluate the running service environment to determine
+ * if a service is configured for functionality that was built into the core service offering, but has since
+ * been refactored out into a plugin.
+ */
+class PluginRefactorService(
+  private val applicationContext: ApplicationContext,
+  private val pluginManager: SpinnakerPluginManager
+) {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  internal var refactorRuleLocator: RefactorRuleLocator = ClassPathScanningRefactorRuleLocator()
+
+  fun checkForRefactoredCoreFeatures() {
+    log.info("Checking for missing plugins")
+
+    refactorRuleLocator.locateRules().forEach {
+      checkRule(it, applicationContext.environment)
+    }
+  }
+
+  private fun checkRule(refactorRule: PluginRefactorRule, environment: Environment) {
+    refactorRule.checkForMissingPlugins(environment, pluginManager).forEach {
+      if (isMissingPluginIgnored(environment, it)) {
+        log.info("Ignoring plugin refactor rule '${it.source.javaClass.simpleName}': Disabled via '${it.ignoreKey}'")
+        return
+      }
+
+      throw MissingRequiredPluginException(it.toMessage())
+    }
+  }
+
+  private fun isMissingPluginIgnored(environment: Environment, missingPlugin: MissingPlugin): Boolean =
+    environment.getProperty(
+      ignoreConfig(missingPlugin.ignoreKey),
+      Boolean::class.java,
+      false
+    )
+
+  /**
+   * Defines the strategy for locating [PluginRefactorRule] classes.
+   */
+  internal interface RefactorRuleLocator {
+    fun locateRules(): List<PluginRefactorRule>
+  }
+
+  /**
+   * The [RefactorRuleLocator] used for normal application flows.
+   */
+  internal class ClassPathScanningRefactorRuleLocator : RefactorRuleLocator {
+
+    override fun locateRules(): List<PluginRefactorRule> {
+      // We need to use classpath scanning instead of Spring, since the plugin framework runs so early.
+      val provider = ClassPathScanningCandidateComponentProvider(false).apply {
+        addIncludeFilter(AssignableTypeFilter(PluginRefactorRule::class.java))
+      }
+
+      return provider.findCandidateComponents("com.netflix.spinnaker")
+        .mapNotNull { it.beanClassName }
+        .map {
+          ClassUtils.resolveClassName(it, ClassUtils.getDefaultClassLoader()).newInstance() as PluginRefactorRule
+        }
+    }
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/refactor/dsl.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/refactor/dsl.kt
@@ -5,19 +5,19 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
-apply plugin: "java-library"
+package com.netflix.spinnaker.kork.plugins.refactor
 
-dependencies {
-  api(platform(project(":spinnaker-dependencies")))
-
-  implementation project(':kork-core')
-  implementation project(":kork-plugins")
-}
+/**
+ * Creates a config path for a given ignore key.
+ */
+internal fun ignoreConfig(key: String): String =
+  "spinnaker.extensibility.refactor-rules.ignore.$key"

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
 import com.netflix.spinnaker.kork.plugins.events.ExtensionLoaded
 import com.netflix.spinnaker.kork.plugins.internal.TestPlugin
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationAspect
+import com.netflix.spinnaker.kork.plugins.refactor.PluginRefactorService
 import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
 import com.netflix.spinnaker.kork.plugins.update.release.provider.PluginInfoReleaseProvider
 import dev.minutest.junit.JUnit5Minutests
@@ -31,6 +32,7 @@ import org.pf4j.ExtensionFactory
 import org.pf4j.ExtensionPoint
 import org.pf4j.PluginWrapper
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.support.GenericApplicationContext
 
@@ -122,10 +124,16 @@ class ExtensionBeanDefinitionRegistryPostProcessorTest : JUnit5Minutests {
     val applicationEventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
     val invocationAspects: List<InvocationAspect<*>> = mockk(relaxed = true)
     val pluginDescriptor: SpinnakerPluginDescriptor = mockk(relaxed = true)
+    val pluginRefactorService: PluginRefactorService = mockk(relaxed = true)
 
     val subject = ExtensionBeanDefinitionRegistryPostProcessor(
-      pluginManager, updateManager,
-      pluginInfoReleaseProvider, springPluginStatusProvider, applicationEventPublisher, invocationAspects
+      pluginManager,
+      updateManager,
+      pluginInfoReleaseProvider,
+      springPluginStatusProvider,
+      applicationEventPublisher,
+      pluginRefactorService,
+      invocationAspects
     )
 
     init {

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/refactor/MissingPluginTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/refactor/MissingPluginTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.refactor
+
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.mockk
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class MissingPluginTest : JUnit5Minutests {
+
+  fun tests() = rootContext {
+    val rule: PluginRefactorRule = mockk()
+
+    test("toMessage formatting without minimum version") {
+      val missingPlugin = MissingPlugin("missing.plugin", "Some explanation", "ignoreme", rule)
+      expectThat(missingPlugin.toMessage()).isEqualTo(
+        "${rule.javaClass.simpleName} has detected plugin 'missing.plugin' is missing: Some explanation. " +
+          "If you know this plugin's capabilities are satisfied another way, you may ignore this rule by setting " +
+          "'spinnaker.extensibility.refactor-rules.ignore.ignoreme' to 'true'"
+      )
+    }
+
+    test("toMessage formatting with minimum version") {
+      val missingPlugin = MissingPlugin("missing.plugin", "Some explanation", "ignoreme", rule, "0.0.1")
+      expectThat(missingPlugin.toMessage()).isEqualTo(
+        "${rule.javaClass.simpleName} has detected plugin 'missing.plugin' (>=0.0.1) is missing: Some explanation. " +
+          "If you know this plugin's capabilities are satisfied another way, you may ignore this rule by setting " +
+          "'spinnaker.extensibility.refactor-rules.ignore.ignoreme' to 'true'"
+      )
+    }
+  }
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/refactor/PluginRefactorServiceTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/refactor/PluginRefactorServiceTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.refactor
+
+import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.context.ApplicationContext
+import org.springframework.core.env.Environment
+import strikt.api.expectThrows
+
+class PluginRefactorServiceTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    context("no rules found") {
+      fixture {
+        Fixture()
+      }
+      test("nothing happens") {
+        subject.checkForRefactoredCoreFeatures()
+      }
+    }
+
+    context("rule finds missing plugin") {
+      fixture {
+        Fixture().apply {
+          ruleLocator.rules = listOf(TestPluginRefactorRule())
+        }
+      }
+
+      test("exception is thrown") {
+        expectThrows<MissingRequiredPluginException> {
+          subject.checkForRefactoredCoreFeatures()
+        }
+      }
+
+      test("ignored plugin rules no-op check") {
+        every { environment.getProperty(eq(ignoreConfig("ignoreme")), eq(Boolean::class.java), eq(false)) } returns true
+        subject.checkForRefactoredCoreFeatures()
+      }
+    }
+  }
+
+  private inner class Fixture {
+    val applicationContext: ApplicationContext = mockk(relaxed = true)
+    val environment: Environment = mockk(relaxed = true)
+    val pluginManager: SpinnakerPluginManager = mockk(relaxed = true)
+    val ruleLocator = TestRefactorRuleLocator(listOf())
+
+    val subject = PluginRefactorService(applicationContext, pluginManager).apply {
+      refactorRuleLocator = ruleLocator
+    }
+
+    init {
+      every { applicationContext.environment } returns environment
+      every { environment.getProperty(any(), eq(Boolean::class.java), eq(false)) } returns false
+    }
+  }
+
+  private class TestPluginRefactorRule : PluginRefactorRule {
+
+    override fun checkForMissingPlugins(
+      environment: Environment,
+      pluginManager: SpinnakerPluginManager
+    ): Set<MissingPlugin> =
+      setOf(
+        MissingPlugin(
+          pluginId = "test.missing-plugin",
+          message = "Some description",
+          ignoreKey = "ignoreme",
+          source = this
+        )
+      )
+  }
+
+  private class TestRefactorRuleLocator(
+    var rules: List<PluginRefactorRule>
+  ) : PluginRefactorService.RefactorRuleLocator {
+
+    override fun locateRules(): List<PluginRefactorRule> = rules
+  }
+}

--- a/kork-pubsub/src/main/java/com/netflix/spinnaker/kork/pubsub/config/PubsubConfig.java
+++ b/kork-pubsub/src/main/java/com/netflix/spinnaker/kork/pubsub/config/PubsubConfig.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.kork.pubsub.config;
 
+import com.netflix.spinnaker.kork.plugins.refactor.PluginRefactorRule;
+import com.netflix.spinnaker.kork.pubsub.AwsPubsubPluginRefactorRule;
 import com.netflix.spinnaker.kork.pubsub.PubsubPublishers;
 import com.netflix.spinnaker.kork.pubsub.PubsubSubscribers;
 import org.springframework.context.annotation.Bean;
@@ -32,5 +34,10 @@ public class PubsubConfig {
   @Bean
   PubsubPublishers pubsubPublishers() {
     return new PubsubPublishers();
+  }
+
+  @Bean
+  public static PluginRefactorRule amazonSqsPluginRefactorRule() {
+    return new AwsPubsubPluginRefactorRule();
   }
 }


### PR DESCRIPTION
Utility to help refactor core service functionality out into plugins.

An example `PluginRefactorRule`, for removing `kork-pubsub-aws` from core could be put in `kork-pubsub`:

```java
public class AwsPubsubPluginRefactorRule implements PluginRefactorRule {

  private final static String PLUGIN_ID = "io.spinnaker.infra-amazon";
  private final static String IGNORE_KEY = "korkPubsubSqs";

  @Nonnull
  @Override
  public Set<MissingPlugin> checkForMissingPlugins(
    @Nonnull Environment environment,
    @Nonnull SpinnakerPluginManager pluginManager
  ) {
    if (hasAwsPubsubEnabled(environment) && !pluginManager.hasPlugin(PLUGIN_ID)) {
      return Collections.singleton(new MissingPlugin(
        PLUGIN_ID,
        "'amazon.pubsub.enabled' is true, but SQS support has been moved out of core into a plugin.",
        IGNORE_KEY,
        this,
        null
      ));
    }
    return Collections.emptySet();
  }

  private static boolean hasAwsPubsubEnabled(Environment environment) {
    return environment.getProperty("pubsub.amazon.enabled", Boolean.class, false);
  }
}
```

✏️  I had originally written this with the concept of auto-downloading plugins, but I've rolled that back in favor of hard-crashing the service. Downloading on behalf of the operator can be revisited down the road if need be.