### PR TITLE
fix(security): `getAuthenticationHeaders()` should support MDC attributes with `null` values

### DIFF
--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java
@@ -299,7 +299,7 @@ public class AuthenticatedRequest {
                 || Header.ACCOUNTS.getHeader().equalsIgnoreCase(header);
 
         if (isSpinnakerHeader && !isSpinnakerAuthHeader) {
-          headers.put(header, Optional.of(mdcEntry.getValue()));
+          headers.put(header, Optional.ofNullable(mdcEntry.getValue()));
         }
       }
     }

--- a/kork-security/src/test/groovy/com/netflix/spinnaker/security/AuthenticatedRequestSpec.groovy
+++ b/kork-security/src/test/groovy/com/netflix/spinnaker/security/AuthenticatedRequestSpec.groovy
@@ -32,7 +32,7 @@ class AuthenticatedRequestSpec extends Specification {
     AuthenticatedRequest.getSpinnakerUser(new org.springframework.security.core.userdetails.User("spinnaker-other", "", [])).get() == "spinnaker-other"
   }
 
-  void "should extract allowed account details by priority (Principal > MDC"() {
+  void "should extract allowed account details by priority (Principal > MDC)"() {
     when:
     MDC.clear()
     MDC.put(Header.ACCOUNTS.header, "account1,account2")
@@ -101,11 +101,13 @@ class AuthenticatedRequestSpec extends Specification {
   void "should not fail when no headers are set"() {
     when:
     MDC.clear()
+    MDC.put("X-SPINNAKER-MY-ATTRIBUTE", null)
 
     then:
     Map allheaders = AuthenticatedRequest.getAuthenticationHeaders()
     allheaders == [
-            'X-SPINNAKER-USER': Optional.empty(),
-            'X-SPINNAKER-ACCOUNTS': Optional.empty()]
+      'X-SPINNAKER-USER'        : Optional.empty(),
+      'X-SPINNAKER-ACCOUNTS'    : Optional.empty(),
+      'X-SPINNAKER-MY-ATTRIBUTE': Optional.empty()]
   }
 }


### PR DESCRIPTION
In cases where the value is not available, `Optional.empty()`
should be returned.

This gets us closer to the behavior that existed prior to the
refactor (and generifying) on 04/19.