### PR TITLE
fix(dependencies): add com.amazonaws:aws-java-sdk-sts to kork-aws

### DIFF
--- a/kork-aws/kork-aws.gradle
+++ b/kork-aws/kork-aws.gradle
@@ -37,6 +37,8 @@ dependencies {
     transitive = false
   }
 
+  runtimeOnly "com.amazonaws:aws-java-sdk-sts"
+
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-runner"


### PR DESCRIPTION
Orca in particular (and other services likely) is unable to correctly assume
the IAM role associated with it's pod's service account when deployed to EKS.
It fails with a message like:

 Reason: Unable to load AWS credentials from any provider in the chain

This appears to be because orca is not pulling in aws-java-sdk-sts as a dependency
anywhere. Other services like front50 and clouddriver are pulling in this library
and are able to function correctly in this EKS / IRSA deployment scenario.

kork-aws seems to be a good place to put this dependency after discussion on Slack.

I noticed this when trying to configure orca using a secret in secretsmanager.

fixes: https://github.com/spinnaker/spinnaker/issues/6502