### PR TITLE
fix(plugins): Use getter/setters for accessing config flag

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -288,7 +288,7 @@ public class PluginsAutoConfiguration {
                         new CompoundVerifier()))
             .collect(Collectors.toList());
 
-    if (properties.enableDefaultRepositories) {
+    if (properties.isEnableDefaultRepositories()) {
       log.info("Enabling spinnaker-official and spinnaker-community plugin repositories");
 
       repositories.add(

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
@@ -67,7 +67,15 @@ public class PluginsConfigurationProperties {
    * Whether or not to add the plugin repositories from https://github.com/spinnaker/plugins by
    * default.
    */
-  public boolean enableDefaultRepositories = true;
+  private boolean enableDefaultRepositories = true;
+
+  public boolean isEnableDefaultRepositories() {
+    return enableDefaultRepositories;
+  }
+
+  public void setEnableDefaultRepositories(boolean enableDefaultRepositories) {
+    this.enableDefaultRepositories = enableDefaultRepositories;
+  }
 
   /** Definition of a single {@link org.pf4j.update.UpdateRepository}. */
   public static class PluginRepositoryProperties {


### PR DESCRIPTION
An oddity here, I'm not really sure why things are buggered here for people.