### PR TITLE
feat(plugins): Get plugin ID from proxied spinnaker extension point

### DIFF
--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/internal/ExtensionInvocationHandler.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/internal/ExtensionInvocationHandler.java
@@ -27,4 +27,7 @@ public interface ExtensionInvocationHandler extends InvocationHandler {
 
   /** Get the proxy target class. */
   Class<? extends SpinnakerExtensionPoint> getTargetClass();
+
+  /** Get the plugin ID of the proxied extension point. */
+  String getPluginId();
 }

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/internal/ExtensionPointMetadataProvider.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/internal/ExtensionPointMetadataProvider.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.kork.plugins.api.internal;
 
 import java.lang.reflect.Proxy;
 
-class ExtensionClassProvider {
+public class ExtensionPointMetadataProvider {
 
   public static Class<? extends SpinnakerExtensionPoint> getExtensionClass(
       SpinnakerExtensionPoint extensionPoint) {
@@ -29,5 +29,14 @@ class ExtensionClassProvider {
       return extensionInvocationHandler.getTargetClass();
     }
     return extensionPoint.getClass();
+  }
+
+  public static String getPluginId(SpinnakerExtensionPoint extensionPoint) {
+    if (Proxy.isProxyClass(extensionPoint.getClass())) {
+      ExtensionInvocationHandler extensionInvocationHandler =
+          (ExtensionInvocationHandler) Proxy.getInvocationHandler(extensionPoint);
+      return extensionInvocationHandler.getPluginId();
+    }
+    return "default";
   }
 }

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/internal/SpinnakerExtensionPoint.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/internal/SpinnakerExtensionPoint.java
@@ -23,11 +23,19 @@ import org.pf4j.ExtensionPoint;
 public interface SpinnakerExtensionPoint extends ExtensionPoint {
 
   /**
+   * Return the plugin ID this extension point implementation is associated with. Returns "default"
+   * if extension point is not associated with a plugin.
+   */
+  default String getPluginId() {
+    return ExtensionPointMetadataProvider.getPluginId(this);
+  }
+
+  /**
    * Spinnaker extension points are typically proxied to provide some extension invocation
    * instrumentation (logging, metrics, etc). To get the extension class type, use this method
    * instead of {@link #getClass()}.
    */
   default Class<? extends SpinnakerExtensionPoint> getExtensionClass() {
-    return ExtensionClassProvider.getExtensionClass(this);
+    return ExtensionPointMetadataProvider.getExtensionClass(this);
   }
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/ExtensionInvocationProxy.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/ExtensionInvocationProxy.kt
@@ -44,6 +44,8 @@ class ExtensionInvocationProxy(
     return target.javaClass
   }
 
+  override fun getPluginId(): String = pluginDescriptor.pluginId
+
   override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
     val invocationStates: MutableSet<InvocationState> = mutableSetOf()
     invocationStates.before(proxy, method, args)

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/LazyExtensionInvocationProxy.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/LazyExtensionInvocationProxy.kt
@@ -44,6 +44,8 @@ class LazyExtensionInvocationProxy(
 
   override fun getTargetClass(): Class<out SpinnakerExtensionPoint> = targetClass
 
+  override fun getPluginId(): String = descriptor.pluginId
+
   override fun invoke(proxy: Any, method: Method, args: Array<out Any>?) = delegate.invoke(proxy, method, args)
 
   companion object {


### PR DESCRIPTION
So a service can have some understanding of plugin IDs associated with extension point instances, if need be.