### PR TITLE
chore(dependencies): Upgrade org.postgresql:postgresql to resolve CVE

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -159,6 +159,7 @@ dependencies {
     api("org.objenesis:objenesis:2.5.1")
     api("org.pf4j:pf4j:3.2.0")
     api("org.pf4j:pf4j-update:2.3.0")
+    api("org.postgresql:postgresql:42.2.13")
     api("org.springdoc:springdoc-openapi-webmvc-core:${versions.openapi}")
     api("org.springdoc:springdoc-openapi-kotlin:${versions.openapi}")
     api("org.springframework.boot:spring-boot-configuration-processor:${versions.springBoot}")


### PR DESCRIPTION
As recommended to fix CVE-2020-13692 for all the affected spinnaker services [(clouddriver, fiat, front50, orca)](https://github.com/spinnaker/front50/pull/1050), proposing the changes in kork.