### PR TITLE
feat(web): Generic exception handler support for `IllegalArgumentException`

### DIFF
--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/GenericExceptionHandlers.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/GenericExceptionHandlers.java
@@ -72,7 +72,11 @@ public class GenericExceptionHandlers extends ResponseEntityExceptionHandler {
         HttpStatus.NOT_FOUND.value(), exceptionMessageDecorator.decorate(e, e.getMessage()));
   }
 
-  @ExceptionHandler({InvalidRequestException.class, UserException.class})
+  @ExceptionHandler({
+    InvalidRequestException.class,
+    UserException.class,
+    IllegalArgumentException.class
+  })
   public void handleInvalidRequestException(
       Exception e, HttpServletResponse response, HttpServletRequest request) throws IOException {
     storeException(request, response, e);

--- a/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/exceptions/GenericExceptionHandlersMvcSpec.groovy
+++ b/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/exceptions/GenericExceptionHandlersMvcSpec.groovy
@@ -60,6 +60,14 @@ class GenericExceptionHandlersMvcSpec extends Specification {
     entity.statusCode == HttpStatus.BAD_REQUEST
   }
 
+  def "should map IllegalArgumentException as 400"() {
+    when:
+    def entity = restTemplate.getForEntity("http://localhost:$port/test-controller/illegalArgumentException", HashMap.class)
+
+    then: "status is 400"
+    entity.statusCode == HttpStatus.BAD_REQUEST
+  }
+
   @Import(ErrorConfiguration)
   @Configuration
   @EnableAutoConfiguration
@@ -93,6 +101,11 @@ class GenericExceptionHandlersMvcSpec extends Specification {
 
     @GetMapping("/path1")
     void get(@RequestParam("param") String param) {
+    }
+
+    @GetMapping("/illegalArgumentException")
+    void illegalArgumentException() {
+      throw new IllegalArgumentException()
     }
 
   }


### PR DESCRIPTION
Replaces a one-off `ExceptionHandler` in `clouddriver`.

See: https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy#L97