### PR TITLE
new version of Strikt that is on mavenCentral

### DIFF
--- a/kork-plugins-tck/kork-plugins-tck.gradle
+++ b/kork-plugins-tck/kork-plugins-tck.gradle
@@ -9,7 +9,7 @@ dependencies {
   implementation "org.pf4j:pf4j"
 
   //Test framework dependencies
-  api("io.strikt:strikt-core")
+  api("io.strikt:strikt-jvm")
   api("dev.minutest:minutest")
   api("io.mockk:mockk")
   api("org.springframework.boot:spring-boot-starter-test")

--- a/kork-plugins-tck/src/test/kotlin/com/spinnaker/netflix/kork/plugins/TestPluginGeneratorTest.kt
+++ b/kork-plugins-tck/src/test/kotlin/com/spinnaker/netflix/kork/plugins/TestPluginGeneratorTest.kt
@@ -20,9 +20,9 @@ import com.netflix.spinnaker.kork.plugins.testplugin.testPlugin
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expectThat
-import strikt.assertions.isDirectory
 import strikt.assertions.isEqualTo
-import strikt.assertions.isRegularFile
+import strikt.java.isDirectory
+import strikt.java.isRegularFile
 import java.nio.file.Files
 import java.nio.file.Path
 

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -50,7 +50,7 @@ dependencies {
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
-  api(platform("io.strikt:strikt-bom:0.28.1"))
+  api(platform("io.strikt:strikt-bom:0.29.0"))
   api(platform("org.spockframework:spock-bom:1.3-groovy-2.5"))
   api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:1.5.17"))
   api(platform("org.testcontainers:testcontainers-bom:1.15.1"))


### PR DESCRIPTION
Bintray / JCenter is shutting down so I started publishing Strikt to Maven Central. This PR switches us to a newer version that is available from there. There are a couple of minor changes because JVM-specific things have moved to a new sub-module.﻿