### PR TITLE
fix(logging): only log a warning when the generic handler handles an …

### DIFF
--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/GenericExceptionHandlers.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/GenericExceptionHandlers.java
@@ -119,6 +119,7 @@ public class GenericExceptionHandlers extends ResponseEntityExceptionHandler {
   @ExceptionHandler(Exception.class)
   public void handleException(Exception e, HttpServletResponse response, HttpServletRequest request)
       throws IOException {
+    logger.warn("Handled error in generic exception handler", e);
     storeException(request, response, e);
 
     ResponseStatus responseStatus =
@@ -149,7 +150,6 @@ public class GenericExceptionHandlers extends ResponseEntityExceptionHandler {
       HttpServletRequest request, HttpServletResponse response, Exception ex) {
     // store exception as an attribute of HttpServletRequest such that it can be referenced by
     // GenericErrorController
-    logger.warn("Handled error in generic exception handler", ex);
     defaultErrorAttributes.resolveException(request, response, null, ex);
   }
 


### PR DESCRIPTION
…exception

The other @ExceptionHandler methods call storeException too, so move the warning to
@ExceptionHandler(Exception.class)