### PR TITLE
fix(plugins): Handle exception due to malformed configuration for plugin version

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/SpringPluginInfoReleaseSource.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/SpringPluginInfoReleaseSource.kt
@@ -36,7 +36,13 @@ class SpringPluginInfoReleaseSource(
   }
 
   private fun pluginInfoRelease(pluginInfo: SpinnakerPluginInfo): PluginInfoRelease? {
-    val pluginVersion = pluginStatusProvider.pluginVersion(pluginInfo.id)
+    val pluginVersion: String?
+    try {
+      pluginVersion = pluginStatusProvider.pluginVersion(pluginInfo.id)
+    } catch(e : IllegalArgumentException) {
+      log.error("Unable to read configured plugin version from Spring property due to: {}", e.message)
+      return null
+    }
     val release = pluginInfo.getReleases().firstOrNull { it.version == pluginVersion }
     return if (release != null) {
       log.info("Spring configured release version '{}' for plugin '{}'", release.version, pluginInfo.id)

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/SpringPluginInfoReleaseSourceTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/SpringPluginInfoReleaseSourceTest.kt
@@ -32,6 +32,7 @@ import io.mockk.mockk
 import strikt.api.expectThat
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
+import java.lang.IllegalArgumentException
 
 class SpringPluginInfoReleaseSourceTest : JUnit5Minutests {
 
@@ -64,6 +65,15 @@ class SpringPluginInfoReleaseSourceTest : JUnit5Minutests {
         .get { releases.size }.isEqualTo(2)
         .get { releases.find { it.pluginId == plugin1.id } }.isEqualTo(PluginInfoRelease(plugin1.id, plugin1ExpectedRelease))
         .get { releases.find { it.pluginId == plugin2.id } }.isEqualTo(PluginInfoRelease(plugin2.id, plugin2ExpectedRelease))
+    }
+
+    test("Skips plugin with version configuration that throws IllegalArgumentException") {
+      every { pluginStatusProvider.pluginVersion(plugin1.id) } throws IllegalArgumentException()
+
+      val releases = subject.getReleases(pluginInfoList.subList(0, 1))
+
+      expectThat(releases).isA<Set<PluginInfoRelease>>()
+        .get { releases.size }.isEqualTo(0)
     }
   }
 


### PR DESCRIPTION
We saw an issue wherein plugins failed to load (specifically, all Deck plugins in Gate's plugin cache) because of a bad plugin version configuration.  I think in this scenario it's reasonable to handle the exception so that we can allow other plugins to load.  The other version resolution mechanisms will still run here - latest version, preferred version, and pinned version in front50 - so the plugin will at least still load in a best effort manner.