### PR TITLE
chore(dependencies): bring in specific spring version

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -22,6 +22,7 @@ ext {
     spectator        : "0.103.0",
     spek             : "1.2.1",
     spek2            : "2.0.9",
+    spring           : "5.2.9.RELEASE", // this should be kept in sync with spring-boot / removed once the need for a version override is gone
     springBoot       : "2.2.5.RELEASE",
     springCloud      : "Hoxton.SR4",
     springfoxSwagger : "2.9.2",
@@ -44,6 +45,7 @@ dependencies {
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
   api(platform("org.junit:junit-bom:5.6.2"))
   api(platform("com.fasterxml.jackson:jackson-bom:2.11.1"))
+  api(platform("org.springframework:spring-framework-bom:${versions.spring}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))


### PR DESCRIPTION
this allows us to bump Spring to a newer version independent of bumping Spring-Boot