### PR TITLE
fix(redis): fix parsing parameters from uri

### DIFF
--- a/kork-jedis/kork-jedis.gradle
+++ b/kork-jedis/kork-jedis.gradle
@@ -14,6 +14,7 @@ dependencies {
   testImplementation project(":kork-jedis-test")
   testImplementation "org.codehaus.groovy:groovy-all"
   testImplementation "org.spockframework:spock-core"
+  testImplementation "junit:junit"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
 }

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
@@ -65,10 +65,10 @@ public class JedisPoolFactory {
   }
 
   private static int parseDatabase(String path) {
-    if (path == null) {
-      return 0;
+    if (path == null || path.equals("") || path.equals("/")) {
+      return Protocol.DEFAULT_DATABASE;
     }
-    return Integer.parseInt(("/" + Protocol.DEFAULT_DATABASE).split("/", 2)[1]);
+    return Integer.parseInt(path.substring(1));
   }
 
   private static String parsePassword(String userInfo) {

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/JedisPoolFactory.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.Protocol;
 import redis.clients.jedis.util.Pool;
 
 public class JedisPoolFactory {
@@ -45,36 +44,24 @@ public class JedisPoolFactory {
       throw new MissingRequiredConfiguration("Jedis client must have a connection defined");
     }
 
-    URI redisConnection = URI.create(properties.connection);
-
-    String host = redisConnection.getHost();
-    int port = redisConnection.getPort() == -1 ? Protocol.DEFAULT_PORT : redisConnection.getPort();
-    int database = parseDatabase(redisConnection.getPath());
-    String password = parsePassword(redisConnection.getUserInfo());
+    RedisClientConnectionProperties cxp =
+        new RedisClientConnectionProperties(URI.create(properties.connection));
     GenericObjectPoolConfig poolConfig =
         Optional.ofNullable(properties.poolConfig).orElse(objectPoolConfig);
-    boolean isSSL = redisConnection.getScheme().equals("rediss");
 
     return new InstrumentedJedisPool(
         registry,
         // Pool name should always be "null", as setting this is incompat with some SaaS Redis
         // offerings
         new JedisPool(
-            poolConfig, host, port, properties.timeoutMs, password, database, null, isSSL),
+            poolConfig,
+            cxp.addr(),
+            cxp.port(),
+            properties.timeoutMs,
+            cxp.password(),
+            cxp.database(),
+            null,
+            cxp.isSSL()),
         name);
-  }
-
-  private static int parseDatabase(String path) {
-    if (path == null || path.equals("") || path.equals("/")) {
-      return Protocol.DEFAULT_DATABASE;
-    }
-    return Integer.parseInt(path.substring(1));
-  }
-
-  private static String parsePassword(String userInfo) {
-    if (userInfo == null) {
-      return null;
-    }
-    return userInfo.split(":", 2)[1];
   }
 }

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientConfiguration.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientConfiguration.java
@@ -223,7 +223,7 @@ public class RedisClientConfiguration {
     int port = cx.getPort() == -1 ? Protocol.DEFAULT_PORT : cx.getPort();
     String password =
         (cx.getUserInfo() != null && cx.getUserInfo().contains(":"))
-            ? cx.getUserInfo().substring(cx.getUserInfo().indexOf(":"))
+            ? cx.getUserInfo().substring(cx.getUserInfo().indexOf(":") + 1)
             : null;
 
     boolean isSSL = cx.getScheme().equals("rediss");

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientConfiguration.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientConfiguration.java
@@ -31,7 +31,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.Protocol;
 
 /**
  * Offers a standardized Spring configuration for a named redis clients, as well as primary and
@@ -220,23 +219,17 @@ public class RedisClientConfiguration {
 
   private JedisCluster getJedisCluster(
       GenericObjectPoolConfig objectPoolConfig, ClientConfigurationWrapper config, URI cx) {
-    int port = cx.getPort() == -1 ? Protocol.DEFAULT_PORT : cx.getPort();
-    String password =
-        (cx.getUserInfo() != null && cx.getUserInfo().contains(":"))
-            ? cx.getUserInfo().substring(cx.getUserInfo().indexOf(":") + 1)
-            : null;
-
-    boolean isSSL = cx.getScheme().equals("rediss");
+    RedisClientConnectionProperties cxp = new RedisClientConnectionProperties(cx);
 
     return new JedisCluster(
-        new HostAndPort(cx.getHost(), port),
+        new HostAndPort(cxp.addr(), cxp.port()),
         config.getTimeoutMs(),
         config.getTimeoutMs(),
         config.getMaxAttempts(),
-        password,
+        cxp.password(),
         null,
         objectPoolConfig,
-        isSSL);
+        cxp.isSSL());
   }
 
   @ConfigurationProperties(prefix = "redis")

--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientConnectionProperties.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/RedisClientConnectionProperties.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.jedis;
+
+import java.net.URI;
+import redis.clients.jedis.Protocol;
+
+public class RedisClientConnectionProperties {
+  private URI connection;
+
+  public RedisClientConnectionProperties(URI connection) {
+    this.connection = connection;
+  }
+
+  public boolean isSSL() {
+    return this.connection.getScheme().equals("rediss");
+  }
+
+  public String password() {
+    if (this.connection.getUserInfo() == null || !this.connection.getUserInfo().contains(":")) {
+      return null;
+    }
+    return this.connection.getUserInfo().split(":", 2)[1];
+  }
+
+  public String addr() {
+    return this.connection.getHost();
+  }
+
+  public int port() {
+    return this.connection.getPort() == -1 ? Protocol.DEFAULT_PORT : this.connection.getPort();
+  }
+
+  public int database() {
+    if (connection.getPath() == null
+        || connection.getPath().equals("")
+        || connection.getPath().equals("/")) {
+      return Protocol.DEFAULT_DATABASE;
+    }
+    return Integer.parseInt(connection.getPath().substring(1));
+  }
+}

--- a/kork-jedis/src/test/java/com/netflix/spinnaker/kork/jedis/RedisClientConnectionPropertiesTest.java
+++ b/kork-jedis/src/test/java/com/netflix/spinnaker/kork/jedis/RedisClientConnectionPropertiesTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.jedis;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import org.junit.Test;
+import redis.clients.jedis.Protocol;
+
+public class RedisClientConnectionPropertiesTest {
+  private static final String TEST_SSL_URI = "rediss://somehost.somedomain.net:8379/";
+  private static final String TEST_NON_SSL_URI = "redis://somehost.somedomain.net:8379/";
+  private static final String TEST_PASSWORD_URI =
+      "rediss://admin:S0meP%40ssw0rd@somehost.somedomain.net:8379/";
+  private static final String TEST_NO_PASSWORD_URI = "rediss://admin@somehost.somedomain.net:8379/";
+  private static final String TEST_CONFIGURED_PORT =
+      "rediss://admin:S0meP%40ssw0rd@somehost.somedomain.net:8379/";
+  private static final String TEST_DEFAULT_PORT =
+      "rediss://admin:S0meP@ssw0rd@somehost.somedomain.net/";
+  private static final String TEST_CONFGIURED_DATABASE =
+      "rediss://admin:S0meP%40ssw0rd@somehost.somedomain.net/8";
+  private static final String TEST_DEFAULT_DATABASE =
+      "rediss://admin:S0meP%40ssw0rd@somehost.somedomain.net";
+
+  @Test
+  public void getSSLwhenSSLScheme() {
+    URI uri = URI.create(TEST_SSL_URI);
+    RedisClientConnectionProperties rcp = new RedisClientConnectionProperties(uri);
+    assertTrue(rcp.isSSL());
+  }
+
+  @Test
+  public void getNotSSLwhenNotSSLScheme() {
+    URI uri = URI.create(TEST_NON_SSL_URI);
+    RedisClientConnectionProperties rcp = new RedisClientConnectionProperties(uri);
+    assertFalse(rcp.isSSL());
+  }
+
+  @Test
+  public void getConfiguredPassword() {
+    URI uri = URI.create(TEST_PASSWORD_URI);
+    RedisClientConnectionProperties rcp = new RedisClientConnectionProperties(uri);
+    assertEquals("S0meP@ssw0rd", rcp.password());
+  }
+
+  @Test
+  public void getNullWhenNoPassword() {
+    URI uri = URI.create(TEST_NO_PASSWORD_URI);
+    RedisClientConnectionProperties rcp = new RedisClientConnectionProperties(uri);
+    assertNull(rcp.password());
+  }
+
+  @Test
+  public void getConfiguredPort() {
+    URI uri = URI.create(TEST_CONFIGURED_PORT);
+    RedisClientConnectionProperties rcp = new RedisClientConnectionProperties(uri);
+    assertEquals(8379, rcp.port());
+  }
+
+  @Test
+  public void getDefaultPort() {
+    URI uri = URI.create(TEST_DEFAULT_PORT);
+    RedisClientConnectionProperties rcp = new RedisClientConnectionProperties(uri);
+    assertEquals(Protocol.DEFAULT_PORT, rcp.port());
+  }
+
+  @Test
+  public void getConfiguredDatabase() {
+    URI uri = URI.create(TEST_CONFGIURED_DATABASE);
+    RedisClientConnectionProperties rcp = new RedisClientConnectionProperties(uri);
+    assertEquals(8, rcp.database());
+  }
+
+  @Test
+  public void getDefaultDatabase() {
+    URI uri = URI.create(TEST_DEFAULT_DATABASE);
+    RedisClientConnectionProperties rcp = new RedisClientConnectionProperties(uri);
+    assertEquals(Protocol.DEFAULT_DATABASE, rcp.database());
+  }
+
+  @Test
+  public void getHost() {
+    URI uri = URI.create(TEST_SSL_URI);
+    RedisClientConnectionProperties rcp = new RedisClientConnectionProperties(uri);
+    assertEquals("somehost.somedomain.net", rcp.addr());
+  }
+}


### PR DESCRIPTION
Fixes parsing of `password` when using redis clusters, previously this included the basic authentication separator `:`  as part of the password.
Fixes parsing of `database` when using redis node pools, previously the default database `0` was always returned.
Moves these functions into `RedisClientConnectionProperties` so that they can be shared between redis types.