### PR TITLE
Add Springdoc-openapi to dependency BOM

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -14,6 +14,7 @@ ext {
     protobuf         : "3.9.1",
     okhttp           : "2.7.0",
     okhttp3          : "3.14.9",
+    openapi          : "1.3.9", // this needs to be kept in sync with spring boot as it pulls in the spring-boot-dependencies BOM
     resilience4j     : "1.0.0",
     retrofit         : "1.9.0",
     retrofit2        : "2.8.1",
@@ -141,6 +142,8 @@ dependencies {
     api("org.objenesis:objenesis:2.5.1")
     api("org.pf4j:pf4j:3.2.0")
     api("org.pf4j:pf4j-update:2.3.0")
+    api("org.springdoc:springdoc-openapi-webmvc-core:${versions.openapi}")
+    api("org.springdoc:springdoc-openapi-kotlin:${versions.openapi}")
     api("org.springframework.boot:spring-boot-configuration-processor:${versions.springBoot}")
     api("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:2.1.5.RELEASE")
     api("org.springframework.security.extensions:spring-security-saml-dsl-core:1.0.5.RELEASE")


### PR DESCRIPTION
Used by Keel currently, and important to keep in line with Spring Boot.