### PR TITLE
fix(build): updating embedded redis version

### DIFF
--- a/kork-jedis-test/kork-jedis-test.gradle
+++ b/kork-jedis-test/kork-jedis-test.gradle
@@ -4,5 +4,5 @@ dependencies {
   api(platform(project(":spinnaker-dependencies")))
 
   api "redis.clients:jedis"
-  api "com.netflix.spinnaker.embedded-redis:embedded-redis"
+  api "io.spinnaker.embedded-redis:embedded-redis"
 }

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -89,7 +89,7 @@ dependencies {
     api("com.netflix.spectator:spectator-reg-atlas:${versions.spectator}")
     api("com.netflix.spectator:spectator-web-spring:${versions.spectator}")
     api("com.netflix.spectator:spectator-reg-micrometer:${versions.spectator}")
-    api("com.netflix.spinnaker.embedded-redis:embedded-redis:0.8.0")
+    api("io.spinnaker.embedded-redis:embedded-redis:0.9.0")
     api("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
     api("com.nhaarman:mockito-kotlin:1.6.0")
     api("com.ninja-squad:springmockk:2.0.3")


### PR DESCRIPTION
https://github.com/spinnaker/clouddriver/runs/3355608452 is failing due to 0.8.0 not being available, 0.9.0 is available on mavenCentral