### PR TITLE
feat(web): `AuthenticatedRequest.clear()` is now configurable

### DIFF
--- a/kork-web/src/main/groovy/com/netflix/spinnaker/filters/AuthenticatedRequestFilter.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/filters/AuthenticatedRequestFilter.groovy
@@ -53,13 +53,16 @@ class AuthenticatedRequestFilter implements Filter {
   private final boolean extractSpinnakerHeaders
   private final boolean extractSpinnakerUserOriginHeader
   private final boolean forceNewSpinnakerRequestId
+  private final boolean clearAuthenticatedRequestPostFilter
 
   public AuthenticatedRequestFilter(boolean extractSpinnakerHeaders = false,
                                     boolean extractSpinnakerUserOriginHeader = false,
-                                    boolean forceNewSpinnakerRequestId = false) {
+                                    boolean forceNewSpinnakerRequestId = false,
+                                    boolean clearAuthenticatedRequestPostFilter = true) {
     this.extractSpinnakerHeaders = extractSpinnakerHeaders
     this.extractSpinnakerUserOriginHeader = extractSpinnakerUserOriginHeader
     this.forceNewSpinnakerRequestId = forceNewSpinnakerRequestId
+    this.clearAuthenticatedRequestPostFilter = clearAuthenticatedRequestPostFilter
   }
 
   @Override
@@ -143,7 +146,9 @@ class AuthenticatedRequestFilter implements Filter {
 
       chain.doFilter(request, response)
     } finally {
-      AuthenticatedRequest.clear()
+      if (clearAuthenticatedRequestPostFilter) {
+        AuthenticatedRequest.clear()
+      }
     }
   }
 


### PR DESCRIPTION
This supports the `RequestLoggingFilter` in `gate` which would
benefit from the `AuthenticatedRequest` not being explicitly
cleared.

Specifically, the `RequestLoggingFilter` runs outside the
`AuthenticatedRequestFilter` and is missing some MDC variables
that are being prematurely cleared (X-SPINNAKER-REQUEST/USER).