### PR TITLE
fix(bumpdeps): point to maven central instead of bintray

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -13,8 +13,8 @@ jobs:
         ref: ${{ github.event.client_payload.ref }}
         key: korkVersion
         repositories: clouddriver,echo,fiat,front50,gate,halyard,igor,keel,orca,rosco,swabbie
-        mavenRepositoryUrl: https://dl.bintray.com/spinnaker/spinnaker
-        groupId: com.netflix.spinnaker.kork
+        mavenRepositoryUrl: https://repo.maven.apache.org/maven2
+        groupId: io.spinnaker.kork
         artifactId: kork-bom
       env:
         GITHUB_OAUTH: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
            draft: false
            prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
       - name: Pause before dependency bump
-        run: sleep 900
+        run: sleep 600
       - name: Trigger dependency bump workflow
         uses: peter-evans/repository-dispatch@v1
         with:


### PR DESCRIPTION
Also dropping the waiting time in the release workflow to make the overall wait time 20 minutes (didn't realize that bumpdeps polls for the artifact for 10 minutes).