### PR TITLE
fix(no-discovery): publish discovery events as expected by keiko

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/discovery/NoDiscoveryStatusPublisher.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/discovery/NoDiscoveryStatusPublisher.java
@@ -45,8 +45,10 @@ public class NoDiscoveryStatusPublisher
   }
 
   private void setInstanceStatus(InstanceStatus instanceStatus) {
+    InstanceStatus previousStatus =
+        instanceStatus == InstanceStatus.UP ? InstanceStatus.UNKNOWN : InstanceStatus.UP;
     eventPublisher.publishEvent(
         new RemoteStatusChangedEvent(
-            new DiscoveryStatusChangeEvent(InstanceStatus.UNKNOWN, instanceStatus)));
+            new DiscoveryStatusChangeEvent(previousStatus, instanceStatus)));
   }
 }


### PR DESCRIPTION
Trying to fix the `/admin/instance/enabled` endpoint in Orca. One of the reasons why it won't work is that the `NoDiscoveryStatusPublisher` emits `(previous=UNKNOWN, current=DOWN)`, but Keiko expects `(previous=UP, current=DOWN)`: https://github.com/spinnaker/orca/blob/master/keiko-spring/src/main/kotlin/com/netflix/spinnaker/q/discovery/DiscoveryActivator.kt#L43.

This all sort of seems like a hack to me, but I checked the uses of `DiscoveryStatusChangeEvent` across Spinnaker and this seems consistent with how it's used. (e.g., here: https://github.com/spinnaker/swabbie/blob/03e1b624c55340302d7b98459166a3e01e138d98/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerTest.kt#L64)