### PR TITLE
chore(dependencies): Upgrade Spring Boot to 2.2.13

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -24,8 +24,8 @@ ext {
     spectator        : "0.103.0",
     spek             : "1.1.5",
     spek2            : "2.0.9",
-    spring           : "5.2.9.RELEASE", // this should be kept in sync with spring-boot / removed once the need for a version override is gone
-    springBoot       : "2.2.5.RELEASE",
+    spring           : "5.2.12.RELEASE", // this should be kept in sync with spring-boot / removed once the need for a version override is gone
+    springBoot       : "2.2.13.RELEASE",
     springCloud      : "Hoxton.SR4",
     springfoxSwagger : "2.9.2",
     swagger          : "1.5.20", //this should stay in sync with what springfoxSwagger expects
@@ -51,7 +51,7 @@ dependencies {
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
-  api(platform("org.junit:junit-bom:5.6.2"))
+  api(platform("org.junit:junit-bom:5.6.3"))
   api(platform("com.fasterxml.jackson:jackson-bom:2.11.1"))
   api(platform("org.springframework:spring-framework-bom:${versions.spring}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))


### PR DESCRIPTION
Part of spinnaker/spinnaker#6537
Upgrade spring boot from 2.2.5 to 2.2.13. 
Along with it upgrade org.junit:junit-bom to 5.6.3. due to this:
spring boot 2.2.13 uses groovy version 2.5.14, that upgrades org.codehaus.groovy:groovy-test from 2.5.11 (constrained in spinnaker-dependencies) to 2.5.14 and upgrades junit:junit from 4.13 to 4.13.1. 
In kork, org.junit:junit-bom is constrained to 5.6.2, having bug as junit-vintage-engine:5.6.2 does not parse junit version of format x.y.z, just parse x.y. 
This bug is fixed in 5.6.3 and 5.7.0. 
https://github.com/junit-team/junit5/issues/2529   
https://github.com/junit-team/junit5/issues/2198 