### PR TITLE
feat(x509/crl): reimplement the ability to revoke certificates

### DIFF
--- a/kork-tomcat/kork-tomcat.gradle
+++ b/kork-tomcat/kork-tomcat.gradle
@@ -5,5 +5,8 @@ dependencies {
 
   api(platform(project(":spinnaker-dependencies")))
   implementation("org.springframework.boot:spring-boot-starter-web")
+  implementation("com.netflix.spectator:spectator-api")
+  implementation("com.google.guava:guava")
+  implementation(project(":kork-core"))
 
 }

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/DefaultTomcatConnectorCustomizer.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/DefaultTomcatConnectorCustomizer.java
@@ -17,6 +17,8 @@
 
 package com.netflix.spinnaker.kork.tomcat;
 
+import com.netflix.spinnaker.kork.tomcat.x509.BlocklistingSSLImplementation;
+import com.netflix.spinnaker.kork.tomcat.x509.SslExtensionConfigurationProperties;
 import org.apache.catalina.connector.Connector;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.http11.AbstractHttp11JsseProtocol;
@@ -28,16 +30,22 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.Ssl;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+@Component
 class DefaultTomcatConnectorCustomizer implements TomcatConnectorCustomizer {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final TomcatConfigurationProperties tomcatConfigurationProperties;
+  private final SslExtensionConfigurationProperties sslExtensionConfigurationProperties;
 
-  DefaultTomcatConnectorCustomizer(TomcatConfigurationProperties tomcatConfigurationProperties) {
+  DefaultTomcatConnectorCustomizer(
+      TomcatConfigurationProperties tomcatConfigurationProperties,
+      SslExtensionConfigurationProperties sslExtensionConfigurationProperties) {
     this.tomcatConfigurationProperties = tomcatConfigurationProperties;
+    this.sslExtensionConfigurationProperties = sslExtensionConfigurationProperties;
   }
 
   @Override
@@ -67,11 +75,15 @@ class DefaultTomcatConnectorCustomizer implements TomcatConnectorCustomizer {
           throw new RuntimeException(
               String.format("Ssl configs: found %d, expected 1.", sslConfigs.length));
         }
+        ((AbstractHttp11JsseProtocol<?>) handler)
+            .setSslImplementationName(BlocklistingSSLImplementation.class.getName());
         SSLHostConfig sslHostConfig = sslConfigs[0];
         sslHostConfig.setHonorCipherOrder(true);
         sslHostConfig.setCiphers(String.join(",", tomcatConfigurationProperties.getCipherSuites()));
         sslHostConfig.setProtocols(
             String.join(",", tomcatConfigurationProperties.getTlsVersions()));
+        sslHostConfig.setCertificateRevocationListFile(
+            sslExtensionConfigurationProperties.getCrlFile());
       }
     }
   }

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/TomcatConfiguration.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/TomcatConfiguration.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.kork.tomcat;
 
+import com.netflix.spinnaker.kork.tomcat.x509.SslExtensionConfigurationProperties;
 import org.apache.catalina.connector.Connector;
 import org.apache.coyote.http11.Http11NioProtocol;
 import org.slf4j.Logger;
@@ -33,15 +34,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties({TomcatConfigurationProperties.class})
+@EnableConfigurationProperties({
+  TomcatConfigurationProperties.class,
+  SslExtensionConfigurationProperties.class
+})
 class TomcatConfiguration {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   @Bean
   TomcatConnectorCustomizer defaultTomcatConnectorCustomizer(
-      TomcatConfigurationProperties tomcatConfigurationProperties) {
-    return new DefaultTomcatConnectorCustomizer(tomcatConfigurationProperties);
+      TomcatConfigurationProperties tomcatConfigurationProperties,
+      SslExtensionConfigurationProperties sslExtensionConfigurationProperties) {
+    return new DefaultTomcatConnectorCustomizer(
+        tomcatConfigurationProperties, sslExtensionConfigurationProperties);
   }
 
   /**

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/Blocklist.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/Blocklist.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.tomcat.x509;
+
+import java.security.cert.X509Certificate;
+
+public interface Blocklist {
+
+  static Blocklist forFile(String blocklistFile) {
+    return new ReloadingFileBlocklist(blocklistFile);
+  }
+
+  boolean isBlocklisted(X509Certificate cert);
+}

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/BlocklistEnabledDynamicConfigMonitor.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/BlocklistEnabledDynamicConfigMonitor.java
@@ -1,0 +1,23 @@
+package com.netflix.spinnaker.kork.tomcat.x509;
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BlocklistEnabledDynamicConfigMonitor {
+  private final DynamicConfigService dynamicConfigService;
+
+  @Autowired
+  public BlocklistEnabledDynamicConfigMonitor(DynamicConfigService dynamicConfigService) {
+    this.dynamicConfigService = dynamicConfigService;
+    syncEnabledProperty();
+  }
+
+  @Scheduled(fixedRate = 5000L)
+  public void syncEnabledProperty() {
+    BlocklistingX509TrustManager.BLOCKLIST_ENABLED.set(
+        dynamicConfigService.isEnabled("ssl.blocklist", true));
+  }
+}

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/BlocklistingJSSESocketFactory.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/BlocklistingJSSESocketFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.tomcat.x509;
+
+import com.netflix.spectator.api.Registry;
+import java.util.Objects;
+import java.util.Optional;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import org.apache.tomcat.util.net.SSLHostConfigCertificate;
+import org.apache.tomcat.util.net.jsse.JSSEUtil;
+
+public class BlocklistingJSSESocketFactory extends JSSEUtil {
+  private static final String BLOCKLIST_PREFIX = "blocklist:";
+
+  private final Blocklist blocklist;
+  private final Registry registry;
+
+  public BlocklistingJSSESocketFactory(SSLHostConfigCertificate certificate, Registry registry) {
+    super(certificate);
+    this.registry = Objects.requireNonNull(registry);
+    String blocklistFile =
+        Optional.ofNullable(certificate.getSSLHostConfig().getCertificateRevocationListFile())
+            .filter(file -> file.startsWith(BLOCKLIST_PREFIX))
+            .map(file -> file.substring(BLOCKLIST_PREFIX.length()))
+            .orElse(null);
+
+    if (blocklistFile != null) {
+      certificate.getSSLHostConfig().setCertificateRevocationListFile(null);
+      blocklist = Blocklist.forFile(blocklistFile);
+    } else {
+      blocklist = null;
+    }
+  }
+
+  @Override
+  public TrustManager[] getTrustManagers() throws Exception {
+    TrustManager[] trustManagers = super.getTrustManagers();
+    if (blocklist != null && trustManagers != null) {
+      int delegatedCount = 0;
+      for (int i = 0; i < trustManagers.length; i++) {
+        TrustManager tm = trustManagers[i];
+        if (tm instanceof X509TrustManager) {
+          trustManagers[i] =
+              new BlocklistingX509TrustManager((X509TrustManager) tm, blocklist, registry);
+          delegatedCount++;
+        }
+      }
+
+      if (delegatedCount != 1) {
+        throw new IllegalStateException("expected single X509TrustManager");
+      }
+    }
+
+    return trustManagers;
+  }
+}

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/BlocklistingSSLImplementation.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/BlocklistingSSLImplementation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.tomcat.x509;
+
+import com.netflix.spectator.api.Spectator;
+import org.apache.tomcat.util.net.SSLHostConfigCertificate;
+import org.apache.tomcat.util.net.SSLUtil;
+import org.apache.tomcat.util.net.jsse.JSSEImplementation;
+
+/**
+ * An SSLImplementation that enforces a blocklist of client certificates.
+ *
+ * <p>To enable the blocklist behavior, use the {{AbstractEndpoint}} {{crlFile}} property following
+ * the naming convention {{blocklist:/path/to/blocklist/file}}
+ *
+ * <p>The format of the blocklist file is one entry per line conforming to {{issuer X500
+ * name:::blocklisted certificate serial number}} Blank lines and lines that begin with {{#}} are
+ * ignored.
+ *
+ * <p>The Blocklist file is refreshed periodically, so it can be updated in place to pick up newly
+ * revoked certificates.
+ */
+public class BlocklistingSSLImplementation extends JSSEImplementation {
+
+  @Override
+  public SSLUtil getSSLUtil(SSLHostConfigCertificate certificate) {
+    // this is not DI friendly since its instantiated by classname by Tomcat
+    // so we need to use Spectator.globalRegistry Singleton:
+    return new BlocklistingJSSESocketFactory(certificate, Spectator.globalRegistry());
+  }
+}

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/BlocklistingX509TrustManager.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/BlocklistingX509TrustManager.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.tomcat.x509;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import java.security.cert.CRLReason;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateRevokedException;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.X509TrustManager;
+
+public class BlocklistingX509TrustManager implements X509TrustManager {
+  // Hookpoint for shutoff via property monitor:
+  public static AtomicBoolean BLOCKLIST_ENABLED = new AtomicBoolean(true);
+  private final X509TrustManager delegate;
+  private final Blocklist blocklist;
+  private final Registry registry;
+  private final Id checkClientTrusted;
+
+  public BlocklistingX509TrustManager(
+      X509TrustManager delegate, Blocklist blocklist, Registry registry) {
+    this.delegate = Objects.requireNonNull(delegate);
+    this.blocklist = Objects.requireNonNull(blocklist);
+    this.registry = Objects.requireNonNull(registry);
+    checkClientTrusted = registry.createId("ssl.blocklist.checkClientTrusted");
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] x509Certificates, String authType)
+      throws CertificateException {
+    if (BLOCKLIST_ENABLED.get()) {
+      boolean rejected = false;
+      try {
+        if (x509Certificates != null) {
+          for (X509Certificate cert : x509Certificates) {
+            if (blocklist.isBlocklisted(cert)) {
+              rejected = true;
+              throw new CertificateRevokedException(
+                  new Date(),
+                  CRLReason.UNSPECIFIED,
+                  cert.getIssuerX500Principal(),
+                  Collections.emptyMap());
+            }
+          }
+        }
+      } finally {
+        registry
+            .counter(checkClientTrusted.withTag("rejected", Boolean.toString(rejected)))
+            .increment();
+      }
+    }
+
+    delegate.checkClientTrusted(x509Certificates, authType);
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] x509Certificates, String authType)
+      throws CertificateException {
+    delegate.checkServerTrusted(x509Certificates, authType);
+  }
+
+  @Override
+  public X509Certificate[] getAcceptedIssuers() {
+    return delegate.getAcceptedIssuers();
+  }
+}

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/ReloadingFileBlocklist.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/ReloadingFileBlocklist.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.tomcat.x509;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.security.auth.x500.X500Principal;
+
+public class ReloadingFileBlocklist implements Blocklist {
+  private static class Entry {
+    private static final String DELIMITER = ":::";
+    private final X500Principal issuer;
+    private final BigInteger serial;
+
+    private static Entry fromString(String blocklistEntry) {
+      int idx = blocklistEntry.indexOf(DELIMITER);
+      if (idx == -1) {
+        throw new IllegalArgumentException(
+            "Missing delimiter " + DELIMITER + " in " + blocklistEntry);
+      }
+      X500Principal principal = new X500Principal(blocklistEntry.substring(0, idx));
+      BigInteger serial = new BigInteger(blocklistEntry.substring(idx + DELIMITER.length()));
+      return new Entry(principal, serial);
+    }
+
+    private Entry(X500Principal issuer, BigInteger serial) {
+      this.issuer = Objects.requireNonNull(issuer);
+      this.serial = Objects.requireNonNull(serial);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Entry entry = (Entry) o;
+
+      if (!issuer.equals(entry.issuer)) return false;
+      return serial.equals(entry.serial);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = issuer.hashCode();
+      result = 31 * result + serial.hashCode();
+      return result;
+    }
+  }
+
+  private static final int DEFAULT_RELOAD_INTERVAL_SECONDS = 5;
+  private final String blocklistFile;
+  private final LoadingCache<String, Set<Entry>> blocklist;
+
+  public ReloadingFileBlocklist(String blocklistFile, long reloadInterval, TimeUnit unit) {
+    this.blocklistFile = blocklistFile;
+    this.blocklist =
+        CacheBuilder.newBuilder()
+            .expireAfterAccess(reloadInterval, unit)
+            .build(
+                new CacheLoader<String, Set<Entry>>() {
+                  @Override
+                  public Set<Entry> load(String key) throws Exception {
+                    File f = new File(key);
+                    if (!f.exists()) {
+                      return Collections.emptySet();
+                    }
+                    return ImmutableSet.copyOf(
+                        Files.readAllLines(f.toPath()).stream()
+                            .map(String::trim)
+                            .filter(line -> !(line.isEmpty() || line.startsWith("#")))
+                            .map(Entry::fromString)
+                            .collect(Collectors.toSet()));
+                  }
+                });
+  }
+
+  public ReloadingFileBlocklist(String blocklistFile) {
+    this(blocklistFile, DEFAULT_RELOAD_INTERVAL_SECONDS, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public boolean isBlocklisted(X509Certificate cert) {
+    try {
+      return blocklist
+          .get(blocklistFile)
+          .contains(new Entry(cert.getIssuerX500Principal(), cert.getSerialNumber()));
+    } catch (ExecutionException ee) {
+      Throwable cause = ee.getCause();
+      if (cause != null) {
+        if (cause instanceof RuntimeException) {
+          throw (RuntimeException) cause;
+        }
+        throw new RuntimeException(cause);
+      }
+      throw new RuntimeException(ee);
+    }
+  }
+}

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/SslExtensionConfigurationProperties.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/x509/SslExtensionConfigurationProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.tomcat.x509;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("server.ssl")
+public class SslExtensionConfigurationProperties {
+  private String crlFile = null;
+
+  public String getCrlFile() {
+    return crlFile;
+  }
+
+  public void setCrlFile(String crlFile) {
+    this.crlFile = crlFile;
+  }
+}


### PR DESCRIPTION
This change effectively reverts https://github.com/spinnaker/kork/pull/684
as the removal of this functionality could have disastrous consequences
for operators.  The shameful choice in naming has been addressed.

\#684 was merged without any type of deprecation warning and there
doesn't seem to be an alternative approach for operators relying on the
ability to revoke certificates.

This reverts commit c6b94918d6fd26d1c84af3a4cf53f8cf2f5082e9.