### PR TITLE
feat(secret engine): Google Secret Manager support

### DIFF
--- a/kork-secrets-gcp/kork-secrets-gcp.gradle
+++ b/kork-secrets-gcp/kork-secrets-gcp.gradle
@@ -26,4 +26,9 @@ dependencies {
   implementation 'com.google.auth:google-auth-library-oauth2-http'
   implementation "org.springframework.boot:spring-boot-autoconfigure"
   implementation "org.slf4j:slf4j-api"
+  implementation "com.fasterxml.jackson.core:jackson-databind"
+  implementation "com.google.cloud:google-cloud-secretmanager"
+
+  testImplementation "junit:junit"
+  testImplementation "org.mockito:mockito-core"
 }

--- a/kork-secrets-gcp/src/main/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngine.java
+++ b/kork-secrets-gcp/src/main/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngine.java
@@ -50,14 +50,6 @@ public class GoogleSecretsManagerSecretEngine implements SecretEngine {
 
   private static SecretManagerServiceClient client;
 
-  public GoogleSecretsManagerSecretEngine() {
-    try {
-      client = SecretManagerServiceClient.create();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   @Override
   public String identifier() {
     return GoogleSecretsManagerSecretEngine.IDENTIFIER;
@@ -100,6 +92,9 @@ public class GoogleSecretsManagerSecretEngine implements SecretEngine {
   protected SecretPayload getSecretPayload(
       String projectNumber, String secretId, String secretVersion) {
     try {
+      if (client == null) {
+        client = SecretManagerServiceClient.create();
+      }
       if (secretVersion == null) {
         secretVersion = LATEST;
       }
@@ -107,7 +102,7 @@ public class GoogleSecretsManagerSecretEngine implements SecretEngine {
           SecretVersionName.of(projectNumber, secretId, secretVersion);
       AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
       return response.getPayload();
-    } catch (ApiException e) {
+    } catch (IOException | ApiException e) {
       throw new SecretException(
           String.format(
               "Failed to parse secret when using Google Secrets Manager to fetch: [projectNumber: %s, secretId: %s]",

--- a/kork-secrets-gcp/src/main/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngine.java
+++ b/kork-secrets-gcp/src/main/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngine.java
@@ -29,23 +29,23 @@ import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
 import com.netflix.spinnaker.kork.secrets.SecretEngine;
 import com.netflix.spinnaker.kork.secrets.SecretException;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GoogleSecretsManagerSecretEngine implements SecretEngine {
-  protected static final String PROJECT_NUMBER = "p";
-  protected static final String SECRET_ID = "s";
-  protected static final String SECRET_KEY = "k";
-  protected static final String VERSION_ID = "v";
-  protected static final String LATEST = "latest";
+  private static final String PROJECT_NUMBER = "p";
+  private static final String SECRET_ID = "s";
+  private static final String SECRET_KEY = "k";
+  private static final String VERSION_ID = "v";
+  private static final String LATEST = "latest";
 
   private static final String IDENTIFIER = "google-secrets-manager";
 
-  private final Map<String, Map<String, String>> cache = new HashMap<>();
+  private final Map<String, Map<String, String>> cache = new ConcurrentHashMap<>();
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private static SecretManagerServiceClient client;

--- a/kork-secrets-gcp/src/main/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngine.java
+++ b/kork-secrets-gcp/src/main/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngine.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2022 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.secrets.engines;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
+import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
+import com.netflix.spinnaker.kork.secrets.SecretEngine;
+import com.netflix.spinnaker.kork.secrets.SecretException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GoogleSecretsManagerSecretEngine implements SecretEngine {
+  protected static final String PROJECT_NUMBER = "p";
+  protected static final String SECRET_ID = "s";
+  protected static final String SECRET_KEY = "k";
+  protected static final String VERSION_ID = "latest";
+
+  private static final String IDENTIFIER = "google-secrets-manager";
+
+  private final Map<String, Map<String, String>> cache = new HashMap<>();
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public String identifier() {
+    return GoogleSecretsManagerSecretEngine.IDENTIFIER;
+  }
+
+  @Override
+  public byte[] decrypt(EncryptedSecret encryptedSecret) {
+    String projectNumber = encryptedSecret.getParams().get(PROJECT_NUMBER);
+    String secretId = encryptedSecret.getParams().get(SECRET_ID);
+    String secretKey = encryptedSecret.getParams().get(SECRET_KEY);
+    if (encryptedSecret.isEncryptedFile()) {
+      return getSecretPayload(projectNumber, secretId).getData().toStringUtf8().getBytes();
+    } else if (secretKey != null) {
+      return getSecretPayloadString(projectNumber, secretId, secretKey);
+    } else {
+      return getSecretPayloadString(projectNumber, secretId);
+    }
+  }
+
+  @Override
+  public void validate(EncryptedSecret encryptedSecret) {
+    Set<String> paramNamesSet = encryptedSecret.getParams().keySet();
+    if (!paramNamesSet.contains(PROJECT_NUMBER)) {
+      throw new InvalidSecretFormatException(
+          "Project number parameter is missing (" + PROJECT_NUMBER + "=...)");
+    }
+    if (!paramNamesSet.contains(SECRET_ID)) {
+      throw new InvalidSecretFormatException(
+          "Secret id parameter is missing (" + SECRET_ID + "=...)");
+    }
+    if (encryptedSecret.isEncryptedFile() && paramNamesSet.contains(SECRET_KEY)) {
+      throw new InvalidSecretFormatException("Encrypted file should not specify key");
+    }
+  }
+
+  protected SecretPayload getSecretPayload(String projectNumber, String secretId) {
+    try {
+      SecretManagerServiceClient client = SecretManagerServiceClient.create();
+      SecretVersionName secretVersionName =
+          SecretVersionName.of(projectNumber, secretId, VERSION_ID);
+      AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
+      return response.getPayload();
+    } catch (IOException | ApiException e) {
+      throw new SecretException(
+          String.format(
+              "Failed to parse secret when using Google Secrets Manager to fetch: [projectNumber: %s, secretId: %s]",
+              projectNumber, secretId),
+          e);
+    }
+  }
+
+  @Override
+  public void clearCache() {
+    cache.clear();
+  }
+
+  private byte[] getSecretPayloadString(String projectNumber, String secretId, String secretKey) {
+    if (!cache.containsKey(secretId)) {
+      String secretString = getSecretPayload(projectNumber, secretId).getData().toStringUtf8();
+      try {
+        Map<String, String> map = objectMapper.readValue(secretString, Map.class);
+        cache.put(secretId, map);
+      } catch (JsonProcessingException | IllegalArgumentException e) {
+        throw new SecretException(
+            String.format(
+                "Failed to parse secret when using Google Secrets Manager to fetch: [projectNumber: %s, secretId: %s, secretKey: %s]",
+                projectNumber, secretId, secretKey),
+            e);
+      }
+    }
+    return Optional.ofNullable(cache.get(secretId).get(secretKey))
+        .orElseThrow(
+            () ->
+                new SecretException(
+                    String.format(
+                        "Specified key not found in Google Secrets Manager: [projectNumber: %s, secretId: %s, secretKey: %s]",
+                        projectNumber, secretId, secretKey)))
+        .getBytes();
+  }
+
+  private byte[] getSecretPayloadString(String projectNumber, String secretId) {
+    return getSecretPayload(projectNumber, secretId).getData().toStringUtf8().getBytes();
+  }
+}

--- a/kork-secrets-gcp/src/test/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngineTest.java
+++ b/kork-secrets-gcp/src/test/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngineTest.java
@@ -72,7 +72,7 @@ public class GoogleSecretsManagerSecretEngineTest {
             "encrypted:google-secrets-manager!p:824069899151!s:spinnaker-store!k:minioAccessKeyId");
     doReturn(minioAccessKeyId)
         .when(googleSecretsManagerSecretEngine)
-        .getSecretPayload(any(), any());
+        .getSecretPayload(any(), any(), any());
     assertArrayEquals("minioadmin".getBytes(), googleSecretsManagerSecretEngine.decrypt(kvSecret));
   }
 
@@ -82,7 +82,7 @@ public class GoogleSecretsManagerSecretEngineTest {
         EncryptedSecret.parse("encrypted:google-secrets-manager!p:824069899151!s:account-name");
     doReturn(plaintextSecretValue)
         .when(googleSecretsManagerSecretEngine)
-        .getSecretPayload(any(), any());
+        .getSecretPayload(any(), any(), any());
     assertArrayEquals(
         "my-k8s-v2-account-name".getBytes(),
         googleSecretsManagerSecretEngine.decrypt(plaintextSecret));
@@ -94,7 +94,9 @@ public class GoogleSecretsManagerSecretEngineTest {
         EncryptedSecret.parse(
             "encryptedFile:google-secrets-manager!p:824069899151!s:spinnaker-store!k:minioAccessKeyId");
     exceptionRule.expect(InvalidSecretFormatException.class);
-    doReturn(kvSecretValue).when(googleSecretsManagerSecretEngine).getSecretPayload(any(), any());
+    doReturn(kvSecretValue)
+        .when(googleSecretsManagerSecretEngine)
+        .getSecretPayload(any(), any(), any());
     googleSecretsManagerSecretEngine.validate(kvSecret);
   }
 
@@ -104,7 +106,7 @@ public class GoogleSecretsManagerSecretEngineTest {
         EncryptedSecret.parse("encryptedFile:google-secrets-manager!p:824069899151!s:certificate");
     doReturn(secretStringFileValue)
         .when(googleSecretsManagerSecretEngine)
-        .getSecretPayload(any(), any());
+        .getSecretPayload(any(), any(), any());
     assertArrayEquals(
         "-----BEGIN CERTIFICATE-----".getBytes(),
         googleSecretsManagerSecretEngine.decrypt(secretStringFile));
@@ -116,7 +118,7 @@ public class GoogleSecretsManagerSecretEngineTest {
         EncryptedSecret.parse("encryptedFile:google-secrets-manager!p:824069899151!s:certificate");
     doReturn(binarySecretValue)
         .when(googleSecretsManagerSecretEngine)
-        .getSecretPayload(any(), any());
+        .getSecretPayload(any(), any(), any());
     assertArrayEquals(
         "-----BEGIN CERTIFICATE-----".getBytes(),
         googleSecretsManagerSecretEngine.decrypt(secretBinaryFile));
@@ -129,7 +131,7 @@ public class GoogleSecretsManagerSecretEngineTest {
             "encrypted:google-secrets-manager!p:824069899151!s:spinnaker-store!k:minioAccessKeyId");
     doReturn(binarySecretValue)
         .when(googleSecretsManagerSecretEngine)
-        .getSecretPayload(any(), any());
+        .getSecretPayload(any(), any(), any());
     exceptionRule.expect(SecretException.class);
     googleSecretsManagerSecretEngine.decrypt(kvSecret);
   }
@@ -141,7 +143,7 @@ public class GoogleSecretsManagerSecretEngineTest {
             "encrypted:google-secrets-manager!j:824069899151!s:spinnaker-store!k:account-name");
     doReturn(binarySecretValue)
         .when(googleSecretsManagerSecretEngine)
-        .getSecretPayload(any(), any());
+        .getSecretPayload(any(), any(), any());
     exceptionRule.expect(SecretException.class);
     googleSecretsManagerSecretEngine.decrypt(kvSecret);
   }

--- a/kork-secrets-gcp/src/test/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngineTest.java
+++ b/kork-secrets-gcp/src/test/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngineTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2022 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.secrets.engines;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.protobuf.ByteString;
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
+import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
+import com.netflix.spinnaker.kork.secrets.SecretException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Spy;
+
+public class GoogleSecretsManagerSecretEngineTest {
+
+  @Spy
+  private GoogleSecretsManagerSecretEngine googleSecretsManagerSecretEngine =
+      new GoogleSecretsManagerSecretEngine();
+
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
+
+  private final SecretPayload minioAccessKeyId =
+      SecretPayload.newBuilder()
+          .setData(ByteString.copyFromUtf8("{\"minioAccessKeyId\":\"minioadmin\"}"))
+          .build();
+
+  private final SecretPayload binarySecretValue =
+      SecretPayload.newBuilder()
+          .setData(ByteString.copyFromUtf8("-----BEGIN CERTIFICATE-----"))
+          .build();
+
+  private final SecretPayload secretStringFileValue =
+      SecretPayload.newBuilder()
+          .setData(ByteString.copyFromUtf8("-----BEGIN CERTIFICATE-----"))
+          .build();
+
+  private final SecretPayload kvSecretValue =
+      SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("minioadmin")).build();
+
+  private final SecretPayload plaintextSecretValue =
+      SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("my-k8s-v2-account-name")).build();
+
+  @Before
+  public void setup() {
+    initMocks(this);
+  }
+
+  @Test
+  public void decryptStringWithKey() {
+    EncryptedSecret kvSecret =
+        EncryptedSecret.parse(
+            "encrypted:google-secrets-manager!p:824069899151!s:spinnaker-store!k:minioAccessKeyId");
+    doReturn(minioAccessKeyId)
+        .when(googleSecretsManagerSecretEngine)
+        .getSecretPayload(any(), any());
+    assertArrayEquals("minioadmin".getBytes(), googleSecretsManagerSecretEngine.decrypt(kvSecret));
+  }
+
+  @Test
+  public void decryptStringWithoutKey() {
+    EncryptedSecret plaintextSecret =
+        EncryptedSecret.parse("encrypted:google-secrets-manager!p:824069899151!s:account-name");
+    doReturn(plaintextSecretValue)
+        .when(googleSecretsManagerSecretEngine)
+        .getSecretPayload(any(), any());
+    assertArrayEquals(
+        "my-k8s-v2-account-name".getBytes(),
+        googleSecretsManagerSecretEngine.decrypt(plaintextSecret));
+  }
+
+  @Test
+  public void decryptFileWithKey() {
+    EncryptedSecret kvSecret =
+        EncryptedSecret.parse(
+            "encryptedFile:google-secrets-manager!p:824069899151!s:spinnaker-store!k:minioAccessKeyId");
+    exceptionRule.expect(InvalidSecretFormatException.class);
+    doReturn(kvSecretValue).when(googleSecretsManagerSecretEngine).getSecretPayload(any(), any());
+    googleSecretsManagerSecretEngine.validate(kvSecret);
+  }
+
+  @Test
+  public void decryptSecretStringAsFile() {
+    EncryptedSecret secretStringFile =
+        EncryptedSecret.parse("encryptedFile:google-secrets-manager!p:824069899151!s:certificate");
+    doReturn(secretStringFileValue)
+        .when(googleSecretsManagerSecretEngine)
+        .getSecretPayload(any(), any());
+    assertArrayEquals(
+        "-----BEGIN CERTIFICATE-----".getBytes(),
+        googleSecretsManagerSecretEngine.decrypt(secretStringFile));
+  }
+
+  @Test
+  public void decryptSecretBinaryAsFile() {
+    EncryptedSecret secretBinaryFile =
+        EncryptedSecret.parse("encryptedFile:google-secrets-manager!p:824069899151!s:certificate");
+    doReturn(binarySecretValue)
+        .when(googleSecretsManagerSecretEngine)
+        .getSecretPayload(any(), any());
+    assertArrayEquals(
+        "-----BEGIN CERTIFICATE-----".getBytes(),
+        googleSecretsManagerSecretEngine.decrypt(secretBinaryFile));
+  }
+
+  @Test
+  public void decryptStringWithBinaryResult() {
+    EncryptedSecret kvSecret =
+        EncryptedSecret.parse(
+            "encrypted:google-secrets-manager!p:824069899151!s:spinnaker-store!k:minioAccessKeyId");
+    doReturn(binarySecretValue)
+        .when(googleSecretsManagerSecretEngine)
+        .getSecretPayload(any(), any());
+    exceptionRule.expect(SecretException.class);
+    googleSecretsManagerSecretEngine.decrypt(kvSecret);
+  }
+
+  @Test
+  public void decryptStringWithInvalidParam() {
+    EncryptedSecret kvSecret =
+        EncryptedSecret.parse(
+            "encrypted:google-secrets-manager!j:824069899151!s:spinnaker-store!k:account-name");
+    doReturn(binarySecretValue)
+        .when(googleSecretsManagerSecretEngine)
+        .getSecretPayload(any(), any());
+    exceptionRule.expect(SecretException.class);
+    googleSecretsManagerSecretEngine.decrypt(kvSecret);
+  }
+}

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -10,6 +10,7 @@ ext {
     aws              : "1.12.135",
     bouncycastle     : "1.64", // 1.64 removes CVE-2019-17359
     brave            : "5.12.3",
+    gcp              : "24.3.0",
     groovy           : "2.5.14", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
     jooq             : "3.13.6",
     jsch             : "0.1.54",
@@ -59,6 +60,8 @@ dependencies {
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
+  api(platform("com.google.cloud:libraries-bom:${versions.gcp}"))
+  api(platform("com.google.cloud:google-cloud-secretmanager:2.1.1"))
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
   api(platform("io.strikt:strikt-bom:0.31.0"))
   api(platform("org.spockframework:spock-bom:1.3-groovy-2.5"))

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -10,7 +10,7 @@ ext {
     aws              : "1.12.135",
     bouncycastle     : "1.64", // 1.64 removes CVE-2019-17359
     brave            : "5.12.3",
-    gcp              : "24.3.0",
+    gcp              : "25.3.0",
     groovy           : "2.5.14", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
     jooq             : "3.13.6",
     jsch             : "0.1.54",


### PR DESCRIPTION
This PR addresses the issue [#6666](https://github.com/spinnaker/spinnaker/issues/6666). It's not a breaking change.

With this feature, secrets of latest version can be accessed from Google Secret Manager using one of the following patterns:

**encrypted**:google-secrets-manager!p:<PROJECT_NUMBER>!s:<SECRET_ID>!k:<SECRET_KEY>!v:<SECRET_VERSION>
**encrypted**:google-secrets-manager!p:<PROJECT_NUMBER>!s:<SECRET_ID>!v:<SECRET_VERSION>
**encryptedFile**:google-secrets-manager!p:<PROJECT_NUMBER>!s:<SECRET_ID>!v:<SECRET_VERSION> 

 v:<SECRET_VERSION> is optional and in it's absence latest secret version is fetched.
