### PR TITLE
chore(aws): Bump aws sdk

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -6,7 +6,7 @@ javaPlatform {
 
 ext {
   versions = [
-    aws              : "1.11.904",
+    aws              : "1.11.934",
     bouncycastle     : "1.64", // 1.64 removes CVE-2019-17359
     brave            : "5.12.3",
     groovy           : "2.5.11", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this


### PR DESCRIPTION
Bumping to match the latest [Netflix/AWSObjectMapper](https://github.com/Netflix/AWSObjectMapper/releases) release and pick up new fields.