### PR TITLE
fix(plugins): Refactor PluginSdk to also allow using plugin class

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/SdkFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/SdkFactory.kt
@@ -24,7 +24,11 @@ import org.pf4j.PluginWrapper
 interface SdkFactory {
 
   /**
-   * Create the SDK for the provided [extensionClass] and [pluginWrapper].
+   * Create the SDK for the provided [pluginClass] and [pluginWrapper].
+   *
+   * TODO(rz): pluginWrapper should never be null. Investigate.
+   *
+   * @param pluginClass Any class inside of a plugin.
    */
-  fun create(extensionClass: Class<*>, pluginWrapper: PluginWrapper?): Any
+  fun create(pluginClass: Class<*>, pluginWrapper: PluginWrapper?): Any
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/HttpClientSdkFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/HttpClientSdkFactory.kt
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.kork.plugins.sdk.IdResolver
 import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory
 import com.netflix.spinnaker.kork.plugins.sdk.httpclient.internal.CompositeOkHttpClientFactory
+import org.pf4j.Plugin
 import org.pf4j.PluginWrapper
 import org.springframework.core.env.Environment
 
@@ -32,13 +33,13 @@ class HttpClientSdkFactory(
   private val objectMapper: ObjectMapper,
   private val okHttp3ClientConfiguration: OkHttp3ClientConfiguration
 ) : SdkFactory {
-  override fun create(extensionClass: Class<*>, pluginWrapper: PluginWrapper?): Any {
+
+  override fun create(pluginClass: Class<*>, pluginWrapper: PluginWrapper?): Any {
     return Ok3HttpClientRegistry(
-      IdResolver.pluginOrExtensionId(extensionClass, pluginWrapper),
+      IdResolver.pluginOrExtensionId(pluginClass, pluginWrapper),
       environment,
       objectMapper,
       okHttpClientFactory,
       okHttp3ClientConfiguration
-    )
-  }
+    )  }
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/serde/SerdeServiceSdkFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/serde/SerdeServiceSdkFactory.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.kork.plugins.sdk.serde
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory
+import org.pf4j.Plugin
 import org.pf4j.PluginWrapper
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationContext
@@ -53,6 +54,6 @@ class SerdeServiceSdkFactory(
       .let { SerdeServiceImpl(it) }
   }
 
-  override fun create(extensionClass: Class<*>, pluginWrapper: PluginWrapper?): Any =
+  override fun create(pluginClass: Class<*>, pluginWrapper: PluginWrapper?): Any =
     serdeService
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/yaml/JacksonYamlResourceLoader.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/yaml/JacksonYamlResourceLoader.kt
@@ -21,17 +21,21 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.netflix.spinnaker.kork.plugins.api.yaml.YamlResourceLoader
 
-class JacksonYamlResourceLoader(private val extensionClass: Class<*>) : YamlResourceLoader {
+class JacksonYamlResourceLoader(
+  private val pluginClass: Class<*>
+) : YamlResourceLoader {
 
-  private val mapper: ObjectMapper = ObjectMapper(YAMLFactory()).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+  private val mapper: ObjectMapper = ObjectMapper(YAMLFactory())
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
   override fun <T : Any?> loadResource(resourceName: String, toValueType: Class<T>): T? {
-
-    this.extensionClass.classLoader.getResourceAsStream(resourceName).use { inputStream ->
+    pluginClass.classLoader.getResourceAsStream(resourceName).use { inputStream ->
       if (inputStream != null) {
         return mapper.readValue(inputStream, toValueType)
       }
-      throw IllegalArgumentException("Cannot load specified resource: $resourceName , for extension: ${extensionClass.simpleName}")
+      throw IllegalArgumentException(
+        "Cannot load specified resource '$resourceName' for '${pluginClass.simpleName}'"
+      )
     }
   }
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/yaml/YamlResourceLoaderSdkFactory.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/yaml/YamlResourceLoaderSdkFactory.kt
@@ -17,14 +17,14 @@
 package com.netflix.spinnaker.kork.plugins.sdk.yaml
 
 import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory
+import org.pf4j.Plugin
 import org.pf4j.PluginWrapper
 
 /**
  * Creates YAML Resource Loader for the provided extension class.
  */
-class YamlResourceLoaderSdkFactory() : SdkFactory {
+class YamlResourceLoaderSdkFactory : SdkFactory {
 
-  override fun create(extensionClass: Class<*>, pluginWrapper: PluginWrapper?): Any {
-    return JacksonYamlResourceLoader(extensionClass)
-  }
+  override fun create(pluginClass: Class<*>, pluginWrapper: PluginWrapper?): Any =
+    JacksonYamlResourceLoader(pluginClass)
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizer.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizer.kt
@@ -34,7 +34,7 @@ class PluginSdksRegisteringCustomizer(
   override fun accept(plugin: Plugin, context: ConfigurableApplicationContext) {
     val sdk = PluginSdksImpl(
       serviceApplicationContext.getBeansOfType(SdkFactory::class.java).values
-        .map { it.create(Any::class.java, plugin.wrapper) }
+        .map { it.create(plugin.javaClass, plugin.wrapper) }
     )
     context.beanFactory.registerSingleton("pluginSdks", sdk)
   }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/yaml/JacksonYamlResourceLoaderTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/yaml/JacksonYamlResourceLoaderTest.kt
@@ -39,7 +39,7 @@ class JacksonYamlResourceLoaderTest : JUnit5Minutests {
         expectThrows<IllegalArgumentException> {
           subject.loadResource("unknown.yml", HashMap<String, String>().javaClass)
         }.and {
-          message.isEqualTo("Cannot load specified resource: unknown.yml , for extension: Fixture")
+          message.isEqualTo("Cannot load specified resource 'unknown.yml' for 'Fixture'")
         }
       }
 


### PR DESCRIPTION
I thought I could be lazy and just pass `Any::class.java` to the `SdkFactory` instead of the extension class, which is not available. This didn't work so hot because the resource loader SDK uses the value to load resources from the class path.

With this fix in, it looks like all of our plugins load as-is without modification under V2.