### PR TITLE
chore(swagger): Upgrade SpringFox and Swagger

### DIFF
--- a/kork-swagger/src/main/java/com/netflix/spinnaker/config/SwaggerConfig.java
+++ b/kork-swagger/src/main/java/com/netflix/spinnaker/config/SwaggerConfig.java
@@ -16,13 +16,10 @@
 
 package com.netflix.spinnaker.config;
 
-import static com.google.common.base.Predicates.or;
-
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -32,11 +29,9 @@ import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.paths.AbstractPathProvider;
+import springfox.documentation.spring.web.paths.DefaultPathProvider;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-@EnableSwagger2
 @Configuration
 @ConditionalOnProperty("swagger.enabled")
 @ConfigurationProperties(prefix = "swagger")
@@ -80,7 +75,7 @@ public class SwaggerConfig {
   }
 
   private Predicate<String> paths() {
-    return or(patterns.stream().map(PathSelectors::regex).collect(Collectors.toList()));
+    return patterns.stream().map(PathSelectors::regex).reduce(x -> false, Predicate::or);
   }
 
   private ApiInfo apiInfo() {
@@ -123,7 +118,8 @@ public class SwaggerConfig {
     return documentationPath;
   }
 
-  public class BasePathProvider extends AbstractPathProvider {
+  // TODO: make sure this works given https://github.com/springfox/springfox/issues/3493
+  public class BasePathProvider extends DefaultPathProvider {
     private String basePath;
     private String documentationPath;
 
@@ -133,13 +129,13 @@ public class SwaggerConfig {
     }
 
     @Override
-    protected String applicationPath() {
-      return basePath;
+    public String getOperationPath(String operationPath) {
+      return documentationPath + "/" + super.getOperationPath(operationPath);
     }
 
     @Override
-    protected String getDocumentationPath() {
-      return documentationPath;
+    public String getResourceListingPath(String groupName, String apiDeclaration) {
+      return documentationPath + "/" + super.getResourceListingPath(groupName, apiDeclaration);
     }
   }
 }

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -25,8 +25,8 @@ ext {
     spring           : "5.2.9.RELEASE", // this should be kept in sync with spring-boot / removed once the need for a version override is gone
     springBoot       : "2.2.5.RELEASE",
     springCloud      : "Hoxton.SR4",
-    springfoxSwagger : "2.9.2",
-    swagger          : "1.5.20" //this should stay in sync with what springfoxSwagger expects
+    springfoxSwagger : "3.0.0",
+    swagger          : "2.1.2" //this should stay in sync with what springfoxSwagger expects
   ]
 }
 
@@ -127,7 +127,7 @@ dependencies {
     api("io.mockk:mockk:1.10.0")
     api("io.springfox:springfox-swagger-ui:${versions.springfoxSwagger}")
     api("io.springfox:springfox-swagger2:${versions.springfoxSwagger}")
-    api("io.swagger:swagger-annotations:${versions.swagger}")
+    api("io.swagger.core.v3:swagger-annotations:${versions.swagger}")
     api("javax.annotation:javax.annotation-api:1.3.2")
     api("javax.xml.bind:jaxb-api:2.3.1")
     api("mysql:mysql-connector-java:8.0.20")


### PR DESCRIPTION
Upgrades SpringFox, which brings with it a newer/better version of Swagger. Among other things, this fixes the forever-annoying issue with the Swagger UI not properly auto-scrolling and auto-expanding a linked API section.

I haven't been able to test this yet, hence the draft. Something in the updated dependency tree broke loading of one of keel's plugins. 😞   If anyone has some spare cycles and could try this with another service, it would be greatly appreciated.

Heads-up: the new version changes the Swagger UI path from `/swagger-ui.html` to `/swagger-ui/index.html`. There's no way to customize that as far as I've seen. Not sure how big of a deal that would be.