### PR TITLE
fix(metrics): Mark metric criticality on controllers

### DIFF
--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/interceptors/Criticality.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/interceptors/Criticality.java
@@ -30,7 +30,7 @@ import javax.annotation.Nonnull;
  * <p>This could be used to inform alerting conditions.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Documented
 public @interface Criticality {
 

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptor.java
@@ -162,6 +162,13 @@ public class MetricsInterceptor extends HandlerInterceptorAdapter {
     if (handlerMethod.hasMethodAnnotation(Criticality.class)) {
       Criticality criticality = handlerMethod.getMethodAnnotation(Criticality.class);
       return criticality.value();
+    } else if (handlerMethod
+        .getMethod()
+        .getDeclaringClass()
+        .isAnnotationPresent(Criticality.class)) {
+      Criticality criticality =
+          handlerMethod.getMethod().getDeclaringClass().getAnnotation(Criticality.class);
+      return criticality.value();
     }
     return Criticality.Value.UNKNOWN;
   }

--- a/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptorSpec.groovy
+++ b/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptorSpec.groovy
@@ -81,9 +81,9 @@ class MetricsInterceptorSpec extends Specification {
 
     where:
     exception                  | handlerMethod      | variablesToTag | requestParamsToAdd | expectedTags
-    null                       | "get"              | []             | []                 | [success: "true", statusCode: "200", status: "2xx", "method": "get", controller: "Example", cause: "None", criticality: "unknown"]
-    new NullPointerException() | "get"              | []             | []                 | [success: "false", statusCode: "500", status: "5xx", "method": "get", controller: "Example", cause: "NullPointerException", criticality: "unknown"]
-    null                       | "get"              | ["account"]    | ['user']           | [success: "true", statusCode: "200", status: "2xx", "method": "get", controller: "Example", cause: 'None', "account": "test", user: 'Anastasiia', criticality: "unknown"]
+    null                       | "get"              | []             | []                 | [success: "true", statusCode: "200", status: "2xx", "method": "get", controller: "Example", cause: "None", criticality: "low"]
+    new NullPointerException() | "get"              | []             | []                 | [success: "false", statusCode: "500", status: "5xx", "method": "get", controller: "Example", cause: "NullPointerException", criticality: "low"]
+    null                       | "get"              | ["account"]    | ['user']           | [success: "true", statusCode: "200", status: "2xx", "method": "get", controller: "Example", cause: 'None', "account": "test", user: 'Anastasiia', criticality: "low"]
     new NullPointerException() | "highCriticality"  | []             | []                 | [success: "false", statusCode: "500", status: "5xx", "method": "highCriticality", controller: "Example", cause: "NullPointerException", criticality: "high"]
 
     templateVariables = ["account": "test", "empty": "empty"]
@@ -102,6 +102,7 @@ class MetricsInterceptorSpec extends Specification {
     interceptor.afterCompletion(null, null, handler, null)
   }
 
+  @Criticality(Criticality.Value.LOW)
   class Example {
     void get() {}
 


### PR DESCRIPTION
Method annotation takes precedence, then to controller (class) annotation, then fallsback to "unknown".