### PR TITLE
fix(cves): Outdated commons collection library constraints

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -114,6 +114,8 @@ dependencies {
     api("com.vdurmont:semver4j:3.1.0")
     api("commons-configuration:commons-configuration:1.8")
     api("commons-io:commons-io:2.5")
+    // CVE's in 3.2.1
+    api("commons-collections:commons-collections:[3.2.2,3.3)")
     api("de.danielbechler:java-object-diff:0.95")
     api("de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.2.0")
     api("dev.minutest:minutest:1.11.0")


### PR DESCRIPTION
Makes sure services are using a more recent commons collection that has some CVE fixes.  3.2.2 is really the last released version of this library, and I'd not expect any additional updates on this particular library.  This fix is a "safeguard" vs. any real known vulnerability that mostly impacts security scans.