### PR TITLE
feat(metrics): Add Criticality annotation and use in MetricsInterceptor

### DIFF
--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/interceptors/Criticality.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/interceptors/Criticality.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.web.interceptors;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.annotation.Nonnull;
+
+/**
+ * Specify the metric criticality of high, low, or unknown.
+ *
+ * <p>This could be used to inform alerting conditions.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+@Documented
+public @interface Criticality {
+
+  /** Criticality value - defaults to "unknown". */
+  @Nonnull
+  String value() default Value.UNKNOWN;
+
+  class Value {
+    public static final String HIGH = "high";
+    public static final String LOW = "low";
+    public static final String UNKNOWN = "unknown";
+  }
+}

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptor.java
@@ -121,7 +121,8 @@ public class MetricsInterceptor extends HandlerInterceptorAdapter {
               .withTag("controller", controller)
               .withTag("method", handlerMethod.getMethod().getName())
               .withTag("status", status.toString().charAt(0) + "xx")
-              .withTag("statusCode", status.toString());
+              .withTag("statusCode", status.toString())
+              .withTag("criticality", metricCriticality(handlerMethod));
 
       Map variables = (Map) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
       for (String pathVariable : pathVariablesToTag) {
@@ -155,6 +156,14 @@ public class MetricsInterceptor extends HandlerInterceptorAdapter {
               registry, registry.createId(contentLengthMetricName).withTags(id.tags()))
           .record(request.getContentLengthLong());
     }
+  }
+
+  private String metricCriticality(HandlerMethod handlerMethod) {
+    if (handlerMethod.hasMethodAnnotation(Criticality.class)) {
+      Criticality criticality = handlerMethod.getMethodAnnotation(Criticality.class);
+      return criticality.value();
+    }
+    return Criticality.Value.UNKNOWN;
   }
 
   protected Long getNanoTime() {

--- a/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptorMicrometerTest.java
+++ b/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptorMicrometerTest.java
@@ -76,6 +76,7 @@ public class MetricsInterceptorMicrometerTest {
             Arrays.asList(
                 Tag.of("cause", "IllegalArgumentException"),
                 Tag.of("controller", "TestController"),
+                Tag.of("criticality", "unknown"),
                 Tag.of("method", "execute"),
                 Tag.of("param-1", "val-1"),
                 Tag.of("param-2", "None"),
@@ -88,6 +89,7 @@ public class MetricsInterceptorMicrometerTest {
             Arrays.asList(
                 Tag.of("cause", "RuntimeException"),
                 Tag.of("controller", "TestController"),
+                Tag.of("criticality", "unknown"),
                 Tag.of("method", "execute"),
                 Tag.of("param-1", "None"),
                 Tag.of("param-2", "None"),
@@ -100,6 +102,7 @@ public class MetricsInterceptorMicrometerTest {
             Arrays.asList(
                 Tag.of("cause", "None"),
                 Tag.of("controller", "TestController"),
+                Tag.of("criticality", "unknown"),
                 Tag.of("method", "execute"),
                 Tag.of("param-1", "val-1"),
                 Tag.of("param-2", "None"),
@@ -112,6 +115,7 @@ public class MetricsInterceptorMicrometerTest {
             Arrays.asList(
                 Tag.of("cause", "None"),
                 Tag.of("controller", "TestController"),
+                Tag.of("criticality", "unknown"),
                 Tag.of("method", "execute"),
                 Tag.of("param-1", "None"),
                 Tag.of("param-2", "None"),


### PR DESCRIPTION
When we add this annotation to controller methods we will be able to set the criticality of the controller method - this is useful to better setup alerts on failures of only controller methods tagged with a criticality of "high".