### PR TITLE
chore(dependencies): Upgrade eureka-client to resolve xstream CVEs

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -79,7 +79,7 @@ dependencies {
     api("com.netflix.archaius:archaius-core:0.7.7")
     api("com.netflix.awsobjectmapper:awsobjectmapper:${versions.aws}")
     api("com.netflix.dyno:dyno-jedis:1.7.2")
-    api("com.netflix.eureka:eureka-client:1.9.18")
+    api("com.netflix.eureka:eureka-client:1.10.15")
     api("com.netflix.frigga:frigga:0.24.0")
     api("com.netflix.netflix-commons:netflix-eventbus:0.3.0")
     api("com.netflix.spectator:spectator-api:${versions.spectator}")


### PR DESCRIPTION
Upgrade eureka to resolve below XStream CVEs

[CVE-2021-29505](https://github.com/advisories/GHSA-7chv-rrw6-w6fc)
[CVE-2021-21351](https://nvd.nist.gov/vuln/detail/CVE-2021-21351)
[CVE-2021-21350](https://nvd.nist.gov/vuln/detail/CVE-2021-21350)
[CVE-2021-21347](https://nvd.nist.gov/vuln/detail/CVE-2021-21347)
[CVE-2021-21346](https://nvd.nist.gov/vuln/detail/CVE-2021-21346)
[CVE-2021-21345](https://nvd.nist.gov/vuln/detail/CVE-2021-21345)
[CVE-2021-21344](https://nvd.nist.gov/vuln/detail/CVE-2021-21344)
[CVE-2021-21342](https://nvd.nist.gov/vuln/detail/CVE-2021-21342)