### PR TITLE
feat(secrets): Add UserSecret API

### DIFF
--- a/kork-secrets/kork-secrets.gradle
+++ b/kork-secrets/kork-secrets.gradle
@@ -5,6 +5,9 @@ apply from: "$rootDir/gradle/lombok.gradle"
 dependencies {
   api(platform(project(":spinnaker-dependencies")))
 
+  api project(":kork-core")
+  api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+  api "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
   implementation "org.springframework.boot:spring-boot-autoconfigure"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.yaml:snakeyaml"
@@ -15,7 +18,6 @@ dependencies {
   testImplementation "org.spockframework:spock-core"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
-  testRuntimeOnly "org.slf4j:slf4j-simple"
 
   testImplementation("org.springframework:spring-test")
   testImplementation("org.springframework.boot:spring-boot-test")

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretConfiguration.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretConfiguration.java
@@ -16,18 +16,80 @@
 
 package com.netflix.spinnaker.kork.secrets;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.netflix.spinnaker.kork.secrets.user.UserSecret;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretMapper;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretMixin;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretTypeProvider;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.util.ClassUtils;
 
 @Configuration
 @ComponentScan
+@Log4j2
 public class SecretConfiguration {
 
   @Bean
   static SecretBeanPostProcessor secretBeanPostProcessor(
       ConfigurableApplicationContext applicationContext, SecretManager secretManager) {
     return new SecretBeanPostProcessor(applicationContext, secretManager);
+  }
+
+  @Bean
+  public UserSecretTypeProvider defaultUserSecretTypeProvider(ResourceLoader loader) {
+    var provider = new ClassPathScanningCandidateComponentProvider(false);
+    provider.setResourceLoader(loader);
+    provider.addIncludeFilter(new AssignableTypeFilter(UserSecret.class));
+    return () ->
+        provider.findCandidateComponents(UserSecret.class.getPackageName()).stream()
+            .map(BeanDefinition::getBeanClassName)
+            .filter(Objects::nonNull)
+            .map(className -> tryLoadUserSecretClass(className, loader.getClassLoader()))
+            .filter(Objects::nonNull);
+  }
+
+  @Nullable
+  private static Class<? extends UserSecret> tryLoadUserSecretClass(
+      @Nonnull String className, @Nullable ClassLoader classLoader) {
+    try {
+      return ClassUtils.forName(className, classLoader).asSubclass(UserSecret.class);
+    } catch (ClassNotFoundException e) {
+      log.error(
+          "Unable to load discovered UserSecret class {}. User secrets with this type will not be parseable.",
+          className,
+          e);
+      return null;
+    }
+  }
+
+  @Bean
+  public UserSecretMapper userSecretMapper(
+      final List<UserSecretTypeProvider> userSecretTypeProviders) {
+    List<ObjectMapper> mappers = List.of(new ObjectMapper(), new YAMLMapper(), new CBORMapper());
+    Set<Class<?>> classes =
+        userSecretTypeProviders.stream()
+            .flatMap(UserSecretTypeProvider::getUserSecretTypes)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    mappers.forEach(
+        mapper ->
+            mapper.addMixIn(UserSecret.class, UserSecretMixin.class).registerSubtypes(classes));
+    return new UserSecretMapper(mappers);
   }
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretEngine.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretEngine.java
@@ -16,6 +16,10 @@
 
 package com.netflix.spinnaker.kork.secrets;
 
+import com.netflix.spinnaker.kork.secrets.user.UserSecret;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretReference;
+import javax.annotation.Nonnull;
+
 /**
  * SecretEngines contain service specific functionality in order to decrypt EncryptedSecrets.
  * Identifiers are used in order to identify which SecretEngine an EncryptedSecret refers to.
@@ -25,6 +29,11 @@ public interface SecretEngine {
   String identifier();
 
   byte[] decrypt(EncryptedSecret encryptedSecret);
+
+  @Nonnull
+  default UserSecret decrypt(@Nonnull UserSecretReference reference) {
+    throw new UnsupportedOperationException("This operation is not supported");
+  }
 
   /**
    * In order for a secretEngine to decrypt an EncryptedSecret, it may require extra information
@@ -39,6 +48,17 @@ public interface SecretEngine {
 
   default EncryptedSecret encrypt(String secretToEncrypt) {
     throw new UnsupportedOperationException("This operation is not supported");
+  }
+
+  default void validate(@Nonnull UserSecretReference reference) {
+    if (!reference
+        .getParameters()
+        .containsKey(StandardSecretParameter.ENCODING.getParameterName())) {
+      throw new InvalidSecretFormatException(
+          String.format(
+              "No encoding parameter specified (%s=...) in %s",
+              StandardSecretParameter.ENCODING.getParameterName(), reference));
+    }
   }
 
   void clearCache();

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/StandardSecretParameter.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/StandardSecretParameter.java
@@ -1,0 +1,15 @@
+package com.netflix.spinnaker.kork.secrets;
+
+import javax.annotation.Nonnull;
+import lombok.Getter;
+
+public enum StandardSecretParameter {
+  KEY("k"),
+  ENCODING("e");
+
+  @Getter @Nonnull private final String parameterName;
+
+  StandardSecretParameter(String parameterName) {
+    this.parameterName = parameterName;
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/engines/NoopSecretEngine.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/engines/NoopSecretEngine.java
@@ -18,6 +18,11 @@ package com.netflix.spinnaker.kork.secrets.engines;
 
 import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import com.netflix.spinnaker.kork.secrets.SecretEngine;
+import com.netflix.spinnaker.kork.secrets.user.OpaqueUserSecret;
+import com.netflix.spinnaker.kork.secrets.user.UserSecret;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretReference;
+import java.util.Map;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 /**
@@ -40,7 +45,16 @@ public class NoopSecretEngine implements SecretEngine {
   }
 
   @Override
+  @Nonnull
+  public UserSecret decrypt(@Nonnull UserSecretReference reference) {
+    return OpaqueUserSecret.builder().stringData(Map.copyOf(reference.getParameters())).build();
+  }
+
+  @Override
   public void validate(EncryptedSecret encryptedSecret) {}
+
+  @Override
+  public void validate(@Nonnull UserSecretReference reference) {}
 
   @Override
   public void clearCache() {}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/OpaqueUserSecret.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/OpaqueUserSecret.java
@@ -1,0 +1,83 @@
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Opaque user secrets are generic user secrets containing a list of roles allowed to use data from
+ * this secret along with maps for string and binary data. This type of user secret has the
+ * following fields:
+ *
+ * <dl>
+ *   <dt>type
+ *   <dd><tt>opaque</tt>
+ *   <dt>roles
+ *   <dd>List of Fiat roles allowed to use this secret. When other Spinnaker resources use this user
+ *       secret, the intersection between that user's roles and the user secret's roles must be
+ *       non-empty.
+ *   <dt>data
+ *   <dd>Contains base64-encoded values as a map of keys to values.
+ *   <dt>stringData
+ *   <dd>Contains UTF-8-encoded values as a map of keys to values.
+ * </dl>
+ */
+@JsonTypeName(OpaqueUserSecret.TYPE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Getter
+public class OpaqueUserSecret implements UserSecret {
+  public static final String TYPE = "opaque";
+
+  private final List<String> roles;
+  private final Map<String, byte[]> data;
+  private final Map<String, String> stringData;
+
+  @Builder
+  @JsonCreator
+  public OpaqueUserSecret(
+      @JsonProperty("roles") List<String> roles,
+      @JsonProperty("data") Map<String, byte[]> data,
+      @JsonProperty("stringData") Map<String, String> stringData) {
+    this.roles = roles != null ? roles : List.of();
+    this.data = data != null ? data : Map.of();
+    this.stringData = stringData != null ? stringData : Map.of();
+  }
+
+  @Override
+  @Nonnull
+  public String getType() {
+    return TYPE;
+  }
+
+  @Override
+  @Nonnull
+  public String getSecretString(@Nonnull String key) {
+    var value = stringData.get(key);
+    if (value != null) {
+      return value;
+    }
+    throw new NoSuchElementException(key);
+  }
+
+  @Override
+  @Nonnull
+  public byte[] getSecretBytes(@Nonnull String key) {
+    var bytes = data.get(key);
+    if (bytes != null) {
+      return bytes;
+    }
+    var value = stringData.get(key);
+    if (value != null) {
+      return value.getBytes(StandardCharsets.UTF_8);
+    }
+    throw new NoSuchElementException(key);
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecret.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecret.java
@@ -1,0 +1,37 @@
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.secrets.SecretEngine;
+import java.util.Collection;
+import javax.annotation.Nonnull;
+
+/**
+ * User secrets are externally stored secrets with additional user-provided metadata regarding who
+ * is authorized to use the contents of the secret along with defining the type of secret stored.
+ * User secrets are stored in user-specific secrets managers supported by the {@link SecretEngine}
+ * API. User secrets have a {@linkplain #getType() type} which corresponds to a specific
+ * implementation type of this interface for use as a type discriminator. User secrets define a
+ * collection of {@linkplain #getRoles() roles} allowed to use the contents of this secret.
+ *
+ * @see OpaqueUserSecret
+ */
+public interface UserSecret {
+
+  /** Returns the type of user secret. */
+  @Nonnull
+  String getType();
+
+  /** Returns the authorized roles that can use this secret. */
+  @Nonnull
+  Collection<String> getRoles();
+
+  /**
+   * Gets the value of this secret with the provided key and returns a string encoding of it. Secret
+   * values that only have a binary encoding are not supported by this method.
+   */
+  @Nonnull
+  String getSecretString(@Nonnull String key);
+
+  /** Gets the value of this secret with the provided key and returns its raw bytes. */
+  @Nonnull
+  byte[] getSecretBytes(@Nonnull String key);
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManager.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManager.java
@@ -1,0 +1,31 @@
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
+import com.netflix.spinnaker.kork.secrets.SecretEngine;
+import com.netflix.spinnaker.kork.secrets.SecretEngineRegistry;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Central component for obtaining user secrets by reference.
+ *
+ * @see UserSecretReference
+ * @see UserSecret
+ */
+@Component
+@RequiredArgsConstructor
+public class UserSecretManager {
+  private final SecretEngineRegistry registry;
+
+  @Nonnull
+  public UserSecret getUserSecret(@Nonnull UserSecretReference reference) {
+    String engineIdentifier = reference.getEngineIdentifier();
+    SecretEngine engine = registry.getEngine(engineIdentifier);
+    if (engine == null) {
+      throw new SecretDecryptionException("Unknown secret engine identifier: " + engineIdentifier);
+    }
+    engine.validate(reference);
+    return engine.decrypt(reference);
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretMapper.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretMapper.java
@@ -1,0 +1,62 @@
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
+import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
+import com.netflix.spinnaker.kork.secrets.SecretException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.annotation.Nonnull;
+
+/**
+ * Maps decrypted secret data to a corresponding {@link UserSecret} using different encoding
+ * formats. Encoding formats are specified by an {@link ObjectMapper}'s {@link
+ * JsonFactory#getFormatName()} use case-insensitive string comparison.
+ *
+ * @see UserSecretReference
+ */
+public class UserSecretMapper {
+  private final Map<String, ObjectMapper> mappersByEncodingFormat =
+      new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+  public UserSecretMapper(@Nonnull List<ObjectMapper> mappers) {
+    mappers.forEach(
+        mapper -> mappersByEncodingFormat.put(mapper.getFactory().getFormatName(), mapper));
+  }
+
+  @Nonnull
+  public UserSecret deserialize(@Nonnull byte[] input, @Nonnull String encoding) {
+    var mapper = mappersByEncodingFormat.get(encoding);
+    if (mapper == null) {
+      throw new InvalidSecretFormatException(
+          String.format(
+              "Unsupported user secret encoding: %s. Known encoding formats: %s",
+              encoding, mappersByEncodingFormat.keySet()));
+    }
+    try {
+      return mapper.readValue(input, UserSecret.class);
+    } catch (IOException e) {
+      throw new SecretDecryptionException(e);
+    }
+  }
+
+  @Nonnull
+  public byte[] serialize(@Nonnull UserSecret secret, @Nonnull String encoding) {
+    var mapper = mappersByEncodingFormat.get(encoding);
+    if (mapper == null) {
+      throw new InvalidSecretFormatException(
+          String.format(
+              "Unsupported user secret encoding: %s. Known encoding formats: %s",
+              encoding, mappersByEncodingFormat.keySet()));
+    }
+    try {
+      return mapper.writeValueAsBytes(secret);
+    } catch (JsonProcessingException e) {
+      throw new SecretException(e);
+    }
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretMixin.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretMixin.java
@@ -1,0 +1,13 @@
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Jackson mixin for {@link UserSecret} to support encoding and decoding user secrets based on a
+ * provided {@code type} property.
+ */
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type")
+public interface UserSecretMixin {}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretReference.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretReference.java
@@ -1,0 +1,109 @@
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
+import com.netflix.spinnaker.kork.secrets.SecretEngine;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Parses a URI reference to a {@link UserSecret}. These URIs use the scheme {@code secret://}
+ * followed by the {@linkplain SecretEngine#identifier() secret engine identifier}, a question mark,
+ * and parameter key/value pairs separated by ampersands (i.e., parameters are provided as the query
+ * string of this URI). The engine identifier and the query string may be encoded using URL-escaping
+ * for otherwise illegal characters in a URI (see {@link URI} for more details). For example, with
+ * an engine identifier of {@code foo} with parameters {@code s=my-secret}, {@code r=us-north-1},
+ * {@code e=yaml}, and {@code k=my-key}, the corresponding user secret URI would be {@code
+ * secret://foo?s=my-secret&r=us-north-1&e=yaml&k=my-key}.
+ *
+ * <h2>Encoding Parameter</h2>
+ *
+ * <p>User secrets may be encoded in JSON, YAML, or CBOR, and the specific encoding format being
+ * used by a user secret should be specified through the {@code e} parameter with a value of {@code
+ * json}, {@code yaml}, or {@code cbor}. Secret engines may define a default encoding format if no
+ * {@code e} parameter is specified. Additional encoding formats may be configured through the
+ * {@link UserSecretMapper} bean.
+ *
+ * <h2>Key Parameter</h2>
+ *
+ * <p>User secrets may contain more than one secret value. The {@code k} parameter may be specified
+ * to select one of the secrets by name which will return a projected version of the secret with the
+ * selected key.
+ *
+ * @see UserSecret
+ */
+@EqualsAndHashCode
+@ToString
+@Getter
+public class UserSecretReference {
+  private static final Pattern SECRET_URI = Pattern.compile("^secret(File)?://.+");
+  public static final String SECRET_SCHEME = "secret";
+
+  @Nonnull private final String engineIdentifier;
+  @Nonnull private final Map<String, String> parameters = new ConcurrentHashMap<>();
+
+  private UserSecretReference(URI uri) {
+    if (!SECRET_SCHEME.equals(uri.getScheme())) {
+      throw new InvalidSecretFormatException("Only secret:// URIs supported");
+    }
+    engineIdentifier = uri.getAuthority();
+    String[] queryKeyValues = uri.getQuery().split("&");
+    if (queryKeyValues.length == 0) {
+      throw new InvalidSecretFormatException(
+          "Invalid user secret URI has no query parameters defined");
+    }
+    for (String keyValue : queryKeyValues) {
+      String[] pair = keyValue.split("=", 2);
+      if (pair.length != 2) {
+        throw new InvalidSecretFormatException(
+            "Invalid user secret query string; missing parameter value for '" + keyValue + "'");
+      }
+      parameters.put(pair[0], pair[1]);
+    }
+  }
+
+  /**
+   * Parses a user secret URI. Invalid URIs will throw an InvalidSecretFormatException.
+   *
+   * @param input URI data to parse
+   * @return the parsed UserSecretReference
+   * @throws InvalidSecretFormatException when the URI is invalid
+   */
+  @Nonnull
+  public static UserSecretReference parse(@Nonnull String input) {
+    try {
+      return new UserSecretReference(new URI(input));
+    } catch (URISyntaxException e) {
+      throw new InvalidSecretFormatException(e);
+    }
+  }
+
+  /**
+   * Tries to parse a user secret URI into a UserSecretReference. Invalid secret URIs return an
+   * empty value.
+   */
+  @Nonnull
+  public static Optional<UserSecretReference> tryParse(@Nullable Object value) {
+    if (!(value instanceof String && isUserSecret((String) value))) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(new UserSecretReference(new URI((String) value)));
+    } catch (URISyntaxException | InvalidSecretFormatException e) {
+      return Optional.empty();
+    }
+  }
+
+  /** Checks if the provided input string looks like a user secret URI. */
+  public static boolean isUserSecret(@Nonnull String input) {
+    return SECRET_URI.matcher(input).matches();
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretTypeProvider.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretTypeProvider.java
@@ -1,0 +1,11 @@
+package com.netflix.spinnaker.kork.secrets.user;
+
+import java.util.stream.Stream;
+
+/**
+ * Provides subtypes of {@link UserSecret} for registration as user secret types. All beans of this
+ * type contribute zero or more user secret classes.
+ */
+public interface UserSecretTypeProvider {
+  Stream<? extends Class<? extends UserSecret>> getUserSecretTypes();
+}

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/SecretManagerTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/SecretManagerTest.java
@@ -54,7 +54,7 @@ public class SecretManagerTest {
   @Test
   public void decryptTest() throws SecretDecryptionException {
     var secretConfig = "encrypted:s3!paramName:paramValue";
-    when(secretEngine.decrypt(any())).thenReturn("test".getBytes());
+    when(secretEngine.decrypt(any(EncryptedSecret.class))).thenReturn("test".getBytes());
     assertEquals("test", secretManager.decrypt(secretConfig));
   }
 
@@ -69,7 +69,9 @@ public class SecretManagerTest {
 
   @Test
   public void decryptInvalidParams() throws SecretDecryptionException {
-    doThrow(InvalidSecretFormatException.class).when(secretEngine).validate(any());
+    doThrow(InvalidSecretFormatException.class)
+        .when(secretEngine)
+        .validate(any(EncryptedSecret.class));
     String secretConfig = "encrypted:s3!paramName:paramValue";
     exceptionRule.expect(InvalidSecretFormatException.class);
     secretManager.decrypt(secretConfig);
@@ -78,7 +80,7 @@ public class SecretManagerTest {
   @Test
   public void decryptFile() throws SecretDecryptionException, IOException {
     String secretConfig = "encrypted:s3!paramName:paramValue";
-    when(secretEngine.decrypt(any())).thenReturn("test".getBytes());
+    when(secretEngine.decrypt(any(EncryptedSecret.class))).thenReturn("test".getBytes());
     Path path = secretManager.decryptAsFile(secretConfig);
     assertTrue(path.toAbsolutePath().toString().matches(".*.secret$"));
     BufferedReader reader = new BufferedReader(new FileReader(path.toFile()));
@@ -97,7 +99,9 @@ public class SecretManagerTest {
 
   @Test
   public void decryptFileInvalidParams() throws SecretDecryptionException {
-    doThrow(InvalidSecretFormatException.class).when(secretEngine).validate(any());
+    doThrow(InvalidSecretFormatException.class)
+        .when(secretEngine)
+        .validate(any(EncryptedSecret.class));
     String secretConfig = "encrypted:s3!paramName:paramValue";
     exceptionRule.expect(InvalidSecretFormatException.class);
     secretManager.decryptAsFile(secretConfig);

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/SecretSessionTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/SecretSessionTest.java
@@ -35,7 +35,7 @@ public class SecretSessionTest {
     doCallRealMethod().when(secretManager).decrypt(any());
 
     secretEngine = spy(new NoopSecretEngine());
-    doCallRealMethod().when(secretEngine).decrypt(any());
+    doCallRealMethod().when(secretEngine).decrypt(any(EncryptedSecret.class));
 
     secretEngineList.add(secretEngine);
     secretSession = new SecretSession(secretManager);

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManagerTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManagerTest.java
@@ -1,0 +1,34 @@
+package com.netflix.spinnaker.kork.secrets.user;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.netflix.spinnaker.kork.secrets.SecretConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@SpringBootTest(classes = SecretConfiguration.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class UserSecretManagerTest {
+
+  @Autowired UserSecretManager userSecretManager;
+
+  @Test
+  public void getTestSecret() {
+    var ref = UserSecretReference.parse("secret://noop?v=test");
+    var secret = userSecretManager.getUserSecret(ref);
+    assertEquals("test", secret.getSecretString("v"));
+    assertTrue(secret instanceof OpaqueUserSecret);
+    assertTrue(((OpaqueUserSecret) secret).getRoles().isEmpty());
+  }
+
+  @Test
+  public void getTestSecretString() {
+    var ref = UserSecretReference.parse("secret://noop?foo=bar");
+    var userSecret = userSecretManager.getUserSecret(ref);
+    assertEquals("bar", userSecret.getSecretString("foo"));
+  }
+}

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretMapperTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretMapperTest.java
@@ -1,0 +1,87 @@
+package com.netflix.spinnaker.kork.secrets.user;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+import com.netflix.spinnaker.kork.secrets.SecretConfiguration;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = SecretConfiguration.class)
+public class UserSecretMapperTest {
+
+  @Autowired UserSecretMapper mapper;
+
+  @Test
+  public void jsonStringMap() {
+    var bytes =
+        mapper.serialize(
+            OpaqueUserSecret.builder()
+                .roles(List.of("dev", "sre"))
+                .stringData(Map.of("foo", "bar", "second", "second"))
+                .build(),
+            "json");
+    var secret = mapper.deserialize(bytes, "json");
+    assertThat(secret.getRoles(), contains("dev", "sre"));
+    assertThat(secret, instanceOf(OpaqueUserSecret.class));
+    assertThat(secret.getSecretString("foo"), equalTo("bar"));
+    assertThat(secret.getSecretString("second"), equalTo("second"));
+  }
+
+  @Test
+  public void jsonBinaryMap() {
+    var bytes =
+        mapper.serialize(
+            OpaqueUserSecret.builder()
+                .roles(List.of("foo", "bar"))
+                .data(Map.of("first", "second".getBytes(StandardCharsets.UTF_8)))
+                .build(),
+            "json");
+    var secret = mapper.deserialize(bytes, "json");
+    assertThat(secret, instanceOf(OpaqueUserSecret.class));
+    assertThat(secret.getSecretBytes("first"), equalTo("second".getBytes(StandardCharsets.UTF_8)));
+    assertThat(secret.getRoles(), contains("foo", "bar"));
+  }
+
+  @Test
+  public void yamlStringMap() {
+    var bytes =
+        mapper.serialize(
+            OpaqueUserSecret.builder()
+                .roles(List.of("one"))
+                .stringData(Map.of("a", "A", "b", "B", "c", "C"))
+                .build(),
+            "yaml");
+    var secret = mapper.deserialize(bytes, "yaml");
+    assertThat(secret, instanceOf(OpaqueUserSecret.class));
+    assertThat(secret.getRoles(), contains("one"));
+    assertThat(secret.getSecretString("a"), equalTo("A"));
+    assertThat(secret.getSecretString("b"), equalTo("B"));
+    assertThat(secret.getSecretString("c"), equalTo("C"));
+  }
+
+  @Test
+  public void cborBinaryMap() {
+    var binaryData = "packed".getBytes(StandardCharsets.UTF_8);
+    var bytes =
+        mapper.serialize(
+            OpaqueUserSecret.builder()
+                .roles(List.of("one", "two", "three"))
+                .data(Map.of("bin", binaryData))
+                .build(),
+            "cbor");
+    var secret = mapper.deserialize(bytes, "cbor");
+    assertThat(secret, instanceOf(OpaqueUserSecret.class));
+    assertThat(secret.getRoles(), contains("one", "two", "three"));
+    assertThat(secret.getSecretBytes("bin"), equalTo(binaryData));
+  }
+}

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretReferenceTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretReferenceTest.java
@@ -1,0 +1,38 @@
+package com.netflix.spinnaker.kork.secrets.user;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+public class UserSecretReferenceTest {
+
+  @Test
+  public void invalidSecretURI() {
+    assertFalse(UserSecretReference.isUserSecret("secret"));
+    assertFalse(UserSecretReference.isUserSecret("secretFile"));
+    assertFalse(UserSecretReference.isUserSecret("file:///hello"));
+  }
+
+  @Test
+  public void goodSecretURI() {
+    var ref = UserSecretReference.parse("secret://foo?param1=bar1&param2=baz2");
+    assertNotNull(ref);
+    assertEquals("foo", ref.getEngineIdentifier());
+    var parameters = ref.getParameters();
+    assertEquals("bar1", parameters.get("param1"));
+    assertEquals("baz2", parameters.get("param2"));
+  }
+
+  @Test
+  public void encodedURIData() {
+    var ref =
+        UserSecretReference.parse(
+            "secret://engine%20identifier?first=hello%20world&second=%68%65%6c%6c%6f%20%77%6f%72%6c%64");
+    assertEquals("engine identifier", ref.getEngineIdentifier());
+    var parameters = ref.getParameters();
+    assertEquals("hello world", parameters.get("first"));
+    assertEquals("hello world", parameters.get("second"));
+  }
+}


### PR DESCRIPTION
This adds a new UserSecret API to kork-secrets. These secrets provide Fiat role requirements in order to use these secrets. A basic "opaque" user secret type is introduced for transporting Fiat role requirements inside a secret payload, though other types of user secrets can be introduced through an extension mechanism.

See https://github.com/spinnaker/governance/pull/286 for the RFC