### PR TITLE
chore(spring): Fixes error when loading empty properties

### DIFF
--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolver.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolver.kt
@@ -129,6 +129,10 @@ class SpringEnvironmentConfigResolver(
     propertyNames
       .filter { it.startsWith("spinnaker.extensibility") }
       .map { it to getProperty(it) }
+      .filter {
+        val second = it.second
+        if (second is Map<*, *>) second.isNotEmpty() else true
+      }
       .toMap()
 
   private inner class SystemConfigException(message: String) : SystemException(message)

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolverTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolverTest.kt
@@ -178,6 +178,7 @@ class SpringEnvironmentConfigResolverTest : JUnit5Minutests {
     "spinnaker.extensibility.plugins.netflix.very-important.extensions.orca.stage.config.optional" to "some new value",
     "spinnaker.extensibility.extensions.netflix.bar.config.somelist[0].hello" to "one",
     "spinnaker.extensibility.extensions.netflix.bar.config.somelist[1].hello" to "two",
+    "spinnaker.extensibility.repositories" to mapOf<String, String>(),
     "spinnaker.extensibility.repositories.foo.url" to "http://localhost:9000",
     "spinnaker.extensibility.plugins.netflix.sweet-plugin.config.somestring" to "overridden default"
   )


### PR DESCRIPTION
chore(spring): Fixes error when loading empty properties

While working on [upgrading spring version](https://github.com/spinnaker/kork/pull/847/files) found a bug where the properties being loaded can be empty. This causes an exception when mapping the properties to a JSON object.

![image](https://user-images.githubusercontent.com/373814/108784941-1111e000-7536-11eb-9c55-44eb43d9c7c2.png)

```
Failed reading extension config: Could not map provided config to expected shape
com.netflix.spinnaker.kork.exceptions.IntegrationException: Failed reading extension config: Could not map provided config to expected shape
	at com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentConfigResolver.resolveInternal(SpringEnvironmentConfigResolver.kt:108)
	at com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentConfigResolver.resolve(SpringEnvironmentConfigResolver.kt:69)
	at com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentConfigResolverTest$tests$1$7.invoke(SpringEnvironmentConfigResolverTest.kt:130)
	at com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentConfigResolverTest$tests$1$7.invoke(SpringEnvironmentConfigResolverTest.kt:38)
```

The root cause for this might be in `org.springframework.core.env.PropertySource#getProperty` from the newer Spring version, however, it's easily reproducible on current version unit tests by adding an empty map to one of the properties (without upgrading Spring).