### PR TITLE
fix(plugins): Use getExtensionClass() instead of getClass() for Expre…

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
@@ -179,7 +179,7 @@ public class ExpressionsSupport {
         registerFunction(
             evaluationContext,
             namespacedFunctionName,
-            p.getClass(),
+            p.getExtensionClass(),
             function.getName(),
             functionTypes);
       }


### PR DESCRIPTION
…ssionFunctionProviders

ExpressionFunctionProvider extends SpinnakerExtensionPoint, enabling SpEL expressions to be contributed by plugins. However, when a function is being registered, the class of the ExpressionFunctionProvider is used - for ExpressionFunctionProviders coming from a plugin, this is a proxy class. In order for this to work correctly, the getExtensionClass() method should be used instead to resolve the appropriate class (proxy class or not).