### PR TITLE
fix(dependencies): update jinjava to remove CVE

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -80,8 +80,9 @@ dependencies {
     api("com.google.apis:google-api-services-storage:v1-rev141-1.25.0")
     api("com.google.code.findbugs:jsr305:3.0.2")
     api("com.google.guava:guava:30.0-jre")
-    // JinJava 2.5.3 has a bad bug: https://github.com/HubSpot/jinjava/issues/429
-    api("com.hubspot.jinjava:jinjava:2.5.2")
+    api("com.hubspot.jinjava:jinjava:2.5.10") {
+      because "CVE-2020-12668"
+    }
     api("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
     api("com.jcraft.jsch:${versions.jsch}")
     api("com.jcraft:jsch.agentproxy.connector-factory:${versions.jschAgentProxy}")


### PR DESCRIPTION
Updating this removes CVE-2020-12668.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-12668

At Armory, we have had the 2.5.4+ config for a year, meaning we have run 2.5.8 to 2.5.10 since they came out. So this is a pretty safe change. We are just moving our own overrides to open source to fix CVE's for everyone.

In the past we weren’t able to update to 2.5.3 because of this bug:
https://github.com/HubSpot/jinjava/issues/429
Tests were created in Orca that demonstrated the bug:
https://github.com/spinnaker/orca/pull/3608
I have pinned orca to 2.5.10 and run these tests to ensure they pass. This implies that this bug has been fixed by 2.5.10.