### PR TITLE
feat(credentials): easily create customizable credential repositories

### DIFF
--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/NoopCredentialsLifecycleHandler.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/NoopCredentialsLifecycleHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials;
+
+public class NoopCredentialsLifecycleHandler<T extends Credentials>
+    implements CredentialsLifecycleHandler<T> {
+  @Override
+  public void credentialsAdded(T credentials) {}
+
+  @Override
+  public void credentialsUpdated(T credentials) {}
+
+  @Override
+  public void credentialsDeleted(T credentials) {}
+}

--- a/kork-credentials/kork-credentials.gradle
+++ b/kork-credentials/kork-credentials.gradle
@@ -23,6 +23,15 @@ dependencies {
   implementation "org.springframework.boot:spring-boot"
   implementation 'javax.annotation:javax.annotation-api'
   implementation 'org.slf4j:slf4j-api'
+
+  testRuntimeOnly "cglib:cglib-nodep"
+  testRuntimeOnly "org.objenesis:objenesis"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+
+  testImplementation "org.mockito:mockito-core"
+  testImplementation "org.assertj:assertj-core"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-params"
 }
 
 test {

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypeBaseConfiguration.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypeBaseConfiguration.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.netflix.spinnaker.credentials.definition.*;
+import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.BasicCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.core.ResolvableType;
+
+/**
+ * CredentialsTypeBaseConfiguration is a convenient way to configure {@link CredentialsRepository}
+ * and {@link AbstractCredentialsLoader} for all the {@link CredentialsTypeProperties} configured in
+ * the system.
+ *
+ * <p>It will try to reuse any {@link CredentialsRepository}, {@link CredentialsDefinitionSource},
+ * {@link CredentialsParser}, {@link CredentialsLifecycleHandler}, or {@link
+ * AbstractCredentialsLoader} that may have been added as a bean and create default implementations
+ * otherwise.
+ */
+@RequiredArgsConstructor
+public class CredentialsTypeBaseConfiguration implements ApplicationContextAware {
+  protected final List<CredentialsTypeProperties<?, ?>> credentialsTypeProperties;
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    credentialsTypeProperties.forEach(
+        prop -> initializeCredentialsRepository(prop, applicationContext));
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <T extends Credentials, U extends CredentialsDefinition>
+      void initializeCredentialsRepository(
+          CredentialsTypeProperties<T, U> properties, ApplicationContext applicationContext) {
+    // Get or build lifecycle handler
+    CredentialsLifecycleHandler<?> lifecycleHandler =
+        getParameterizedBean(
+                applicationContext,
+                CredentialsLifecycleHandler.class,
+                properties.getCredentialsClass())
+            .orElseGet(NoopCredentialsLifecycleHandler::new);
+
+    // Get or build credentials repository
+    CredentialsRepository<T> credentialsRepository =
+        getParameterizedBean(
+                applicationContext, CredentialsRepository.class, properties.getCredentialsClass())
+            .orElseGet(
+                () ->
+                    registerCredentialsRepository(
+                        applicationContext, properties, lifecycleHandler));
+
+    // Get or build credential source
+    CredentialsDefinitionSource<U> credentialsDefinitionSource =
+        getParameterizedBean(
+                applicationContext,
+                CredentialsDefinitionSource.class,
+                properties.getCredentialsDefinitionClass())
+            .orElse(properties.getDefaultCredentialsSource());
+
+    // Get or build credentials parser
+    CredentialsParser<U, T> credentialsParser =
+        getParameterizedBean(
+                applicationContext,
+                CredentialsParser.class,
+                properties.getCredentialsDefinitionClass(),
+                properties.getCredentialsClass())
+            .orElse(properties.getCredentialsParser());
+
+    // Get or build credentials loader
+    AbstractCredentialsLoader<T> credentialsLoader =
+        getParameterizedBean(
+                applicationContext,
+                AbstractCredentialsLoader.class,
+                properties.getCredentialsClass())
+            .orElseGet(
+                () ->
+                    registerCredentialsLoader(
+                        applicationContext,
+                        properties,
+                        credentialsDefinitionSource,
+                        credentialsParser,
+                        credentialsRepository));
+
+    // Get or build poller
+    credentialsLoader.load();
+  }
+
+  /**
+   * Registers a new MapBackedCredentialsRepository under the name "credentialsRepository.[type]"
+   *
+   * @param context
+   * @param properties
+   * @param lifecycleHandler
+   * @param <T>
+   * @return Credentials repository registered in Spring
+   */
+  @SuppressWarnings("unchecked")
+  protected <T extends Credentials> CredentialsRepository<T> registerCredentialsRepository(
+      ApplicationContext context,
+      CredentialsTypeProperties<T, ?> properties,
+      CredentialsLifecycleHandler<?> lifecycleHandler) {
+
+    RootBeanDefinition bd = new RootBeanDefinition();
+    bd.setTargetType(
+        ResolvableType.forClassWithGenerics(
+            CredentialsRepository.class, properties.getCredentialsClass()));
+    bd.setBeanClass(MapBackedCredentialsRepository.class);
+    ConstructorArgumentValues values = new ConstructorArgumentValues();
+    values.addGenericArgumentValue(properties.getType());
+    values.addGenericArgumentValue(lifecycleHandler);
+    bd.setConstructorArgumentValues(values);
+
+    String beanName = "credentialsRepository." + properties.getType();
+    ((DefaultListableBeanFactory) ((AbstractApplicationContext) context).getBeanFactory())
+        .registerBeanDefinition(beanName, bd);
+    return context.getBean(beanName, MapBackedCredentialsRepository.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <T extends Credentials, U extends CredentialsDefinition>
+      AbstractCredentialsLoader<T> registerCredentialsLoader(
+          ApplicationContext context,
+          CredentialsTypeProperties<T, U> properties,
+          CredentialsDefinitionSource<U> credentialsDefinitionSource,
+          CredentialsParser<U, T> credentialsParser,
+          CredentialsRepository<T> credentialsRepository) {
+
+    RootBeanDefinition bd = new RootBeanDefinition();
+    bd.setTargetType(
+        ResolvableType.forClassWithGenerics(
+            AbstractCredentialsLoader.class, properties.getCredentialsClass()));
+    bd.setBeanClass(BasicCredentialsLoader.class);
+    ConstructorArgumentValues values = new ConstructorArgumentValues();
+    values.addGenericArgumentValue(credentialsDefinitionSource);
+    values.addGenericArgumentValue(credentialsParser);
+    values.addGenericArgumentValue(credentialsRepository);
+    bd.setConstructorArgumentValues(values);
+
+    String beanName = "credentialsLoader." + properties.getType();
+    ((DefaultListableBeanFactory) ((AbstractApplicationContext) context).getBeanFactory())
+        .registerBeanDefinition(beanName, bd);
+    return context.getBean(beanName, AbstractCredentialsLoader.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <T> Optional<T> getParameterizedBean(
+      ApplicationContext applicationContext, Class<T> paramClass, Class<?>... generics) {
+    ResolvableType resolvableType = ResolvableType.forClassWithGenerics(paramClass, generics);
+    String[] beanNames = applicationContext.getBeanNamesForType(resolvableType);
+    if (beanNames.length == 1) {
+      return Optional.of((T) applicationContext.getBean(beanNames[0]));
+    }
+    if (beanNames.length == 0) {
+      return Optional.empty();
+    }
+    throw new IllegalArgumentException(
+        beanNames.length
+            + " beans found of class "
+            + paramClass
+            + " ("
+            + generics.length
+            + " generics)");
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypeProperties.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypeProperties.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CredentialsTypeProperties<T extends Credentials, U extends CredentialsDefinition> {
+  private final String type;
+  private final Class<T> credentialsClass;
+  private final Class<U> credentialsDefinitionClass;
+  private final CredentialsDefinitionSource<U> defaultCredentialsSource;
+  private final CredentialsParser<U, T> credentialsParser;
+}

--- a/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/CredentialsTypeBaseConfigurationTest.java
+++ b/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/CredentialsTypeBaseConfigurationTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+import java.util.Collections;
+import java.util.List;
+import lombok.Data;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.support.StaticApplicationContext;
+
+public class CredentialsTypeBaseConfigurationTest {
+  private static final String CREDENTIALS_TYPE = "test";
+  private StaticApplicationContext context;
+  private CredentialsTypeBaseConfiguration config;
+
+  @BeforeEach
+  public void setup() {
+    CredentialsDefinitionSource<TestAccount> source =
+        () -> List.of(new TestAccount("account1"), new TestAccount("account2"));
+    CredentialsTypeProperties<TestCredentials, TestAccount> props =
+        CredentialsTypeProperties.<TestCredentials, TestAccount>builder()
+            .type(CREDENTIALS_TYPE)
+            .credentialsClass(TestCredentials.class)
+            .credentialsDefinitionClass(TestAccount.class)
+            .defaultCredentialsSource(source)
+            .credentialsParser(TestCredentials::new)
+            .build();
+    context = new StaticApplicationContext();
+    config = new CredentialsTypeBaseConfiguration(Collections.singletonList(props));
+  }
+
+  @Test
+  public void testCreateCredentials() {
+    config.setApplicationContext(context);
+    CredentialsRepository<TestCredentials> repository =
+        context.getBean(CredentialsRepository.class);
+    assertThat(repository).isNotNull();
+    assertThat(repository.getOne("account1")).isNotNull();
+  }
+
+  @Test
+  public void testOverrideParser() {
+    context.registerBean("customParser", TestCustomParser.class);
+    config.setApplicationContext(context);
+
+    CredentialsRepository<TestCredentials> repository =
+        context.getBean(CredentialsRepository.class);
+    assertThat(repository).isNotNull();
+    TestCredentials cred = repository.getOne("account1");
+    assertThat(cred).isNotNull();
+    assertThat(cred.getProperty()).isNotBlank().isEqualTo("my-value");
+  }
+
+  @Test
+  public void testOverrideLifecycleHandler() {
+    TestLifecycleHandler handler = Mockito.mock(TestLifecycleHandler.class);
+    context.getBeanFactory().registerSingleton("customLifecycleHandler", handler);
+    config.setApplicationContext(context);
+
+    CredentialsRepository<TestCredentials> repository =
+        context.getBean(CredentialsRepository.class);
+    assertThat(repository).isNotNull();
+    TestCredentials cred = repository.getOne("account1");
+    Mockito.verify(handler).credentialsAdded(cred);
+  }
+
+  @Test
+  public void testOverrideSource() {
+    CredentialsDefinitionSource<TestAccount> source =
+        new TestSource(List.of(new TestAccount("account3"), new TestAccount("account4")));
+    context.getBeanFactory().registerSingleton("customSource", source);
+    config.setApplicationContext(context);
+
+    CredentialsRepository<TestCredentials> repository =
+        context.getBean(CredentialsRepository.class);
+    assertThat(repository).isNotNull();
+    assertThat(repository.getOne("account3")).isNotNull();
+    assertThat(repository.getOne("account1")).isNull();
+  }
+
+  @Test
+  public void testOverrideCredentialsRepository() {
+    TestCredentialsRepository repository =
+        new TestCredentialsRepository(CREDENTIALS_TYPE, new NoopCredentialsLifecycleHandler<>());
+    context.getBeanFactory().registerSingleton("customRepository", repository);
+    config.setApplicationContext(context);
+
+    String[] beanNames = context.getBeanNamesForType(CredentialsRepository.class);
+    assertThat(beanNames).hasSize(1);
+    assertThat(beanNames[0]).isEqualTo("customRepository");
+  }
+
+  private static class TestCredentialsRepository
+      extends MapBackedCredentialsRepository<TestCredentials> {
+
+    public TestCredentialsRepository(
+        String type, CredentialsLifecycleHandler<TestCredentials> eventHandler) {
+      super(type, eventHandler);
+    }
+  }
+
+  @Data
+  private static class TestAccount implements CredentialsDefinition {
+    private final String name;
+  }
+
+  @Data
+  private static class TestSource implements CredentialsDefinitionSource<TestAccount> {
+    private final List<TestAccount> credentialsDefinitions;
+  }
+
+  private static class TestCustomParser implements CredentialsParser<TestAccount, TestCredentials> {
+    @Override
+    public TestCredentials parse(TestAccount account) {
+      TestCredentials creds = new TestCredentials(account);
+      creds.setProperty("my-value");
+      return creds;
+    }
+  }
+
+  private static class TestLifecycleHandler
+      extends NoopCredentialsLifecycleHandler<TestCredentials> {}
+
+  @Data
+  private static class TestCredentials implements Credentials {
+    private final TestAccount testAccount;
+    private String property;
+
+    public String getName() {
+      return testAccount.getName();
+    }
+
+    @Override
+    public String getType() {
+      return CREDENTIALS_TYPE;
+    }
+  }
+}


### PR DESCRIPTION
This adds an easier way to configure credentials repository. This will be used when converting artifact credentials. For instance, the logic in https://github.com/spinnaker/clouddriver/blob/master/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/config/KubernetesConfiguration.java would become:

```
  @Bean
  public CredentialsTypeProperties<KubernetesNamedAccountCredentials, KubernetesConfigurationProperties.ManagedAccount> kubernetesCredentials(
    KubernetesConfigurationProperties configurationProperties,
    KubernetesCredentials.Factory kubernetesCredentialFactory) {
    return CredentialsTypeProperties.<KubernetesNamedAccountCredentials, KubernetesConfigurationProperties.ManagedAccount>builder()
      .credentialsDefinitionClass(KubernetesConfigurationProperties.ManagedAccount.class)
      .credentialsClass(KubernetesNamedAccountCredentials.class)
      .credentialsParser(a -> new KubernetesNamedAccountCredentials(a, kubernetesCredentialFactory))
      .defaultCredentialsSource(configurationProperties::getAccounts)
      .build();
  }
```