### PR TITLE
fix(plugins): V2 promote extensions as singletons

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/DefaultBeanPromoter.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/DefaultBeanPromoter.kt
@@ -25,11 +25,6 @@ class DefaultBeanPromoter(
 ) : BeanPromoter {
 
   override fun promote(beanName: String, bean: Any, beanClass: Class<*>) {
-    serviceApplicationContext.registerBean(
-      beanName,
-      beanClass,
-      { bean },
-      { }
-    )
+    serviceApplicationContext.beanFactory.registerSingleton(beanName, bean)
   }
 }


### PR DESCRIPTION
The original `DefaultBeanPromoter` was calling a convenience function on the `ApplicationContext` that Java was not correctly resolving, causing extensions to be autowiring candidates by the service; which caused breakages as we're selectively promoting beans to the service context. This simplification just registers the extension beans as singletons directly on the bean factory, which is what I wanted all along.