### PR TITLE
feat(plugins): Include spinnaker-official and spinnaker-community repositories by default

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
@@ -63,6 +63,12 @@ public class PluginsConfigurationProperties {
    */
   public Map<String, PluginRepositoryProperties> repositories = new HashMap<>();
 
+  /**
+   * Whether or not to add the plugin repositories from https://github.com/spinnaker/plugins by
+   * default.
+   */
+  public boolean enableDefaultRepositories = true;
+
   /** Definition of a single {@link org.pf4j.update.UpdateRepository}. */
   public static class PluginRepositoryProperties {
     /** Flag to determine if repository is enabled. */


### PR DESCRIPTION
I'd like to get these behind our own DNS and CDN eventually, but I think this may suffice for now?