### PR TITLE
feat(web): Add optional Zipkin integration to RawOkHttpClientFactory

### DIFF
--- a/kork-retrofit/kork-retrofit.gradle
+++ b/kork-retrofit/kork-retrofit.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.squareup.retrofit:converter-jackson"
+  implementation "io.zipkin.brave:brave-instrumentation-okhttp3"
 
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"

--- a/kork-retrofit/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/RetrofitServiceProviderTest.kt
+++ b/kork-retrofit/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/RetrofitServiceProviderTest.kt
@@ -17,6 +17,8 @@
 
 package com.netflix.spinnaker.kork.retrofit
 
+import brave.Tracing
+import brave.http.HttpTracing
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.RetrofitConfiguration
@@ -82,13 +84,17 @@ class RetrofitServiceProviderTest  : JUnit5Minutests {
 private open class TestConfiguration {
 
   @Bean
-  open fun okHttpClient(): OkHttpClient {
-    return RawOkHttpClientFactory().create(OkHttpClientConfigurationProperties(), emptyList())
+  open fun httpTracing(): HttpTracing =
+    HttpTracing.newBuilder(Tracing.newBuilder().build()).build()
+
+  @Bean
+  open fun okHttpClient(httpTracing: HttpTracing): OkHttpClient {
+    return RawOkHttpClientFactory().create(OkHttpClientConfigurationProperties(), emptyList(), httpTracing)
   }
 
   @Bean
   open fun okHttpClientProvider(okHttpClient: OkHttpClient): OkHttpClientProvider {
-    return OkHttpClientProvider(listOf(DefaultOkHttpClientBuilderProvider(okHttpClient,  OkHttpClientConfigurationProperties())))
+    return OkHttpClientProvider(listOf(DefaultOkHttpClientBuilderProvider(okHttpClient, OkHttpClientConfigurationProperties())))
   }
 
   @Bean

--- a/kork-retrofit2/kork-retrofit2.gradle
+++ b/kork-retrofit2/kork-retrofit2.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation "com.squareup.retrofit2:retrofit"
   implementation "com.squareup.retrofit2:converter-jackson"
   implementation "com.squareup.okhttp3:logging-interceptor:4.2.1"
+  implementation "io.zipkin.brave:brave-instrumentation-okhttp3"
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testRuntimeOnly "cglib:cglib-nodep"

--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -31,6 +31,8 @@ dependencies {
   implementation "com.google.guava:guava"
   implementation "javax.inject:javax.inject:1"
 
+  implementation "io.zipkin.brave:brave-instrumentation-okhttp3"
+
   compileOnly "org.springframework.boot:spring-boot-starter-actuator"
 
   testImplementation "org.spockframework:spock-core"

--- a/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/RawOkHttpClientConfiguration.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/RawOkHttpClientConfiguration.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.config.okhttp3;
 
+import brave.Tracing;
+import brave.http.HttpTracing;
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import java.util.List;
 import okhttp3.Interceptor;
@@ -29,6 +31,12 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(OkHttpClientConfigurationProperties.class)
 class RawOkHttpClientConfiguration {
 
+  @Bean
+  @ConditionalOnMissingBean
+  public HttpTracing httpTracing() {
+    return HttpTracing.newBuilder(Tracing.newBuilder().build()).build();
+  }
+
   /**
    * Default {@link OkHttpClient} that is correctly configured for service-to-service communication.
    */
@@ -36,7 +44,9 @@ class RawOkHttpClientConfiguration {
   @ConditionalOnMissingBean
   OkHttpClient okhttp3Client(
       OkHttpClientConfigurationProperties okHttpClientConfigurationProperties,
-      List<Interceptor> interceptors) {
-    return new RawOkHttpClientFactory().create(okHttpClientConfigurationProperties, interceptors);
+      List<Interceptor> interceptors,
+      HttpTracing httpTracing) {
+    return new RawOkHttpClientFactory()
+        .create(okHttpClientConfigurationProperties, interceptors, httpTracing);
   }
 }

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -8,6 +8,7 @@ ext {
   versions = [
     aws              : "1.11.820",
     bouncycastle     : "1.61",
+    brave            : "5.12.3",
     groovy           : "2.5.11", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
@@ -149,5 +150,6 @@ dependencies {
     api("org.springframework.security.extensions:spring-security-saml-dsl-core:1.0.5.RELEASE")
     api("org.springframework.security.extensions:spring-security-saml2-core:1.0.9.RELEASE")
     api("org.threeten:threeten-extra:1.0")
+    api("io.zipkin.brave:brave-instrumentation-okhttp3:${versions.brave}")
   }
 }


### PR DESCRIPTION
Doing the bare minimum for OSS here; getting Zipkin wired up into okhttp, but not configuring Sleuth. I suspect it's a slim chance that Zipkin is going to be utilized outside of Netflix, so I figured I would spare the effort of wiring that up for OSS.

Does this seem reasonable? Sleuth can always be added later for everyone else if there's demand.