### PR TITLE
chore(dependencies): don't create an autobump PR for halyard on a kor…

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -13,7 +13,7 @@ jobs:
         ref: ${{ github.event.client_payload.ref }}
         baseBranch: ${{ github.event.client_payload.branch }}
         key: korkVersion
-        repositories: clouddriver,echo,fiat,front50,gate,halyard,igor,keel,orca,rosco,swabbie
+        repositories: clouddriver,echo,fiat,front50,gate,igor,keel,orca,rosco,swabbie
         mavenRepositoryUrl: https://repo.maven.apache.org/maven2
         groupId: io.spinnaker.kork
         artifactId: kork-bom


### PR DESCRIPTION
…k release branch

since release branches in halyard don't align with release branches in kork.  For example,
a release-1.27.x branch exists in both kork and halyard.  In kork release-1.27.x aligns
with spinnaker version 1.27.x, but halyard version numbers are independent from spinnaker
versions.