### PR TITLE
fix(retrofit): Explicitly mark BAD_REQUEST and NOT_FOUND errors as not retryable

### DIFF
--- a/kork-retrofit/kork-retrofit.gradle
+++ b/kork-retrofit/kork-retrofit.gradle
@@ -16,6 +16,7 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "com.netflix.spectator:spectator-reg-micrometer"
+  testImplementation "com.squareup.okhttp3:mockwebserver"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
 

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandler.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandler.java
@@ -55,8 +55,7 @@ public final class SpinnakerRetrofitErrorHandler implements ErrorHandler {
           return new NotFoundException(e).setRetryable(false);
         }
         SpinnakerHttpException retval = new SpinnakerHttpException(e);
-        if (HttpStatus.Series.resolve(e.getResponse().getStatus())
-            == HttpStatus.Series.CLIENT_ERROR) {
+        if (e.getResponse().getStatus() == HttpStatus.BAD_REQUEST.value()) {
           retval.setRetryable(false);
         }
         return retval;

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandler.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandler.java
@@ -52,9 +52,14 @@ public final class SpinnakerRetrofitErrorHandler implements ErrorHandler {
     switch (e.getKind()) {
       case HTTP:
         if (e.getResponse().getStatus() == HttpStatus.NOT_FOUND.value()) {
-          return new NotFoundException(e);
+          return new NotFoundException(e).setRetryable(false);
         }
-        return new SpinnakerHttpException(e);
+        SpinnakerHttpException retval = new SpinnakerHttpException(e);
+        if (HttpStatus.Series.resolve(e.getResponse().getStatus())
+            == HttpStatus.Series.CLIENT_ERROR) {
+          retval.setRetryable(false);
+        }
+        return retval;
       case NETWORK:
         return new SpinnakerNetworkException(e);
       default:

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -16,7 +16,8 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
@@ -53,20 +54,22 @@ public class SpinnakerRetrofitErrorHandlerTest {
   }
 
   @Test
-  public void testNotFoundHasNullRetryable() throws Exception {
+  public void testNotFoundIsNotRetryable() throws Exception {
     mockWebServer.enqueue(new MockResponse().setResponseCode(HttpStatus.NOT_FOUND.value()));
     NotFoundException notFoundException =
         assertThrows(NotFoundException.class, () -> retrofitService.getFoo());
-    assertNull(notFoundException.getRetryable());
+    assertNotNull(notFoundException.getRetryable());
+    assertFalse(notFoundException.getRetryable());
   }
 
   @Test
-  public void testClientErrorHasNullRetryable() throws Exception {
+  public void testClientErrorIsNotRetryable() throws Exception {
     // Arbitrarily choose BAD_REQUEST as an example of a client (e.g. 4xx) error
     mockWebServer.enqueue(new MockResponse().setResponseCode(HttpStatus.BAD_REQUEST.value()));
     SpinnakerHttpException spinnakerHttpException =
         assertThrows(SpinnakerHttpException.class, () -> retrofitService.getFoo());
-    assertNull(spinnakerHttpException.getRetryable());
+    assertNotNull(spinnakerHttpException.getRetryable());
+    assertFalse(spinnakerHttpException.getRetryable());
   }
 
   interface RetrofitService {

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Avast Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import retrofit.RestAdapter;
+import retrofit.client.Response;
+import retrofit.http.GET;
+
+public class SpinnakerRetrofitErrorHandlerTest {
+
+  private static RetrofitService retrofitService;
+
+  private static final MockWebServer mockWebServer = new MockWebServer();
+
+  @BeforeAll
+  public static void setupOnce() throws Exception {
+    mockWebServer.start();
+    retrofitService =
+        new RestAdapter.Builder()
+            .setEndpoint(mockWebServer.url("/").toString())
+            .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
+            .build()
+            .create(RetrofitService.class);
+  }
+
+  @AfterAll
+  public static void shutdownOnce() throws Exception {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  public void testNotFoundHasNullRetryable() throws Exception {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(HttpStatus.NOT_FOUND.value()));
+    NotFoundException notFoundException =
+        assertThrows(NotFoundException.class, () -> retrofitService.getFoo());
+    assertNull(notFoundException.getRetryable());
+  }
+
+  @Test
+  public void testClientErrorHasNullRetryable() throws Exception {
+    // Arbitrarily choose BAD_REQUEST as an example of a client (e.g. 4xx) error
+    mockWebServer.enqueue(new MockResponse().setResponseCode(HttpStatus.BAD_REQUEST.value()));
+    SpinnakerHttpException spinnakerHttpException =
+        assertThrows(SpinnakerHttpException.class, () -> retrofitService.getFoo());
+    assertNull(spinnakerHttpException.getRetryable());
+  }
+
+  interface RetrofitService {
+    @GET("/foo")
+    Response getFoo();
+  }
+}

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
@@ -63,13 +64,22 @@ public class SpinnakerRetrofitErrorHandlerTest {
   }
 
   @Test
-  public void testClientErrorIsNotRetryable() throws Exception {
-    // Arbitrarily choose BAD_REQUEST as an example of a client (e.g. 4xx) error
+  public void testBadRequestIsNotRetryable() throws Exception {
     mockWebServer.enqueue(new MockResponse().setResponseCode(HttpStatus.BAD_REQUEST.value()));
     SpinnakerHttpException spinnakerHttpException =
         assertThrows(SpinnakerHttpException.class, () -> retrofitService.getFoo());
     assertNotNull(spinnakerHttpException.getRetryable());
     assertFalse(spinnakerHttpException.getRetryable());
+  }
+
+  @Test
+  public void testOtherClientErrorHasNullRetryable() throws Exception {
+    // Arbitrarily choose GONE as an example of a client (e.g. 4xx) error that
+    // we expect to have null retryable
+    mockWebServer.enqueue(new MockResponse().setResponseCode(HttpStatus.GONE.value()));
+    SpinnakerHttpException spinnakerHttpException =
+        assertThrows(SpinnakerHttpException.class, () -> retrofitService.getFoo());
+    assertNull(spinnakerHttpException.getRetryable());
   }
 
   interface RetrofitService {


### PR DESCRIPTION
cc: @ajordens .. an attempt to address https://github.com/spinnaker/spinnaker/issues/6237