### PR TITLE
chore(dependencies): Upgrade commons-io:commons-io to resolve CVE

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -122,7 +122,7 @@ dependencies {
     api("com.sun.xml.bind:jaxb-impl:2.3.2")
     api("com.vdurmont:semver4j:3.1.0")
     api("commons-configuration:commons-configuration:1.8")
-    api("commons-io:commons-io:2.5")
+    api("commons-io:commons-io:2.7")
     // CVE's in 3.2.1
     api("commons-collections:commons-collections:[3.2.2,3.3)")
     api("de.danielbechler:java-object-diff:0.95")


### PR DESCRIPTION
This fix CVE-2021-29425 for all the following affected spinnaker components:
clouddriver, echo, fiat, front50, gate, halyard, igor, kayenta, rosco