### PR TITLE
fix(plugins): Register PluginSdks to service application context

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -15,8 +15,7 @@
  */
 package com.netflix.spinnaker.config;
 
-import static com.netflix.spinnaker.kork.plugins.PackageKt.FRAMEWORK_V1;
-import static com.netflix.spinnaker.kork.plugins.PackageKt.FRAMEWORK_V2;
+import static com.netflix.spinnaker.kork.plugins.PackageKt.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.netflix.spectator.api.Registry;
@@ -141,7 +140,7 @@ public class PluginsAutoConfiguration {
 
   @Bean
   @ConditionalOnProperty(
-      value = "spinnaker.extensibility.framework.version",
+      value = FRAMEWORK_VERSION_CONFIG,
       havingValue = FRAMEWORK_V1,
       matchIfMissing = true)
   public static PluginFactory pluginFactoryV1(
@@ -150,9 +149,7 @@ public class PluginsAutoConfiguration {
   }
 
   @Bean
-  @ConditionalOnProperty(
-      value = "spinnaker.extensibility.framework.version",
-      havingValue = FRAMEWORK_V2)
+  @ConditionalOnProperty(value = FRAMEWORK_VERSION_CONFIG, havingValue = FRAMEWORK_V2)
   public static PluginFactory pluginFactoryV2(
       List<SdkFactory> sdkFactories,
       ConfigFactory configFactory,
@@ -319,7 +316,7 @@ public class PluginsAutoConfiguration {
 
   @Bean
   @ConditionalOnProperty(
-      value = "spinnaker.extensibility.framework.version",
+      value = FRAMEWORK_VERSION_CONFIG,
       havingValue = FRAMEWORK_V1,
       matchIfMissing = true)
   public static ExtensionBeanDefinitionRegistryPostProcessor pluginBeanPostProcessor(
@@ -339,9 +336,7 @@ public class PluginsAutoConfiguration {
   }
 
   @Bean
-  @ConditionalOnProperty(
-      value = "spinnaker.extensibility.framework.version",
-      havingValue = FRAMEWORK_V2)
+  @ConditionalOnProperty(value = FRAMEWORK_VERSION_CONFIG, havingValue = FRAMEWORK_V2)
   public SpinnakerPluginService spinnakerPluginService(
       SpinnakerPluginManager pluginManager,
       SpinnakerUpdateManager updateManager,
@@ -353,9 +348,7 @@ public class PluginsAutoConfiguration {
   }
 
   @Bean
-  @ConditionalOnProperty(
-      value = "spinnaker.extensibility.framework.version",
-      havingValue = FRAMEWORK_V2)
+  @ConditionalOnProperty(value = FRAMEWORK_VERSION_CONFIG, havingValue = FRAMEWORK_V2)
   PluginFrameworkInitializer pluginFrameworkInitializer(SpinnakerPluginService pluginService) {
     return new PluginFrameworkInitializer(pluginService);
   }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/package.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/package.kt
@@ -15,5 +15,6 @@
  */
 package com.netflix.spinnaker.kork.plugins
 
+const val FRAMEWORK_VERSION_CONFIG = "spinnaker.extensibility.framework.version"
 const val FRAMEWORK_V1 = "v1"
 const val FRAMEWORK_V2 = "v2"

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizer.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizer.kt
@@ -36,6 +36,6 @@ class PluginSdksRegisteringCustomizer(
       serviceApplicationContext.getBeansOfType(SdkFactory::class.java).values
         .map { it.create(plugin.javaClass, plugin.wrapper) }
     )
-    context.beanFactory.registerSingleton("pluginSdks", sdk)
+    serviceApplicationContext.beanFactory.registerSingleton("${plugin.wrapper.pluginId}-pluginSdks", sdk)
   }
 }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/scenarios/SdksAutowiringTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/scenarios/SdksAutowiringTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.v2.scenarios
+
+import com.netflix.spinnaker.config.PluginsAutoConfiguration
+import com.netflix.spinnaker.kork.plugins.FRAMEWORK_V2
+import com.netflix.spinnaker.kork.plugins.FRAMEWORK_VERSION_CONFIG
+import com.netflix.spinnaker.kork.plugins.api.PluginSdks
+import com.netflix.spinnaker.kork.plugins.testplugin.testPlugin
+import com.netflix.spinnaker.kork.plugins.v2.ApplicationContextGraph
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+
+class SdksAutowiringTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    test("PluginSdks is autowired") {
+      app.run { ctx: AssertableApplicationContext ->
+        val pluginSdks = ctx.getBean(PluginSdks::class.java)
+
+        expectThat(ApplicationContextGraph.pluginContext(generated.plugin.pluginId))
+          .isNotNull()
+          .get {
+            getBean("myExtension").let {
+              val field = it.javaClass.getDeclaredField("pluginSdks")
+              field.get(it)
+            }
+          }.isEqualTo(pluginSdks)
+      }
+    }
+  }
+
+  private inner class Fixture {
+    val generated = GENERATED
+    val app = ApplicationContextRunner()
+      .withPropertyValues(
+        "spring.application.name=kork",
+        "$FRAMEWORK_VERSION_CONFIG=$FRAMEWORK_V2",
+        "spinnaker.extensibility.plugins-root-path=${generated.rootPath.toAbsolutePath()}"
+      )
+      .withConfiguration(
+        AutoConfigurations.of(
+          PluginsAutoConfiguration::class.java
+        )
+      )
+      .enablePlugin(generated.plugin.pluginId)
+  }
+
+  companion object {
+    private val GENERATED = testPlugin {
+      sourceFile(
+        "MyExtension",
+        """
+          package {{basePackageName}};
+
+          import com.netflix.spinnaker.kork.plugins.api.PluginSdks;
+          import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
+
+          public class {{simpleName}} implements SpinnakerExtensionPoint {
+
+            public PluginSdks pluginSdks;
+
+            public {{simpleName}}(PluginSdks pluginSdks) {
+              this.pluginSdks = pluginSdks;
+            }
+          }
+        """.trimIndent()
+      )
+    }.run { generate() }
+  }
+}


### PR DESCRIPTION
We are observing issues of promoting beans that have `PluginSdks` in the constructor not being able to autowire the dependency. This actually happens after the extension has been initialized and successfully autowired with `PluginSdks` - it's occurring when promoting the extension to the service application context. For some reason, the parent service needs to know about the `PluginSdks` instance that has already been autowired.

This side-steps the issue by registering the `PluginSdks` implementation into the service application context, so the child looks up to the parent while resolving.