### PR TITLE
fix(dependencies): Revert JOOQ upgrade

### DIFF
--- a/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
+++ b/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
@@ -43,13 +43,12 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.SetupException;
 import liquibase.resource.ClassLoaderResourceAccessor;
-import org.jooq.CloseableDSLContext;
 import org.jooq.DSLContext;
 import org.jooq.Query;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DataSourceConnectionProvider;
-import org.jooq.impl.DefaultCloseableDSLContext;
 import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -210,9 +209,7 @@ public class SqlTestUtil {
       config.settings().withRenderNameStyle(AS_IS);
     }
 
-    CloseableDSLContext context =
-        new DefaultCloseableDSLContext(
-            config.connectionProvider(), config.dialect(), config.settings());
+    DSLContext context = new DefaultDSLContext(config);
 
     Liquibase migrate;
     try {
@@ -292,12 +289,12 @@ public class SqlTestUtil {
   public static class TestDatabase implements Closeable {
     public final HikariDataSource dataSource;
     public final HikariDataSource previousDataSource;
-    public final CloseableDSLContext context;
-    public final CloseableDSLContext previousContext;
+    public final DSLContext context;
+    public final DSLContext previousContext;
     public final Liquibase liquibase;
     public final Liquibase previousLiquibase;
 
-    TestDatabase(HikariDataSource dataSource, CloseableDSLContext context, Liquibase liquibase) {
+    TestDatabase(HikariDataSource dataSource, DSLContext context, Liquibase liquibase) {
       this.dataSource = dataSource;
       this.context = context;
       this.liquibase = liquibase;
@@ -308,10 +305,10 @@ public class SqlTestUtil {
 
     TestDatabase(
         HikariDataSource dataSource,
-        CloseableDSLContext context,
+        DSLContext context,
         Liquibase liquibase,
         HikariDataSource previousDataSource,
-        CloseableDSLContext previousContext,
+        DSLContext previousContext,
         Liquibase previousLiquibase) {
       this.dataSource = dataSource;
       this.context = context;

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -27,10 +27,8 @@ import com.netflix.spinnaker.kork.sql.telemetry.JooqSlowQueryLogger
 import java.sql.Connection
 import javax.sql.DataSource
 import liquibase.integration.spring.SpringLiquibase
-import org.jooq.CloseableDSLContext
 import org.jooq.DSLContext
 import org.jooq.impl.DataSourceConnectionProvider
-import org.jooq.impl.DefaultCloseableDSLContext
 import org.jooq.impl.DefaultConfiguration
 import org.jooq.impl.DefaultDSLContext
 import org.jooq.impl.DefaultExecuteListenerProvider
@@ -177,12 +175,8 @@ class DefaultSqlConfiguration {
   @Suppress("UndocumentedPublicFunction")
   @Bean(destroyMethod = "close")
   @ConditionalOnMissingBean(DSLContext::class)
-  fun jooq(jooqConfiguration: DefaultConfiguration): CloseableDSLContext =
-    DefaultCloseableDSLContext(
-      jooqConfiguration.connectionProvider(),
-      jooqConfiguration.dialect(),
-      jooqConfiguration.settings()
-    )
+  fun jooq(jooqConfiguration: DefaultConfiguration): DSLContext =
+    DefaultDSLContext(jooqConfiguration)
 
   @Suppress("UndocumentedPublicFunction")
   @Bean(destroyMethod = "close")
@@ -190,7 +184,7 @@ class DefaultSqlConfiguration {
   fun secondaryJooq(
     connectionProvider: DataSourceConnectionProvider,
     sqlProperties: SqlProperties
-  ): CloseableDSLContext {
+  ): DSLContext {
     val secondaryPool: ConnectionPoolProperties = sqlProperties.connectionPools
       .filter { !it.value.default }
       .values
@@ -206,11 +200,7 @@ class DefaultSqlConfiguration {
       set(connectionProvider)
       setSQLDialect(secondaryPool.dialect)
     }
-    return DefaultCloseableDSLContext(
-      secondaryJooqConfig.connectionProvider(),
-      secondaryJooqConfig.dialect(),
-      secondaryJooqConfig.settings()
-    )
+    return DefaultDSLContext(secondaryJooqConfig)
   }
 
   @Suppress("UndocumentedPublicFunction")

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -10,7 +10,7 @@ ext {
     bouncycastle     : "1.64", // 1.64 removes CVE-2019-17359
     brave            : "5.12.3",
     groovy           : "2.5.11", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
-    jooq             : "3.14.4",
+    jooq             : "3.13.2",
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
     protobuf         : "3.9.1",


### PR DESCRIPTION
Seeing some issues with `clouddriver` that seemingly only
happen when running with the newer jooq.

Reverting until we have time to investigate.