### PR TITLE
feat(mysql): set com.mysql.cj.jdbc.Driver as default driver

### DIFF
--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/ConnectionPoolProperties.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/ConnectionPoolProperties.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.kork.sql.config
 
 import java.util.concurrent.TimeUnit
 import org.jooq.SQLDialect
+import org.springframework.boot.jdbc.DatabaseDriver
 
 /**
  * Configuration properties for SQL connection pools.
@@ -38,7 +39,7 @@ import org.jooq.SQLDialect
 data class ConnectionPoolProperties(
   var dialect: SQLDialect = SQLDialect.MYSQL,
   var jdbcUrl: String? = null,
-  var driver: String? = null,
+  var driver: String? = DatabaseDriver.MYSQL.driverClassName,
   var user: String? = null,
   var password: String? = null,
   var connectionTimeoutMs: Long = TimeUnit.SECONDS.toMillis(5),

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlMigrationProperties.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlMigrationProperties.kt
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.kork.sql.config
 
+import org.springframework.boot.jdbc.DatabaseDriver
+
 /**
  * Defines the configuration properties for connecting to a SQL database for schema migration purposes.
  *
@@ -28,6 +30,6 @@ data class SqlMigrationProperties(
   var jdbcUrl: String? = null,
   var user: String? = null,
   var password: String? = null,
-  var driver: String? = null,
+  var driver: String? = DatabaseDriver.MYSQL.driverClassName,
   var additionalChangeLogs: List<String> = mutableListOf()
 )


### PR DESCRIPTION
Useful in case there are two or more mysql drivers on the classpath and it isn't set on neither connectionPools nor migration e.g.
```yml
sql:
  enabled: true
...
  connectionPools:
    default:
      default: true
      jdbcUrl: jdbc:mysql://{host}:3306/clouddriver
      user: clouddriver_service
  migration:
    user: clouddriver_migrate
    jdbcUrl: jdbc:mysql://{host}:3306/clouddriver
```
So it should default to MySQL Connector/J