### PR TITLE
chore(dependencies): Upgrade spring cloud dependencies to Hoxton.SR12

### DIFF
--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -36,6 +36,8 @@ dependencies {
 
   compileOnly "org.springframework.boot:spring-boot-starter-actuator"
 
+  runtimeOnly "org.hibernate.validator:hibernate-validator"
+
   testImplementation "ch.qos.logback:logback-classic"
   testImplementation "ch.qos.logback:logback-core"
   testImplementation "org.spockframework:spock-core"

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -18,14 +18,13 @@ ext {
     okhttp           : "2.7.5", // CVE-2016-2402
     okhttp3          : "3.14.9",
     openapi          : "1.3.9", // this needs to be kept in sync with spring boot as it pulls in the spring-boot-dependencies BOM
-    resilience4j     : "1.0.0",
     retrofit         : "1.9.0",
     retrofit2        : "2.8.1",
     spectator        : "1.0.6",
     spek             : "1.1.5",
     spek2            : "2.0.9",
     springBoot       : "2.3.12.RELEASE",
-    springCloud      : "Hoxton.SR4",
+    springCloud      : "Hoxton.SR12",
     springfoxSwagger : "2.9.2",
     swagger          : "1.5.20", //this should stay in sync with what springfoxSwagger expects
     // tomcat (v9.0.31) was included via spring boot and upgrading spring boot
@@ -133,11 +132,6 @@ dependencies {
     api("de.danielbechler:java-object-diff:0.95")
     api("de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.2.0")
     api("dev.minutest:minutest:1.13.0")
-    api("io.github.resilience4j:resilience4j-annotations:${versions.resilience4j}")
-    api("io.github.resilience4j:resilience4j-circuitbreaker:${versions.resilience4j}")
-    api("io.github.resilience4j:resilience4j-kotlin:${versions.resilience4j}")
-    api("io.github.resilience4j:resilience4j-retry:${versions.resilience4j}")
-    api("io.github.resilience4j:resilience4j-spring-boot2:${versions.resilience4j}")
     api("io.mockk:mockk:1.10.5")
     api("io.springfox:springfox-swagger-ui:${versions.springfoxSwagger}")
     api("io.springfox:springfox-swagger2:${versions.springfoxSwagger}")


### PR DESCRIPTION
With upgrade of spring cloud dependencies, transitive dependency of resilience4j bumped up to 1.7.0. Removed the constraints marked for resilience4j in spinnaker-dependencies.gradle.
Adding runtime dependency of hibernate-validator, which has been removed from resilience4j:1.7.0. It is required by front50, orca and echo.