### PR TITLE
refactor(test): Migrate Spek to Spek2

### DIFF
--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -21,7 +21,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.platform:junit-platform-runner"
-  testImplementation "org.jetbrains.spek:spek-api" // Deprecated
+  testImplementation "org.spekframework.spek2:spek-dsl-jvm"
   testImplementation "com.nhaarman:mockito-kotlin:1.5.0" // Deprecated
   testImplementation "org.assertj:assertj-core"
   testImplementation "io.strikt:strikt-core"
@@ -32,11 +32,12 @@ dependencies {
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
   testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
   testRuntimeOnly "org.jetbrains.spek:spek-junit-platform-engine"
+  testRuntimeOnly "org.spekframework.spek2:spek-runner-junit5"
 }
 
 test {
   useJUnitPlatform {
-    includeEngines "spek", "junit-vintage", "junit-jupiter"
+    includeEngines "spek2", "junit-vintage", "junit-jupiter"
   }
 }
 

--- a/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/PagedIteratorSpec.kt
+++ b/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/PagedIteratorSpec.kt
@@ -28,42 +28,38 @@ import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.on
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.gherkin.Feature
 
 internal object PagedIteratorSpec : Spek({
 
-  describe("fetching paged data") {
-
+  Feature("fetching paged data") {
     val pageSize = 3
     val nextPage = mock<(Int, String?) -> Iterable<String>>()
 
-    given("there is no data") {
+    Scenario("there is no data") {
       val subject = PagedIterator(pageSize, String::toString, nextPage)
 
-      beforeGroup {
+      beforeScenario {
         whenever(nextPage(eq(pageSize), anyOrNull())) doReturn emptyList<String>()
       }
 
-      afterGroup { reset(nextPage) }
+      afterScenario { reset(nextPage) }
 
-      it("has no elements") {
+      Then("has no elements") {
         assertThat(subject.hasNext()).isFalse()
       }
 
-      it("won't return anything") {
+      Then("won't return anything") {
         assertThatThrownBy { subject.next() }
           .isInstanceOf<NoSuchElementException>()
       }
     }
 
-    given("there is less than one full page of data") {
+    Scenario("there is less than one full page of data") {
       val subject = PagedIterator(pageSize, String::toString, nextPage)
 
-      beforeGroup {
+      beforeScenario {
         whenever(nextPage(eq(pageSize), anyOrNull())) doAnswer {
           val (_, cursor) = it.arguments
           when (cursor) {
@@ -73,31 +69,31 @@ internal object PagedIteratorSpec : Spek({
         }
       }
 
-      afterGroup { reset(nextPage) }
+      afterScenario { reset(nextPage) }
 
-      it("has some elements") {
+      Given("has some elements") {
         assertThat(subject.hasNext()).isTrue()
       }
 
-      on("draining the iterator") {
-        val results = mutableListOf<String>()
+      val results = mutableListOf<String>()
+      When("draining the iterator") {
         subject.forEachRemaining { results.add(it) }
+      }
 
-        it("iterates over the available elements") {
-          assertThat(results).containsExactly("ONE", "TWO")
-        }
+      Then("iterates over the available elements") {
+        assertThat(results).containsExactly("ONE", "TWO")
+      }
 
-        it("does not try to fetch another page") {
-          verify(nextPage).invoke(pageSize, null)
-          verifyNoMoreInteractions(nextPage)
-        }
+      Then("does not try to fetch another page") {
+        verify(nextPage).invoke(pageSize, null)
+        verifyNoMoreInteractions(nextPage)
       }
     }
 
-    given("there is exactly one full page of data") {
+    Scenario("there is exactly one full page of data") {
       val subject = PagedIterator(pageSize, String::toString, nextPage)
 
-      beforeGroup {
+      beforeScenario {
         whenever(nextPage(eq(pageSize), anyOrNull())) doAnswer {
           val (_, cursor) = it.arguments
           when (cursor) {
@@ -107,32 +103,32 @@ internal object PagedIteratorSpec : Spek({
         }
       }
 
-      afterGroup { reset(nextPage) }
+      afterScenario { reset(nextPage) }
 
-      it("has some elements") {
+      Given("has some elements") {
         assertThat(subject.hasNext()).isTrue()
       }
 
-      on("draining the iterator") {
-        val results = mutableListOf<String>()
+      val results = mutableListOf<String>()
+      When("draining the iterator") {
         subject.forEachRemaining { results.add(it) }
+      }
 
-        it("iterates over the available elements") {
-          assertThat(results).containsExactly("ONE", "TWO", "THREE")
-        }
+      Then("iterates over the available elements") {
+        assertThat(results).containsExactly("ONE", "TWO", "THREE")
+      }
 
-        it("tries to fetch the next page before stopping") {
-          verify(nextPage).invoke(pageSize, null)
-          verify(nextPage).invoke(pageSize, "THREE")
-          verifyNoMoreInteractions(nextPage)
-        }
+      Then("tries to fetch the next page before stopping") {
+        verify(nextPage).invoke(pageSize, null)
+        verify(nextPage).invoke(pageSize, "THREE")
+        verifyNoMoreInteractions(nextPage)
       }
     }
 
-    given("there are multiple pages of data") {
+    Scenario("there are multiple pages of data") {
       val subject = PagedIterator(pageSize, String::toString, nextPage)
 
-      beforeGroup {
+      beforeScenario {
         whenever(nextPage(eq(pageSize), anyOrNull())) doAnswer {
           val (_, cursor) = it.arguments
           when (cursor) {
@@ -144,24 +140,24 @@ internal object PagedIteratorSpec : Spek({
         }
       }
 
-      afterGroup { reset(nextPage) }
+      afterScenario { reset(nextPage) }
 
-      it("has some elements") {
+      Given("has some elements") {
         assertThat(subject.hasNext()).isTrue()
       }
 
-      on("draining the iterator") {
-        val results = mutableListOf<String>()
+      val results = mutableListOf<String>()
+      When("draining the iterator") {
         subject.forEachRemaining { results.add(it) }
+      }
 
-        it("iterates over the available elements") {
-          assertThat(results)
-            .containsExactly("ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN")
-        }
+      Then("iterates over the available elements") {
+        assertThat(results)
+          .containsExactly("ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN")
+      }
 
-        it("does not try to fetch additional pages") {
-          verify(nextPage, times(3)).invoke(eq(pageSize), anyOrNull())
-        }
+      Then("does not try to fetch additional pages") {
+        verify(nextPage, times(3)).invoke(eq(pageSize), anyOrNull())
       }
     }
   }

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -20,6 +20,7 @@ ext {
     retrofit2        : "2.8.1",
     spectator        : "0.103.0",
     spek             : "1.2.1",
+    spek2            : "2.0.9",
     springBoot       : "2.2.5.RELEASE",
     springCloud      : "Greenwich.SR2",
     springfoxSwagger : "2.9.2",
@@ -134,6 +135,8 @@ dependencies {
     api("org.codehaus.groovy:groovy-all:${versions.groovy}")
     api("org.funktionale:funktionale-partials:1.2")
     api("org.jetbrains:annotations:19.0.0")
+    api("org.spekframework.spek2:spek-dsl-jvm:${versions.spek2}")
+    api("org.spekframework.spek2:spek-runner-junit5:${versions.spek2}")
     api("org.jetbrains.spek:spek-api:${versions.spek}")
     api("org.jetbrains.spek:spek-junit-platform-engine:${versions.spek}")
     api("org.jetbrains.spek:spek-junit-platform-runner:${versions.spek}")


### PR DESCRIPTION
Could've removed Spek from kork entirely, but I wanted to see how Spek 2.x works. 

Supposedly it has better IDE performance than Spek 1.x, but I haven't seen evidence of this yet via kork: Orca has some really large, phenomenally slow tests that could be upgraded that should give better results. Spek 1.x and Spek 2.x can live side-by-side, so I'll try converting a single test to compare, but kork has been entirely migrated.