### PR TITLE
fix(plugins): update constructors for jackson mappers

### DIFF
--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/Front50PluginsConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/Front50PluginsConfiguration.java
@@ -95,9 +95,11 @@ public class Front50PluginsConfiguration {
 
     URL front50Url = getFront50Url(environment, front50RepositoryProps);
 
+    KotlinModule kotlinModule = new KotlinModule.Builder().build();
+
     ObjectMapper objectMapper =
         new ObjectMapper()
-            .registerModule(new KotlinModule())
+            .registerModule(kotlinModule)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .configure(SerializationFeature.INDENT_OUTPUT, true)
             .setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/kork-plugins/src/main/java/com/netflix/spinnaker/config/HttpClientSdkConfiguration.java
+++ b/kork-plugins/src/main/java/com/netflix/spinnaker/config/HttpClientSdkConfiguration.java
@@ -70,12 +70,14 @@ public class HttpClientSdkConfiguration {
     OkHttp3ClientConfiguration config =
         new OkHttp3ClientConfiguration(okHttpClientProperties, okHttp3MetricsInterceptor);
 
+    KotlinModule kotlinModule = new KotlinModule.Builder().build();
+
     // TODO(rz): It'd be nice to make this customizable, but I'm not sure how to do that without
     //  bringing Jackson into the Plugin SDK (quite undesirable).
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.registerModule(new Jdk8Module());
     objectMapper.registerModule(new JavaTimeModule());
-    objectMapper.registerModule(new KotlinModule());
+    objectMapper.registerModule(kotlinModule);
     objectMapper.disable(READ_DATE_TIMESTAMPS_AS_NANOSECONDS);
     objectMapper.disable(WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
     objectMapper.disable(FAIL_ON_UNKNOWN_PROPERTIES);

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolver.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolver.kt
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.node.MissingNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TreeTraversingParser
 import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.netflix.spinnaker.kork.annotations.Beta
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import com.netflix.spinnaker.kork.exceptions.SystemException
@@ -58,7 +58,7 @@ class SpringEnvironmentConfigResolver(
   private val mapper = ObjectMapper()
     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
     .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-    .registerModules(KotlinModule())
+    .registerKotlinModule()
 
   override fun <T> resolve(coordinates: ConfigCoordinates, expectedType: Class<T>): T =
     resolveInternal(coordinates, { mapper.convertValue(emptyMap<Any, Any>(), expectedType) }) {

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/FileDownloaderProvider.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/FileDownloaderProvider.kt
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.kork.plugins.update.downloader
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.netflix.spinnaker.config.PluginsConfigurationProperties.PluginRepositoryProperties.FileDownloaderProperties
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import com.netflix.spinnaker.kork.plugins.config.Configurable
@@ -31,7 +31,7 @@ class FileDownloaderProvider(
   private val compositeFileDownloader: CompositeFileDownloader
 ) {
 
-  private val mapper: ObjectMapper = ObjectMapper().registerModule(KotlinModule())
+  private val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
 
   /**
    * Get a [FileDownloader] for the [UpdateRepository].

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/SerdeServiceImplTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/SerdeServiceImplTest.kt
@@ -16,7 +16,7 @@
 package com.netflix.spinnaker.kork.plugins.sdk
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.netflix.spinnaker.kork.plugins.sdk.serde.SerdeServiceImpl
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -27,7 +27,7 @@ class SerdeServiceImplTest : JUnit5Minutests {
 
   fun tests() = rootContext<SerdeServiceImpl> {
     fixture {
-      SerdeServiceImpl(ObjectMapper().registerModule(KotlinModule()))
+      SerdeServiceImpl(ObjectMapper().registerKotlinModule())
     }
     test("map to converts a hashmap to target type") {
       val o = mapOf(

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientIntegrationTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientIntegrationTest.kt
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.kork.plugins.sdk.httpclient
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.configureFor
@@ -85,7 +85,7 @@ class Ok3HttpClientIntegrationTest : JUnit5Minutests {
         wiremock.url(""),
         OkHttpClient(),
         ObjectMapper().apply {
-          registerModule(KotlinModule())
+          registerKotlinModule()
         }
       )
     }


### PR DESCRIPTION
When we moved to Jackson 2.12 there were some constructors that weren't
updated and weren't caught until runtime. I don't know enough about
Jackson's Kotlin integration to why this wasn't an issue. I built and
ran tests on master for this project and everything was fine, even after
making the constructor changes.

I tested this change by using composite builds to bring this into rosco
and see that it starts successfully now. I'm not sure if we'll need to
do similar kork bumps in other services.