### PR TITLE
chore(build): use dependencies that exist in maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 plugins {
   id 'io.spinnaker.project' version "$spinnakerGradleVersion" apply false
   id "org.jetbrains.kotlin.jvm" version "$kotlinVersion" apply false
-  id "io.gitlab.arturbosch.detekt" version "1.7.4" apply false
+  id "io.gitlab.arturbosch.detekt" version "1.17.1" apply false
   id 'org.jetbrains.kotlin.plugin.allopen' version "$kotlinVersion" apply false
 }
 

--- a/kork-jedis-test/kork-jedis-test.gradle
+++ b/kork-jedis-test/kork-jedis-test.gradle
@@ -4,5 +4,5 @@ dependencies {
   api(platform(project(":spinnaker-dependencies")))
 
   api "redis.clients:jedis"
-  api "com.netflix.spinnaker.embedded-redis:embedded-redis"
+  api "io.spinnaker.embedded-redis:embedded-redis"
 }

--- a/kork-plugins/kork-plugins.gradle
+++ b/kork-plugins/kork-plugins.gradle
@@ -50,5 +50,13 @@ compileJava {
 }
 
 detekt {
+  // Ignore tests since there are a number of warnings.  As of version 1.17.0,
+  // detekt scans test code (i.e. src/test/java and src/test/kotlin) by default.
+  // See https://detekt.github.io/detekt/changelog.html#notable-changes-2 and
+  // https://github.com/detekt/detekt/pull/3649.
+  input = files(
+    "src/main/java",
+    "src/main/kotlin"
+  )
   ignoreFailures = false
 }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/MetricInvocationAspect.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/MetricInvocationAspect.kt
@@ -31,6 +31,7 @@ import java.lang.reflect.Method
 import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
+import java.util.Locale
 
 /**
  * Adds metric instrumentation to extension method invocations.
@@ -160,7 +161,7 @@ class MetricInvocationAspect(
   }
 
   private fun toMetricId(method: Method, metricNamespace: String, annotationMetricId: String?, metricName: String): String? {
-    val methodMetricId = if (method.parameterCount == 0) method.name else String.format("%s%d", method.name, method.parameterCount)
+    val methodMetricId = if (method.parameterCount == 0) method.name else String.format(Locale.US, "%s%d", method.name, method.parameterCount)
     val metricId = if (annotationMetricId.isNullOrEmpty()) methodMetricId else annotationMetricId
     return MethodInstrumentation.toMetricId(metricNamespace, metricId, metricName)
   }

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringEventListenerAdapter.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringEventListenerAdapter.kt
@@ -49,7 +49,7 @@ class SpringEventListenerAdapter(
    * It's not enough to just look at the immediate interfaces of the type, since it's possible a plugin developer
    * will make an abstract class for all event listeners.
    */
-  @Suppress("TooGenericExceptionCaught")
+  @Suppress("TooGenericExceptionCaught", "SwallowedException")
   private fun findEventType(eventListener: SpinnakerEventListener<*>): Class<*>? {
     return try {
       val eventListenerType = ResolvableType.forInstance(eventListener)

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -21,7 +21,7 @@ ext {
     retrofit         : "1.9.0",
     retrofit2        : "2.8.1",
     spectator        : "0.103.0",
-    spek             : "1.2.1",
+    spek             : "1.1.5",
     spek2            : "2.0.9",
     spring           : "5.2.9.RELEASE", // this should be kept in sync with spring-boot / removed once the need for a version override is gone
     springBoot       : "2.2.5.RELEASE",
@@ -50,7 +50,7 @@ dependencies {
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
-  api(platform("io.strikt:strikt-bom:0.29.0"))
+  api(platform("io.strikt:strikt-bom:0.31.0"))
   api(platform("org.spockframework:spock-bom:1.3-groovy-2.5"))
   api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:1.5.17"))
   api(platform("org.testcontainers:testcontainers-bom:1.15.1"))
@@ -90,7 +90,7 @@ dependencies {
     api("com.netflix.spectator:spectator-reg-atlas:${versions.spectator}")
     api("com.netflix.spectator:spectator-web-spring:${versions.spectator}")
     api("com.netflix.spectator:spectator-reg-micrometer:${versions.spectator}")
-    api("com.netflix.spinnaker.embedded-redis:embedded-redis:0.8.0")
+    api("io.spinnaker.embedded-redis:embedded-redis:0.9.0")
     api("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
     api("com.nhaarman:mockito-kotlin:1.6.0")
     api("com.ninja-squad:springmockk:2.0.3")
@@ -119,7 +119,7 @@ dependencies {
     api("commons-collections:commons-collections:[3.2.2,3.3)")
     api("de.danielbechler:java-object-diff:0.95")
     api("de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.2.0")
-    api("dev.minutest:minutest:1.11.0")
+    api("dev.minutest:minutest:1.13.0")
     api("io.github.resilience4j:resilience4j-annotations:${versions.resilience4j}")
     api("io.github.resilience4j:resilience4j-circuitbreaker:${versions.resilience4j}")
     api("io.github.resilience4j:resilience4j-kotlin:${versions.resilience4j}")


### PR DESCRIPTION
some dependencies (or transitive dependencies of those) only existed in bintray, not maven
central, and now that bintray is gone, we need to adjust.