### PR TITLE
fix(plugins): fixes enable-default-repositories flag

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsConfigurationProperties.java
@@ -20,33 +20,30 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import lombok.SneakyThrows;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Root-level configuration properties for plugins.
  *
+ * <p>These properties are mapped using a {@link
+ * org.springframework.boot.context.properties.bind.Binder} because they are needed before the
+ * {@link org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor}
+ * has run.
+ *
  * @see PluginsAutoConfiguration
  */
-@ConfigurationProperties(PluginsConfigurationProperties.CONFIG_NAMESPACE)
 public class PluginsConfigurationProperties {
   public static final String CONFIG_NAMESPACE = "spinnaker.extensibility";
   public static final String DEFAULT_ROOT_PATH = "plugins";
   public static final String FRONT5O_REPOSITORY = "front50";
+  public static final String SPINNAKER_OFFICIAL_REPOSITORY = "spinnaker-official";
+  public static final String SPINNAKER_COMMUNITY_REPOSITORY = "spinnaker-community";
 
   /**
    * The root filepath to the directory containing all plugins.
    *
    * <p>If an absolute path is not provided, the path will be calculated relative to the executable.
    */
-  // Note that this property is not bound at PluginManager initialization time,
-  // but is retained here for documentation purposes. Later consumers of this property
-  // will see the correctly bound value that was used when initializing the plugin subsystem.
   private String pluginsRootPath = DEFAULT_ROOT_PATH;
-
-  // If for some reason we change the associated property name ensure this constant
-  // is updated to match. This is the actual value we will read from the environment
-  // at init time.
-  public static final String ROOT_PATH_CONFIG = CONFIG_NAMESPACE + ".plugins-root-path";
 
   public String getPluginsRootPath() {
     return pluginsRootPath;

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginsConfigurationPropertiesTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginsConfigurationPropertiesTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.plugins
+
+import com.netflix.spinnaker.config.PluginsAutoConfiguration
+import com.netflix.spinnaker.config.PluginsConfigurationProperties
+import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import strikt.api.expectThat
+import strikt.assertions.contains
+import strikt.assertions.doesNotContain
+import strikt.assertions.isEqualTo
+import java.nio.file.Paths
+
+class PluginsConfigurationPropertiesTest : JUnit5Minutests {
+  fun tests() = rootContext {
+    derivedContext<ApplicationContextRunner>("when default plugin repositories are enabled (true by default)") {
+      fixture {
+        ApplicationContextRunner()
+          .withPropertyValues(
+            "spring.application.name=kork",
+          )
+          .withConfiguration(
+            AutoConfigurations.of(
+              PluginsAutoConfiguration::class.java
+            )
+          )
+      }
+
+      test("default repositories should have been configured") {
+        run { ctx ->
+          val updateManager = ctx.getBean(SpinnakerUpdateManager::class.java)
+          expectThat(updateManager.repositories.map { it.id }).contains(
+            PluginsConfigurationProperties.SPINNAKER_OFFICIAL_REPOSITORY,
+            PluginsConfigurationProperties.SPINNAKER_COMMUNITY_REPOSITORY,
+          )
+        }
+      }
+    }
+
+    derivedContext<ApplicationContextRunner>("when default plugin repositories are disabled") {
+      fixture {
+        ApplicationContextRunner()
+          .withPropertyValues(
+            "spring.application.name=kork",
+            "spinnaker.extensibility.enable-default-repositories=false"
+          )
+          .withConfiguration(
+            AutoConfigurations.of(
+              PluginsAutoConfiguration::class.java
+            )
+          )
+      }
+
+      test("default repositories should not been configured") {
+        run { ctx ->
+          val updateManager = ctx.getBean(SpinnakerUpdateManager::class.java)
+          expectThat(updateManager.repositories.map { it.id }).doesNotContain(
+            PluginsConfigurationProperties.SPINNAKER_OFFICIAL_REPOSITORY,
+            PluginsConfigurationProperties.SPINNAKER_COMMUNITY_REPOSITORY,
+          )
+        }
+      }
+    }
+
+    derivedContext<ApplicationContextRunner>("when no plugins root path is configured") {
+      fixture {
+        ApplicationContextRunner()
+          .withPropertyValues(
+            "spring.application.name=kork",
+          )
+          .withConfiguration(
+            AutoConfigurations.of(
+              PluginsAutoConfiguration::class.java
+            )
+          )
+      }
+
+      test("plugins root path is 'plugins'") {
+        run { ctx ->
+          val pluginManager = ctx.getBean(SpinnakerPluginManager::class.java)
+          expectThat(pluginManager.pluginsRoot).isEqualTo(Paths.get(PluginsConfigurationProperties.DEFAULT_ROOT_PATH))
+        }
+      }
+    }
+
+    derivedContext<ApplicationContextRunner>("when a plugins root path is configured") {
+      fixture {
+        ApplicationContextRunner()
+          .withPropertyValues(
+            "spring.application.name=kork",
+            "spinnaker.extensibility.plugins-root-path=path/to/my/plugins"
+          )
+          .withConfiguration(
+            AutoConfigurations.of(
+              PluginsAutoConfiguration::class.java
+            )
+          )
+      }
+
+      test("plugins root path is absolute path of configured value") {
+        run { ctx ->
+          val pluginManager = ctx.getBean(SpinnakerPluginManager::class.java)
+          expectThat(pluginManager.pluginsRoot).isEqualTo(Paths.get("path/to/my/plugins").toAbsolutePath())
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The `spinnaker.extensibility.enable-default-repositories` flag didn't work, which was breaking users who have air-gapped environments and needed to turn the default repos off.

I tried to unify the configuration to be more consistent by just mapping `PluginsConfigurationProperties` with a `Binder` and removed a spot where we were manually mapping a single property (`pluginsRootPath`). I'm not sure why the repositories are handled differently: https://github.com/spinnaker/kork/blob/master/kork-plugins/src/main/java/com/netflix/spinnaker/config/PluginsAutoConfiguration.java#L136-L142. I can clean that up too if that makes sense.

I initially used the `ConfigResolver` instead of a `Binder`, but decided against it since it doesn't map properties in a way that people will expect. It doesn't do the snake case mapping (eg `enable-default-properties` doesn't work).