### PR TITLE
chore(build): bump mysql driver and liquibase-core to latest

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -12,6 +12,7 @@ ext {
     brave            : "5.12.3",
     groovy           : "2.5.11", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
     jooq             : "3.13.2",
+    liquibase        : "4.8.0",
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
     protobuf         : "3.9.1",
@@ -145,7 +146,7 @@ dependencies {
     api("io.swagger:swagger-annotations:${versions.swagger}")
     api("javax.annotation:javax.annotation-api:1.3.2")
     api("javax.xml.bind:jaxb-api:2.3.1")
-    api("mysql:mysql-connector-java:8.0.20")
+    api("mysql:mysql-connector-java:8.0.28")
     api("net.logstash.logback:logstash-logback-encoder:4.11")
     api("net.minidev:json-smart:2.4.1") // TODO: remove this with upgrade of spring-boot version to 2.5.0 or above
     api("org.apache.commons:commons-exec:1.3")
@@ -163,6 +164,7 @@ dependencies {
     api("org.jetbrains.spek:spek-subject-extension:${versions.spek}")
     api("org.jooq:jooq:${versions.jooq}")
     api("org.jooq:jooq-kotlin:${versions.jooq}")
+    api("org.liquibase:liquibase-core:${versions.liquibase}")
     api("org.objenesis:objenesis:2.5.1")
     api("org.pf4j:pf4j:3.2.0")
     api("org.pf4j:pf4j-update:2.3.0")


### PR DESCRIPTION
I see there is no liquibase-core version specified, I've tested on clouddriver running locally, I had problems during the migration by liquibase, when using latest mysql driver i.e.
```sh
Caused by: java.lang.ClassCastException: class java.time.LocalDateTime cannot be cast to class java.lang.String (java.time.LocalDateTime and java.lang.String are in module java.base of loader 'bootstrap')
	at liquibase.changelog.StandardChangeLogHistoryService.getRanChangeSets(StandardChangeLogHistoryService.java:328) ~[liquibase-core-3.8.9.jar:na]
	at liquibase.changelog.AbstractChangeLogHistoryService.upgradeChecksums(AbstractChangeLogHistoryService.java:66) ~[liquibase-core-3.8.9.jar:na]
	at liquibase.changelog.StandardChangeLogHistoryService.upgradeChecksums(StandardChangeLogHistoryService.java:297) ~[liquibase-core-3.8.9.jar:na]
	at liquibase.Liquibase.checkLiquibaseTables(Liquibase.java:1228) ~[liquibase-core-3.8.9.jar:na]
	at liquibase.Liquibase.update(Liquibase.java:193) ~[liquibase-core-3.8.9.jar:na]
	at liquibase.Liquibase.update(Liquibase.java:179) ~[liquibase-core-3.8.9.jar:na]
	at liquibase.integration.spring.SpringLiquibase.performUpdate(SpringLiquibase.java:366) ~[liquibase-core-3.8.9.jar:na]
	at liquibase.integration.spring.SpringLiquibase.afterPropertiesSet(SpringLiquibase.java:314) ~[liquibase-core-3.8.9.jar:na]
	at com.netflix.spinnaker.kork.sql.migration.SpringLiquibaseProxy.afterPropertiesSet(SpringLiquibaseProxy.kt:65) ~[kork-sql-7.131.0.jar:7.131.0]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1853) ~[spring-beans-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1790) ~[spring-beans-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	... 150 common frames omitted
```
and by upgrading the liquibase version, I got it working
See discussion on [stackoverflow](https://stackoverflow.com/questions/66787654/class-java-time-localdatetime-cannot-be-cast-to-class-java-lang-string)