### PR TITLE
fix(sql): Bump mysql-connector-java to 8.0.24 

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -131,7 +131,7 @@ dependencies {
     api("io.swagger:swagger-annotations:${versions.swagger}")
     api("javax.annotation:javax.annotation-api:1.3.2")
     api("javax.xml.bind:jaxb-api:2.3.1")
-    api("mysql:mysql-connector-java:8.0.20")
+    api("mysql:mysql-connector-java:8.0.24")
     api("net.logstash.logback:logstash-logback-encoder:4.11")
     api("org.apache.commons:commons-exec:1.3")
     api("org.apache.commons:commons-lang3:3.9")


### PR DESCRIPTION
In the recent JDK 11.0.11 release TLS 1.0 and 1.1 were disabled. ( [release notes](https://www.oracle.com/java/technologies/javase/11all-relnotes.html) ). 
This led to MySQL connectors failing to connect with "protocol is disabled or cipher suites are inappropriate" errors. 
Bumping version to 8.0.24 should resolve it.