### PR TITLE
chore(dependencies): Upgrade eureka-client to resolve CVE

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -87,7 +87,7 @@ dependencies {
     api("com.netflix.archaius:archaius-core:0.7.7")
     api("com.netflix.awsobjectmapper:awsobjectmapper:${versions.aws}")
     api("com.netflix.dyno:dyno-jedis:1.7.2")
-    api("com.netflix.eureka:eureka-client:1.10.16")
+    api("com.netflix.eureka:eureka-client:1.10.17")
     api("com.netflix.frigga:frigga:0.24.0")
     api("com.netflix.netflix-commons:netflix-eventbus:0.3.0")
     api("com.netflix.spectator:spectator-api:${versions.spectator}")


### PR DESCRIPTION
Bump eureka-client version to resolve CVE-2021-39141 which was introduced by xstream dependency 

Issue related https://github.com/Netflix/eureka/issues/1421