### PR TITLE
chore(deps): Upgrade Kotlin and kotlinx-coroutines

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.4.21
+kotlinVersion=1.4.31
 org.gradle.parallel=true
 spinnakerGradleVersion=8.10.1
 targetJava11=true

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -40,7 +40,7 @@ dependencies {
    * For example, `junit-bom` and `jackson-bom` will win out over the versions of JUnit and Jackson
    * specified by `spring-boot-dependencies`.
    */
-  api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.2"))
+  api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.3"))
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))


### PR DESCRIPTION
Release [1.4.3](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.4.3) just came out and it solves a long-standing issue with coroutine contexts and `ThreadLocal` that we're hoping will finally make our MDC integration in `keel` work! 🙏 

Also bumps Kotlin to 1.4.31.