### PR TITLE
Tomcat reject illegal header

### DIFF
--- a/kork-tomcat/kork-tomcat.gradle
+++ b/kork-tomcat/kork-tomcat.gradle
@@ -6,4 +6,5 @@ dependencies {
   api(platform(project(":spinnaker-dependencies")))
   implementation("org.springframework.boot:spring-boot-starter-web")
 
+  testImplementation "org.springframework.boot:spring-boot-starter-test"
 }

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/DefaultTomcatConnectorCustomizer.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/DefaultTomcatConnectorCustomizer.java
@@ -44,6 +44,10 @@ class DefaultTomcatConnectorCustomizer implements TomcatConnectorCustomizer {
   public void customize(Connector connector) {
     this.applySSLSettings(connector);
     this.applyRelaxedURIProperties(connector);
+    if (tomcatConfigurationProperties.getRejectIllegalHeader() != null) {
+      ((AbstractHttp11Protocol<?>) connector.getProtocolHandler())
+          .setRejectIllegalHeader(tomcatConfigurationProperties.getRejectIllegalHeader());
+    }
   }
 
   Ssl copySslConfigurationWithClientAuth(TomcatServletWebServerFactory tomcat) {

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/TomcatConfigurationProperties.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/TomcatConfigurationProperties.java
@@ -53,6 +53,8 @@ public class TomcatConfigurationProperties {
               "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
               "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"));
 
+  private Boolean rejectIllegalHeader;
+
   public int getLegacyServerPort() {
     return legacyServerPort;
   }
@@ -99,5 +101,13 @@ public class TomcatConfigurationProperties {
 
   public void setCipherSuites(List<String> cipherSuites) {
     this.cipherSuites = cipherSuites;
+  }
+
+  public Boolean getRejectIllegalHeader() {
+    return rejectIllegalHeader;
+  }
+
+  public void setRejectIllegalHeader(Boolean rejectIllegalHeader) {
+    this.rejectIllegalHeader = rejectIllegalHeader;
   }
 }

--- a/kork-tomcat/src/test/java/com/netflix/spinnaker/kork/tomcat/WebEnvironmentTest.java
+++ b/kork-tomcat/src/test/java/com/netflix/spinnaker/kork/tomcat/WebEnvironmentTest.java
@@ -24,8 +24,17 @@ import org.springframework.web.util.UriComponentsBuilder;
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = {WebEnvironmentTest.TestControllerConfiguration.class})
+// It would be lovely to have a per-method TestPropertySource annotation, or
+// some other simple way to parametrize tests to verify what happens when
+// default.rejectIllegalHeader isn't set at all, and set to true, in addition to
+// setting it to false.  At the moment this doesn't seem worth the code
+// duplication / complexity.  See
+// https://github.com/spring-projects/spring-framework/issues/18951.
 @TestPropertySource(
-    properties = {"logging.level.org.apache.coyote.http11.Http11InputBuffer = DEBUG"})
+    properties = {
+      "logging.level.org.apache.coyote.http11.Http11InputBuffer = DEBUG",
+      "default.rejectIllegalHeader = false"
+    })
 class WebEnvironmentTest {
 
   @LocalServerPort int port;
@@ -47,7 +56,7 @@ class WebEnvironmentTest {
 
     ResponseEntity<String> entity =
         restTemplate.exchange(uri, HttpMethod.GET, new HttpEntity<>(headers), String.class);
-    assertEquals(HttpStatus.BAD_REQUEST, entity.getStatusCode());
+    assertEquals(HttpStatus.OK, entity.getStatusCode());
   }
 
   @SpringBootApplication

--- a/kork-tomcat/src/test/java/com/netflix/spinnaker/kork/tomcat/WebEnvironmentTest.java
+++ b/kork-tomcat/src/test/java/com/netflix/spinnaker/kork/tomcat/WebEnvironmentTest.java
@@ -1,0 +1,70 @@
+package com.netflix.spinnaker.kork.tomcat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = {WebEnvironmentTest.TestControllerConfiguration.class})
+@TestPropertySource(
+    properties = {"logging.level.org.apache.coyote.http11.Http11InputBuffer = DEBUG"})
+class WebEnvironmentTest {
+
+  @LocalServerPort int port;
+
+  @Autowired TestRestTemplate restTemplate;
+
+  @Test
+  void testTomcatWithIllegalHttpHeaders() throws Exception {
+    HttpHeaders headers = new HttpHeaders();
+    // this is enough to cause a BAD_REQUEST if tomcat has rejectIllegalHeaders
+    // set to true
+    headers.add("X-Dum@my", "foo");
+
+    URI uri =
+        UriComponentsBuilder.fromHttpUrl("http://localhost/test-controller")
+            .port(port)
+            .build()
+            .toUri();
+
+    ResponseEntity<String> entity =
+        restTemplate.exchange(uri, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+    assertEquals(HttpStatus.BAD_REQUEST, entity.getStatusCode());
+  }
+
+  @SpringBootApplication
+  public static class TestControllerConfiguration {
+    @Bean
+    TestController testController() {
+      return new TestController();
+    }
+  }
+
+  @RestController
+  @RequestMapping("/test-controller")
+  static class TestController {
+
+    @GetMapping
+    void get() {
+      return;
+    }
+  }
+}


### PR DESCRIPTION
This particular log is from a test, but in production, we've seen circumstances where various spinnaker microservices log this message, more often under high load:
```
2021-05-04 12:38:10.495  INFO 16142 --- [o-auto-1-exec-1] o.apache.coyote.http11.Http11Processor   : Error parsing HTTP request header
 Note: further occurrences of HTTP request parsing errors will be logged at DEBUG level.

java.lang.IllegalArgumentException: The HTTP header line [x-dum@my: foo] does not conform to RFC 7230 and has been ignored.
	at org.apache.coyote.http11.Http11InputBuffer.skipLine(Http11InputBuffer.java:986) ~[tomcat-embed-core-9.0.31.jar:9.0.31]
	at org.apache.coyote.http11.Http11InputBuffer.parseHeader(Http11InputBuffer.java:835) ~[tomcat-embed-core-9.0.31.jar:9.0.31]
	at org.apache.coyote.http11.Http11InputBuffer.parseHeaders(Http11InputBuffer.java:565) ~[tomcat-embed-core-9.0.31.jar:9.0.31]
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:277) ~[tomcat-embed-core-9.0.31.jar:9.0.31]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[tomcat-embed-core-9.0.31.jar:9.0.31]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:868) ~[tomcat-embed-core-9.0.31.jar:9.0.31]
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1639) ~[tomcat-embed-core-9.0.31.jar:9.0.31]
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-embed-core-9.0.31.jar:9.0.31]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[na:na]
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-9.0.31.jar:9.0.31]
	at java.base/java.lang.Thread.run(Thread.java:834) ~[na:na]
```
This PR doesn't address the root cause of what is generating the illegal headers.  The requests are coming from spinnaker microservices, but it's not clear where the illegal headers are coming from.  Tomcat 9.0.31 [got more strict with header values](https://github.com/apache/tomcat/commit/8bfb0ff7f25fe7555a5eb2f7984f73546c11aa26) (see also https://tomcat.apache.org/tomcat-9.0-doc/changelog.html#Tomcat_9.0.31_(markt)) which may explain why we haven't seen this before.

When tomcat rejects illegal headers, it drops the request and responds with 400. Setting `default.rejectIllegalHeader` to false convinces tomcat to let the requests through.  This PR doesn't change the default behavior, but does provide a relatively easy way to configure tomcat.

Note that only `server.port` and `default.apiPort` respect this configuration property.  `default.legacyServerPort` does not.

See also https://github.com/spring-projects/spring-boot/pull/26311, which is merged, but doesn't look like it'll appear until spring boot 2.6 which is likely pretty far down the road.