### PR TITLE
chore(plugins): Downgrade plugin release source logging from info to debug

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/LatestPluginInfoReleaseSource.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/LatestPluginInfoReleaseSource.kt
@@ -44,13 +44,13 @@ class LatestPluginInfoReleaseSource(
       updateManager.getLastPluginRelease(pluginInfo.id, serviceName)
 
     return if (latestRelease != null) {
-      log.info("Latest release version '{}' for plugin '{}'", latestRelease.version, pluginInfo.id)
+      log.debug("Latest release version '{}' for plugin '{}'", latestRelease.version, pluginInfo.id)
       PluginInfoRelease(
         pluginInfo.id,
         objectMapper.convertValue(latestRelease, SpinnakerPluginInfo.SpinnakerPluginRelease::class.java)
       )
     } else {
-      log.info("Latest release version not found for plugin '{}'", pluginInfo.id)
+      log.debug("Latest release version not found for plugin '{}'", pluginInfo.id)
       null
     }
   }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/PreferredPluginInfoReleaseSource.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/PreferredPluginInfoReleaseSource.kt
@@ -36,10 +36,10 @@ class PreferredPluginInfoReleaseSource : PluginInfoReleaseSource {
   private fun pluginInfoRelease(pluginInfo: SpinnakerPluginInfo): PluginInfoRelease? {
     val release = pluginInfo.getReleases().find { it.preferred }
     return if (release != null) {
-      log.info("Preferred release version '{}' for plugin '{}'", release.version, pluginInfo.id)
+      log.debug("Preferred release version '{}' for plugin '{}'", release.version, pluginInfo.id)
       PluginInfoRelease(pluginInfo.id, release)
     } else {
-      log.info("No preferred release version found for '{}'", pluginInfo.id)
+      log.debug("No preferred release version found for '{}'", pluginInfo.id)
       null
     }
   }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/SpringPluginInfoReleaseSource.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/release/source/SpringPluginInfoReleaseSource.kt
@@ -45,10 +45,10 @@ class SpringPluginInfoReleaseSource(
     }
     val release = pluginInfo.getReleases().firstOrNull { it.version == pluginVersion }
     return if (release != null) {
-      log.info("Spring configured release version '{}' for plugin '{}'", release.version, pluginInfo.id)
+      log.debug("Spring configured release version '{}' for plugin '{}'", release.version, pluginInfo.id)
       PluginInfoRelease(pluginInfo.id, release)
     } else {
-      log.info("Spring configured release version not found for plugin '{}'", pluginInfo.id)
+      log.debug("Spring configured release version not found for plugin '{}'", pluginInfo.id)
       null
     }
   }


### PR DESCRIPTION
At info level these logs can be a bit noisy, especially since these sources run on a cycle (in the remote plugin cache process).