### PR TITLE
chore(dependencies): update spring boot

### DIFF
--- a/kork-core/kork-core.gradle
+++ b/kork-core/kork-core.gradle
@@ -12,6 +12,7 @@ dependencies {
   api "org.springframework.boot:spring-boot-autoconfigure"
   api "org.springframework.boot:spring-boot-starter-aop"
   api "org.springframework.boot:spring-boot-starter-actuator"
+  api 'org.springframework.boot:spring-boot-starter-json'
   api "com.netflix.spectator:spectator-api"
   api "com.google.code.findbugs:jsr305"
   api "io.github.resilience4j:resilience4j-annotations"

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -10,8 +10,8 @@ ext {
     aws              : "1.12.100",
     bouncycastle     : "1.64", // 1.64 removes CVE-2019-17359
     brave            : "5.12.3",
-    groovy           : "2.5.11", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
-    jooq             : "3.13.2",
+    groovy           : "2.5.14", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
+    jooq             : "3.13.6",
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
     protobuf         : "3.9.1",
@@ -24,8 +24,8 @@ ext {
     spectator        : "1.0.6",
     spek             : "1.1.5",
     spek2            : "2.0.9",
-    spring           : "5.2.12.RELEASE", // this should be kept in sync with spring-boot / removed once the need for a version override is gone
-    springBoot       : "2.2.13.RELEASE",
+    spring           : "5.2.15.RELEASE", // this should be kept in sync with spring-boot / removed once the need for a version override is gone
+    springBoot       : "2.3.12.RELEASE",
     springCloud      : "Hoxton.SR4",
     springfoxSwagger : "2.9.2",
     swagger          : "1.5.20", //this should stay in sync with what springfoxSwagger expects
@@ -150,7 +150,6 @@ dependencies {
     api("net.minidev:json-smart:2.4.1") // TODO: remove this with upgrade of spring-boot version to 2.5.0 or above
     api("org.apache.commons:commons-exec:1.3")
     api("org.apache.commons:commons-lang3:3.9")
-    api("org.assertj:assertj-core:3.15.0")
     api("org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}")
     api("org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}")
     api("org.codehaus.groovy:groovy-all:${versions.groovy}")
@@ -166,7 +165,6 @@ dependencies {
     api("org.objenesis:objenesis:2.5.1")
     api("org.pf4j:pf4j:3.2.0")
     api("org.pf4j:pf4j-update:2.3.0")
-    api("org.postgresql:postgresql:42.2.13") // TODO: remove this with upgrade of spring-boot version to 2.2.8 or above
     api("org.springdoc:springdoc-openapi-webmvc-core:${versions.openapi}")
     api("org.springdoc:springdoc-openapi-kotlin:${versions.openapi}")
     api("org.springframework.boot:spring-boot-configuration-processor:${versions.springBoot}")


### PR DESCRIPTION
Start moving incrementally towards spring boot v2.5.0, first step being bumping to v2.3.12.RELEASE

Closes https://github.com/spinnaker/spinnaker/issues/6565

`library("Spring Framework", "5.2.15.RELEASE") {`
https://github.com/spring-projects/spring-boot/blob/v2.3.12.RELEASE/spring-boot-project/spring-boot-dependencies/build.gradle#L1676

`library("Groovy", "2.5.14") {`
https://github.com/spring-projects/spring-boot/blob/v2.3.12.RELEASE/spring-boot-project/spring-boot-dependencies/build.gradle#L369

`library("jOOQ", "3.13.6") {`
https://github.com/spring-projects/spring-boot/blob/v2.3.12.RELEASE/spring-boot-project/spring-boot-dependencies/build.gradle#L894

`library("Postgresql", "42.2.20") {`
https://github.com/spring-projects/spring-boot/blob/v2.3.12.RELEASE/spring-boot-project/spring-boot-dependencies/build.gradle#L1377

`library("AssertJ", "3.16.1") {`
https://github.com/spring-projects/spring-boot/blob/v2.3.12.RELEASE/spring-boot-project/spring-boot-dependencies/build.gradle#L105

testClasses gradle task run successfully
```sh
> Task :kork-plugins:compileTestJava
> Task :kork-plugins:compileTestGroovy NO-SOURCE
> Task :kork-plugins:testClasses

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 7s
122 actionable tasks: 27 executed, 95 up-to-date
3:20:54: Execution finished 'testClasses'.
```