### PR TITLE
feat(sql): use sessionlevel locking for liquibase locks

### DIFF
--- a/kork-sql/kork-sql.gradle
+++ b/kork-sql/kork-sql.gradle
@@ -12,6 +12,8 @@ dependencies {
   api "org.liquibase:liquibase-core"
   api "com.zaxxer:HikariCP"
 
+  implementation 'com.github.blagerweij:liquibase-sessionlock:1.4.0'
+
   testImplementation "org.springframework.boot:spring-boot-starter-actuator"
   testImplementation "org.springframework.boot:spring-boot-starter-web"
   testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/kork-sql/kork-sql.gradle
+++ b/kork-sql/kork-sql.gradle
@@ -12,7 +12,7 @@ dependencies {
   api "org.liquibase:liquibase-core"
   api "com.zaxxer:HikariCP"
 
-  implementation 'com.github.blagerweij:liquibase-sessionlock:1.4.0'
+  implementation 'com.github.blagerweij:liquibase-sessionlock:1.5.0'
 
   testImplementation "org.springframework.boot:spring-boot-starter-actuator"
   testImplementation "org.springframework.boot:spring-boot-starter-web"


### PR DESCRIPTION
## Purpose
This addresses https://github.com/spinnaker/spinnaker/issues/6625

## Background

* We observed that when clouddriver starts up, liquibase creates a table in the db and stores a lock, to ensure that only one of the pods can do the schema updates at any given point in time. If the pod is terminated before liquibase can release the lock, no new clouddriver pods can come up since in those pods, liquibase fails to acquire this lock as its held by a now dead pod. This lock has no timeout, so manual intervention is needed to clear this.

* Liquibase is aware of this issue, https://github.com/liquibase/liquibase/issues/1453 and has been working on it for a while. In the meantime, they propose using init containers https://www.liquibase.com/blog/using-liquibase-in-kubernetes  for running the liquibase logic or executing the `liquibase releaselocks` command to clear the locks manually, if needed.

* Based on this, we had three possible solutions that we could try:
1. Use the init container approach suggested by liquibase.
2. Have an external resource monitoring job, that checks to see if the pod holding the lock is alive or dead. If it is dead, it it will clear the lock.
3. Rework the locking logic in liquibase to not have transaction level locking, but instead have session level locking.
 

After discussing the options internally, it seems like the best way to solve this would be such that the system self-heals, and doesn't require any external solutions to fix the issue. With solution 1, it can so happen that for long running migrations, the init container can die before releasing the lock, so that doesn't completely make the problem go away. 

So we decided to go with option 3. We found an external library that already solves this problem for mysql db by implementing the session level locking provided by mysql. (https://github.com/blagerweij/liquibase-sessionlock) and have been using it for a while now without a repeat of this issue in our internal systems.
