### PR TITLE
Kotlin 1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,12 @@
 
 plugins {
   id 'io.spinnaker.project' version "$spinnakerGradleVersion" apply false
-  id 'nebula.kotlin' version "$kotlinVersion" apply false
+  id "org.jetbrains.kotlin.jvm" version "$kotlinVersion" apply false
   id "io.gitlab.arturbosch.detekt" version "1.7.4" apply false
   id 'org.jetbrains.kotlin.plugin.allopen' version "$kotlinVersion" apply false
 }
 
-subprojects { 
+subprojects {
   apply plugin: "io.spinnaker.project"
 
   group = "com.netflix.spinnaker.kork"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.3.72
+kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.5.0
 monikerVersion=0.3.3

--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -41,7 +41,7 @@ test {
 
 compileTestKotlin {
   kotlinOptions {
-    languageVersion = "1.3"
+    languageVersion = "1.4"
     jvmTarget = "1.8"
   }
 }

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-apply plugin: "nebula.kotlin"
+apply plugin: "kotlin"
 apply plugin: "kotlin-spring"
 apply plugin: "io.gitlab.arturbosch.detekt"
 
@@ -42,7 +42,14 @@ test {
 
 compileKotlin {
   kotlinOptions {
-    languageVersion = "1.3"
+    languageVersion = "1.4"
+    jvmTarget = "1.8"
+  }
+}
+
+compileTestKotlin {
+  kotlinOptions {
+    languageVersion = "1.4"
     jvmTarget = "1.8"
   }
 }

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -35,7 +35,7 @@ dependencies {
    * For example, `junit-bom` and `jackson-bom` will win out over the versions of JUnit and Jackson
    * specified by `spring-boot-dependencies`.
    */
-  api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.3.7"))
+  api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.3.9"))
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
@@ -86,9 +86,9 @@ dependencies {
     api("com.netflix.spectator:spectator-reg-micrometer:${versions.spectator}")
     api("com.netflix.spinnaker.embedded-redis:embedded-redis:0.8.0")
     api("com.netflix.spinnaker.moniker:moniker:$monikerVersion")
-    api("com.nhaarman.mockitokotlin2:mockito-kotlin:1.5.0")
-    api("com.nhaarman:mockito-kotlin:1.5.0")
-    api("com.ninja-squad:springmockk:2.0.1")
+    api("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
+    api("com.nhaarman:mockito-kotlin:1.6.0")
+    api("com.ninja-squad:springmockk:2.0.3")
     api("com.squareup.okhttp3:logging-interceptor:${versions.okhttp3}")
     api("com.squareup.okhttp3:mockwebserver:${versions.okhttp3}")
     api("com.squareup.okhttp3:okhttp-sse:${versions.okhttp3}")


### PR DESCRIPTION
Nebula Kotlin is no longer supporting Kotlin >= 1.4 so I've switched to using the regular Kotlin Gradle plugin. I also bumped a couple of Kotlin related dependencies.﻿

Consuming projects will also need to switch from using Nebula Kotlin.