### PR TITLE
chore(build): replace org.funktionale:funktionale-partials with io.ar…

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -6,6 +6,7 @@ javaPlatform {
 
 ext {
   versions = [
+    arrow            : "0.13.2",
     aws              : "1.11.1009",
     bouncycastle     : "1.64", // 1.64 removes CVE-2019-17359
     brave            : "5.12.3",
@@ -55,6 +56,7 @@ dependencies {
   api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:1.5.17"))
   api(platform("org.testcontainers:testcontainers-bom:1.15.1"))
   api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))
+  api(platform("io.arrow-kt:arrow-stack:${versions.arrow}"))
 
   constraints {
     api("cglib:cglib-nodep:3.3.0")
@@ -139,7 +141,6 @@ dependencies {
     api("org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}")
     api("org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}")
     api("org.codehaus.groovy:groovy-all:${versions.groovy}")
-    api("org.funktionale:funktionale-partials:1.2")
     api("org.jetbrains:annotations:19.0.0")
     api("org.spekframework.spek2:spek-dsl-jvm:${versions.spek2}")
     api("org.spekframework.spek2:spek-runner-junit5:${versions.spek2}")


### PR DESCRIPTION
…row-kt

since org.funktionale:funktionale-partials isn't available at maven central, and according
to https://github.com/MarioAriasC/funKTionale, https://github.com/arrow-kt/arrow replaces
it.