### PR TITLE
Revert "feat(plugins): Add config property to enable/disable extension proxying"

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java
@@ -366,7 +366,6 @@ public class PluginsAutoConfiguration {
       havingValue = FRAMEWORK_V2,
       matchIfMissing = true)
   public SpinnakerPluginService spinnakerPluginService(
-      PluginsConfigurationProperties properties,
       SpinnakerPluginManager pluginManager,
       SpinnakerUpdateManager updateManager,
       PluginInfoReleaseProvider pluginInfoReleaseProvider,
@@ -379,8 +378,7 @@ public class PluginsAutoConfiguration {
         pluginInfoReleaseProvider,
         springPluginStatusProvider,
         invocationAspects,
-        applicationEventPublisher,
-        properties.shouldProxyExtensions());
+        applicationEventPublisher);
   }
 
   @Bean

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
@@ -77,22 +77,6 @@ public class PluginsConfigurationProperties {
     this.enableDefaultRepositories = enableDefaultRepositories;
   }
 
-  /**
-   * Whether or not plugin extensions are proxied via {@link
-   * com.netflix.spinnaker.kork.plugins.proxy.ExtensionInvocationProxy}.
-   *
-   * <p>Enabled by default, this can be useful to disable when debugging an issue.
-   */
-  private boolean proxyExtensions = true;
-
-  public boolean shouldProxyExtensions() {
-    return proxyExtensions;
-  }
-
-  public void setProxyExtensions(boolean proxyExtensions) {
-    this.proxyExtensions = proxyExtensions;
-  }
-
   /** Definition of a single {@link org.pf4j.update.UpdateRepository}. */
   public static class PluginRepositoryProperties {
     /** Flag to determine if repository is enabled. */

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt
@@ -46,15 +46,13 @@ import java.util.function.Supplier
  * [SpinnakerUpdateManager] as the primary touch points for the plugin framework, decoupling
  * Spinnaker-specific plugin framework logic from PF4J wherever possible.
  */
-@Suppress("LongParameterList")
 class SpinnakerPluginService(
   private val pluginManager: SpinnakerPluginManager,
   private val updateManager: SpinnakerUpdateManager,
   private val pluginInfoReleaseProvider: PluginInfoReleaseProvider,
   private val springPluginStatusProvider: SpringPluginStatusProvider,
   private val invocationAspects: List<InvocationAspect<*>>,
-  private val applicationEventPublisher: ApplicationEventPublisher,
-  private val shouldProxyExtensions: Boolean
+  private val applicationEventPublisher: ApplicationEventPublisher
 ) {
 
   private val log = LoggerFactory.getLogger(javaClass)
@@ -133,37 +131,33 @@ class SpinnakerPluginService(
       )
 
       // Provide an implementation of the extension that can be injected immediately by service-level classes.
-      val extension = if (shouldProxyExtensions) {
-        LazyExtensionInvocationProxy.proxy(
-          lazy {
-            // Force the plugin's initializer to run if it hasn't already.
-            pluginContext.parent?.also { it.getBean(initializerBeanName) }
-              ?: throw IllegalStateException("Plugin context for \"${pluginId}\" was not configured with a parent context")
+      val proxy = LazyExtensionInvocationProxy.proxy(
+        lazy {
+          // Force the plugin's initializer to run if it hasn't already.
+          pluginContext.parent?.also { it.getBean(initializerBeanName) }
+            ?: throw IllegalStateException("Plugin context for \"${pluginId}\" was not configured with a parent context")
 
-            // Fetch the extension from the plugin context.
-            return@lazy pluginContext.getBean(pluginContextBeanName) as SpinnakerExtensionPoint
-          },
-          extensionBeanClass,
-          invocationAspects as List<InvocationAspect<InvocationState>>,
-          container.wrapper.descriptor as SpinnakerPluginDescriptor
-        )
-      } else {
-        pluginContext.getBean(pluginContextBeanName) as SpinnakerExtensionPoint
-      }
+          // Fetch the extension from the plugin context.
+          return@lazy pluginContext.getBean(pluginContextBeanName) as SpinnakerExtensionPoint
+        },
+        extensionBeanClass,
+        invocationAspects as List<InvocationAspect<InvocationState>>,
+        container.wrapper.descriptor as SpinnakerPluginDescriptor
+      )
 
-      val beanDefinition = BeanDefinitionBuilder.genericBeanDefinition().beanDefinition.apply {
-        instanceSupplier = Supplier { extension }
+      val proxyBeanDefinition = BeanDefinitionBuilder.genericBeanDefinition().beanDefinition.apply {
+        instanceSupplier = Supplier { proxy }
         beanClass = extensionBeanClass
       }
       registry.registerBeanDefinition(
         "${pluginId}_${extensionBeanClass.simpleName.decapitalize()}",
-        beanDefinition
+        proxyBeanDefinition
       )
 
       applicationEventPublisher.publishEvent(ExtensionCreated(
         this,
         pluginContextBeanName,
-        extension,
+        proxy,
         extensionBeanClass
       ))
     }


### PR DESCRIPTION
Reverts spinnaker/kork#853

This wasn't working as intended, and furthermore the lazy proxing is quite nice to inject service beans into plugin beans and vice versa.