### PR TITLE
test(sql/postgres): bump testcontainers, truncate cascade for PostgreSQL

### DIFF
--- a/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
+++ b/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
@@ -265,7 +265,14 @@ public class SqlTestUtil {
                     && !table.getName().equals(configuration.getDatabaseChangeLogLockTableName()))
         .forEach(
             table -> {
-              context.truncate(table.getName()).execute();
+              switch (context.dialect()) {
+                case POSTGRES:
+                  context.truncateTable(table.getName()).cascade().execute();
+                  break;
+                default:
+                  context.truncateTable(table.getName()).execute();
+                  break;
+              }
             });
     if (context.dialect() == SQLDialect.MYSQL) {
       context.execute("set foreign_key_checks=1");

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -52,7 +52,7 @@ dependencies {
   api(platform("io.strikt:strikt-bom:0.28.0"))
   api(platform("org.spockframework:spock-bom:1.3-groovy-2.5"))
   api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:1.5.17"))
-  api(platform("org.testcontainers:testcontainers-bom:1.14.3"))
+  api(platform("org.testcontainers:testcontainers-bom:1.15.0"))
   api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))
 
   constraints {


### PR DESCRIPTION
- Bump testcontainers to fix builds on MacOS (https://github.com/testcontainers/testcontainers-java/pull/3159)
- In Clouddriver, we (will) have foreign keys to deal with when and need to cascade.