### PR TITLE
fix(dependency): Issue of brave-bom version conflict resolution while enforcing dependencies from kork-bom in spinnaker services.

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -58,6 +58,7 @@ dependencies {
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
   api(platform("org.junit:junit-bom:5.6.3"))
   api(platform("com.fasterxml.jackson:jackson-bom:2.12.3"))
+  api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
   api(platform("org.springframework:spring-framework-bom:${versions.spring}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
@@ -178,6 +179,5 @@ dependencies {
     api("org.apache.tomcat.embed:tomcat-embed-core:${versions.tomcat}")
     api("org.apache.tomcat.embed:tomcat-embed-el:${versions.tomcat}")
     api("org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcat}")
-    api("io.zipkin.brave:brave-instrumentation-okhttp3:${versions.brave}")
   }
 }


### PR DESCRIPTION
Refer issues :
https://github.com/spinnaker/spinnaker/issues/6623
https://github.com/spinnaker/spinnaker/issues/6624

The issue of brave-bom conflict was observed in all the spinnaker services while enforcing dependencies from kork-bom.
In all the spinnaker services, io.zipkin.brave dependency is introduced by the means of maven imported kork-bom. After introduction of enforcedPlatform, it adhere to the version of brave package provided by Hoxton.SR4, because io.zipkin.brave:brave-bom is not part of spinnaker-dependencies.gradle in kork and its just a constraint here.
To fix this issue, introduced brave-bom dependency with desired version and removed it from constraint section under spinnaker-dependencies.gradle

api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))

The desired version of brave-bom (5.12.3) is supported by org.springframework.cloud:spring-cloud-dependencies:Hoxton.SR5. It can be considered to exclude this dependency after upgrade of Hoxton.SR5.