### PR TITLE
chore(dependencies): Upgrade com.nimbusds:nimbus-jose-jwt to resolve CVE

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -98,6 +98,7 @@ dependencies {
     api("com.netflix.spectator:spectator-reg-atlas:${versions.spectator}")
     api("com.netflix.spectator:spectator-web-spring:${versions.spectator}")
     api("com.netflix.spectator:spectator-reg-micrometer:${versions.spectator}")
+    api("com.nimbusds:nimbus-jose-jwt:7.9")
     api("io.spinnaker.embedded-redis:embedded-redis:0.9.0")
     api("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
     api("com.nhaarman:mockito-kotlin:1.6.0")


### PR DESCRIPTION
[CVE-2019-17195](https://nvd.nist.gov/vuln/detail/CVE-2019-17195)
com.nimbusds:nimbus-jose-jwt is introduced transitively by oracle-sdk, azure-client-auth. Affected spinnaker components are cloudriver, halyard and gate.
