### PR TITLE
feat(plugins): Support application event listeners

### DIFF
--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/events/Async.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/events/Async.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.api.events;
+
+import com.netflix.spinnaker.kork.annotations.Beta;
+import java.lang.annotation.*;
+
+/** Used to mark a {@link SpinnakerEventListener} as asynchronous. */
+@Beta
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+public @interface Async {}

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/events/SpinnakerApplicationEvent.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/events/SpinnakerApplicationEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.api.events;
+
+import javax.annotation.Nullable;
+
+/** The base type for all Spinnaker application events that are accessible by plugins. */
+public interface SpinnakerApplicationEvent {
+
+  /**
+   * The originating object that created the event.
+   *
+   * <p>IMPORTANT: Service developers should exercise caution setting this value, as it could leak
+   * an internal service class, establishing an unwanted implicit contract with plugin developers.
+   */
+  @Nullable
+  Object getSource();
+
+  /** The timestamp (epoch milliseconds) when the event was created. */
+  long getTimestamp();
+}

--- a/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/events/SpinnakerEventListener.java
+++ b/kork-plugins-api/src/main/java/com/netflix/spinnaker/kork/plugins/api/events/SpinnakerEventListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.api.events;
+
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
+import javax.annotation.Nonnull;
+
+/**
+ * An application event listener for Spinnaker events that can be utilized by plugins.
+ *
+ * @param <E> the type of event the listener is for
+ */
+@FunctionalInterface
+public interface SpinnakerEventListener<E extends SpinnakerApplicationEvent>
+    extends SpinnakerExtensionPoint {
+
+  /**
+   * Handles an event of type {@link E}.
+   *
+   * @param event the inbound event
+   */
+  void onApplicationEvent(@Nonnull E event);
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/ApplicationEventListenerBeanPostProcessor.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/ApplicationEventListenerBeanPostProcessor.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.v2
+
+import com.netflix.spinnaker.kork.plugins.api.events.Async
+import com.netflix.spinnaker.kork.plugins.api.events.SpinnakerEventListener
+import org.springframework.beans.factory.config.BeanPostProcessor
+import org.springframework.context.ApplicationListener
+import org.springframework.core.annotation.AnnotationUtils
+
+/**
+ * Adapts [SpinnakerEventListener] instances to Spring's [ApplicationListener].
+ *
+ * This seems to be the least invasive method of registering application event listeners for plugins. It would've been
+ * nice to use a facade `EventListener` annotation, but Spring's processing for this annotation is closed to the
+ * modifications needed to make it work easily. The side effect of creating an adapter here is that plugin event
+ * listeners will be invoked more often than they need to; deferring filtering of events to the adapter itself, rather
+ * than using Spring to do this for us.
+ */
+class ApplicationEventListenerBeanPostProcessor : BeanPostProcessor {
+
+  @Suppress("UNCHECKED_CAST")
+  override fun postProcessBeforeInitialization(bean: Any, beanName: String): Any? {
+    if (SpinnakerEventListener::class.java.isAssignableFrom(bean.javaClass)) {
+      return if (AnnotationUtils.findAnnotation(bean.javaClass, Async::class.java) == null) {
+        SpringEventListenerAdapter(bean as SpinnakerEventListener<*>)
+      } else {
+        AsyncSpringEventListenerAdapter(bean as SpinnakerEventListener<*>)
+      }
+    }
+    return super.postProcessBeforeInitialization(bean, beanName)
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/AsyncSpringEventListenerAdapter.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/AsyncSpringEventListenerAdapter.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.v2
+
+import com.netflix.spinnaker.kork.plugins.api.events.SpinnakerEventListener
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.scheduling.annotation.Async
+
+/**
+ * Creates an asynchronous [ApplicationListener], delegating all implementation to [SpringEventListenerAdapter].
+ */
+class AsyncSpringEventListenerAdapter(
+  eventListener: SpinnakerEventListener<*>
+) : ApplicationListener<ApplicationEvent> {
+
+  private val adapter = SpringEventListenerAdapter(eventListener)
+
+  @Async
+  override fun onApplicationEvent(event: ApplicationEvent) {
+    adapter.onApplicationEvent(event)
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringEventListenerAdapter.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringEventListenerAdapter.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.v2
+
+import com.netflix.spinnaker.kork.plugins.api.events.SpinnakerEventListener
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.core.ResolvableType
+import org.springframework.util.ReflectionUtils
+
+/**
+ * Adapts Spring [ApplicationEvent] events to the plugin-friendly [SpinnakerApplicationEvent] event type.
+ */
+class SpringEventListenerAdapter(
+  internal val eventListener: SpinnakerEventListener<*>
+) : ApplicationListener<ApplicationEvent> {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  private val interestedType: Class<*>? = findEventType(eventListener)
+
+  override fun onApplicationEvent(event: ApplicationEvent) {
+    if (interestedType != null && interestedType.isAssignableFrom(event.javaClass)) {
+      // Grossssssssss
+      val method = eventListener.javaClass.getMethod("onApplicationEvent", interestedType)
+      method.isAccessible = true
+      ReflectionUtils.invokeMethod(method, eventListener, event)
+    }
+  }
+
+  /**
+   * Finds the event type for a [SpinnakerEventListener] class.
+   *
+   * It's not enough to just look at the immediate interfaces of the type, since it's possible a plugin developer
+   * will make an abstract class for all event listeners.
+   */
+  @Suppress("TooGenericExceptionCaught")
+  private fun findEventType(eventListener: SpinnakerEventListener<*>): Class<*>? {
+    return try {
+      val eventListenerType = ResolvableType.forInstance(eventListener)
+      findEventType(eventListenerType)
+    } catch (e: Exception) {
+      log.warn(
+        "Unable to resolve event type for listener, all events will be ignored: {}",
+        eventListener.extensionClass.simpleName
+      )
+      return null
+    }
+  }
+
+  private fun findEventType(type: ResolvableType): Class<*>? {
+    if (type.superType.rawClass.name != "java.lang.Object") {
+      return findEventType(type.superType)
+    }
+
+    return type.interfaces
+      .firstOrNull { SpinnakerEventListener::class.java.isAssignableFrom(it.rawClass!!) }
+      ?.getGeneric(0)
+      ?.rawClass
+  }
+}

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginInitializer.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginInitializer.kt
@@ -50,6 +50,10 @@ class SpringPluginInitializer(
     pluginApplicationContext.classLoader = pluginWrapper.pluginClassLoader
     pluginApplicationContext.setResourceLoader(DefaultResourceLoader(pluginWrapper.pluginClassLoader))
 
+    pluginApplicationContext
+      .beanFactory
+      .addBeanPostProcessor(ApplicationEventListenerBeanPostProcessor())
+
     listOf(
       PluginConfigurationRegisteringCustomizer(applicationContext.getBean(ConfigFactory::class.java)),
       PluginSdksRegisteringCustomizer(applicationContext),

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/ApplicationEventListenerBeanPostProcessorTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/ApplicationEventListenerBeanPostProcessorTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.v2
+
+import com.netflix.spinnaker.kork.plugins.api.events.SpinnakerApplicationEvent
+import com.netflix.spinnaker.kork.plugins.api.events.SpinnakerEventListener
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEvent
+import strikt.api.expectThat
+import strikt.assertions.isA
+
+class ApplicationEventListenerBeanPostProcessorTest {
+
+  @Test
+  fun shouldAdaptListener() {
+    val subject = ApplicationEventListenerBeanPostProcessor()
+
+    expectThat(subject.postProcessBeforeInitialization(TestListener(), "bean"))
+      .isA<SpringEventListenerAdapter>()
+      .get { eventListener }.isA<TestListener>()
+  }
+
+  @Test
+  fun shouldIgnoreOtherBeans() {
+    val subject = ApplicationEventListenerBeanPostProcessor()
+
+    expectThat(subject.postProcessBeforeInitialization(SomethingElse(), "bean"))
+      .isA<SomethingElse>()
+  }
+
+  private inner class TestEvent(private val source: Any) : SpinnakerApplicationEvent {
+    override fun getSource(): Any = source
+    override fun getTimestamp(): Long = 0L
+  }
+
+  private inner class TestListener : SpinnakerEventListener<TestEvent> {
+    override fun onApplicationEvent(event: TestEvent) {
+    }
+  }
+
+  private inner class SomethingElse
+}

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringEventListenerAdapterTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringEventListenerAdapterTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.kork.plugins.v2
+
+import com.netflix.spinnaker.kork.plugins.api.events.SpinnakerApplicationEvent
+import com.netflix.spinnaker.kork.plugins.api.events.SpinnakerEventListener
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEvent
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+
+class SpringEventListenerAdapterTest {
+
+  @Test
+  fun shouldAdaptSpinnakerEvent() {
+    val listener = TestListener()
+    val subject = SpringEventListenerAdapter(listener)
+
+    subject.onApplicationEvent(KorkApplicationEventImpl(this))
+
+    expectThat(listener.invoked).isTrue()
+  }
+
+  @Test
+  fun shouldIgnoreSpringEvent() {
+    val listener = TestListener()
+    val subject = SpringEventListenerAdapter(listener)
+
+    subject.onApplicationEvent(TestSpringEvent(this))
+
+    expectThat(listener.invoked).isFalse()
+  }
+
+  interface KorkApplicationEvent : SpinnakerApplicationEvent
+
+  class KorkApplicationEventImpl(source: Any) : KorkApplicationEvent, ApplicationEvent(source)
+
+  private inner class TestSpringEvent(source: Any): ApplicationEvent(source)
+
+  private inner class TestListener : ListenerAbstraction() {
+    var invoked: Boolean = false
+    override fun onApplicationEvent(event: KorkApplicationEvent) {
+      invoked = true
+    }
+  }
+
+  private abstract class ListenerAbstraction : SpinnakerEventListener<KorkApplicationEvent>
+
+}


### PR DESCRIPTION
Initial support for allowing plugins to listen on application events.

This comes from a community request to listen in on [BeforeInitialExecutionPersist](https://github.com/spinnaker/orca/blob/master/orca-core/src/main/java/com/netflix/spinnaker/orca/events/BeforeInitialExecutionPersist.java). As with all things, I had to create an adapter to convert from Spring types to non-Spring types.

I'll be making a followup PR to adapt Orca accordingly.