### PR TITLE
chore(dependencies): Upgrade net.minidev:json-smart to resolve CVE

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -141,6 +141,7 @@ dependencies {
     api("javax.xml.bind:jaxb-api:2.3.1")
     api("mysql:mysql-connector-java:8.0.20")
     api("net.logstash.logback:logstash-logback-encoder:4.11")
+    api("net.minidev:json-smart:2.4.1") // TODO: remove this with upgrade of spring-boot version to 2.5.0 or above
     api("org.apache.commons:commons-exec:1.3")
     api("org.apache.commons:commons-lang3:3.9")
     api("org.assertj:assertj-core:3.15.0")


### PR DESCRIPTION
[CVE-2021-27568](https://nvd.nist.gov/vuln/detail/CVE-2021-27568)
net.minidev:json-smart is introduced transitively by spring-boot and springframework through com.jayway.jsonpath:json-path, and also by oracle-sdk, azure-client-auth through com.nimbusds:nimbus-jose-jwt. Affected components are clouddriver, echo, front50, gate, halyard, kayenta and orca.