### PR TITLE
feat(expressions): Allow TemporalAdjusters in expressions

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/InstantiationTypeRestrictor.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/allowlist/InstantiationTypeRestrictor.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 
 public class InstantiationTypeRestrictor {
@@ -46,7 +47,8 @@ public class InstantiationTypeRestrictor {
                   DayOfWeek.class,
                   Instant.class,
                   ChronoUnit.class,
-                  URLEncoder.class)));
+                  URLEncoder.class,
+                  TemporalAdjusters.class)));
 
   boolean supports(Class<?> type) {
     return allowedTypes.contains(type);


### PR DESCRIPTION
When automatically updating base image once per week, we'd like to pin the version number to a particular day of the week: 

```java
LocalDate.now().with(TemporalAdjusters.previous(DayOfWeek.WEDNESDAY)).toString()
```