### PR TITLE
chore(dependencies): Upgrade Spring Boot to 2.4.13

### DIFF
--- a/kork-cloud-config-server/kork-cloud-config-server.gradle
+++ b/kork-cloud-config-server/kork-cloud-config-server.gradle
@@ -9,7 +9,7 @@ dependencies {
   implementation project(':kork-secrets')
   implementation "org.springframework.cloud:spring-cloud-context"
   implementation "org.springframework.cloud:spring-cloud-config-server"
-  implementation "org.springframework.cloud:spring-cloud-aws-context:2.2.6.RELEASE"
+  implementation "io.awspring.cloud:spring-cloud-aws-context:2.3.5"
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.assertj:assertj-core"

--- a/kork-cloud-config-server/kork-cloud-config-server.gradle
+++ b/kork-cloud-config-server/kork-cloud-config-server.gradle
@@ -9,7 +9,7 @@ dependencies {
   implementation project(':kork-secrets')
   implementation "org.springframework.cloud:spring-cloud-context"
   implementation "org.springframework.cloud:spring-cloud-config-server"
-  implementation "org.springframework.cloud:spring-cloud-aws-context"
+  implementation "org.springframework.cloud:spring-cloud-aws-context:2.2.6.RELEASE"
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.assertj:assertj-core"

--- a/kork-cloud-config-server/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/SpringCloudAwsS3ResourceLoaderConfiguration.java
+++ b/kork-cloud-config-server/src/main/java/com/netflix/spinnaker/kork/configserver/autoconfig/SpringCloudAwsS3ResourceLoaderConfiguration.java
@@ -1,11 +1,11 @@
 package com.netflix.spinnaker.kork.configserver.autoconfig;
 
+import io.awspring.cloud.context.config.annotation.ContextResourceLoaderConfiguration;
+import io.awspring.cloud.context.support.io.SimpleStorageProtocolResolverConfigurer;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.cloud.aws.context.config.annotation.ContextResourceLoaderConfiguration;
-import org.springframework.cloud.aws.context.support.io.SimpleStorageProtocolResolverConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;

--- a/kork-cloud-config-server/src/main/resources/META-INF/spring.factories
+++ b/kork-cloud-config-server/src/main/resources/META-INF/spring.factories
@@ -2,6 +2,6 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   com.netflix.spinnaker.kork.configserver.autoconfig.CloudConfigAutoConfiguration, \
   com.netflix.spinnaker.kork.configserver.autoconfig.SpringCloudAwsConfiguration, \
   com.netflix.spinnaker.kork.configserver.autoconfig.SpringCloudAwsS3ResourceLoaderConfiguration, \
-  org.springframework.cloud.aws.context.config.annotation.ContextResourceLoaderConfiguration
+  io.awspring.cloud.context.config.annotation.ContextResourceLoaderConfiguration
 org.springframework.context.ApplicationListener=\
   com.netflix.spinnaker.kork.configserver.CloudConfigApplicationListener

--- a/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaAutoConfiguration.java
+++ b/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaAutoConfiguration.java
@@ -27,8 +27,8 @@ import com.netflix.spinnaker.kork.discovery.DiscoveryAutoConfiguration;
 import java.util.Map;
 import java.util.Objects;
 import javax.inject.Provider;
-import org.springframework.boot.actuate.health.HealthAggregator;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.StatusAggregator;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -104,9 +104,9 @@ public class EurekaAutoConfiguration {
   @Bean
   HealthCheckHandler healthCheckHandler(
       ApplicationInfoManager applicationInfoManager,
-      HealthAggregator healthAggregator,
+      StatusAggregator statusAggregator,
       Map<String, HealthIndicator> healthIndicators) {
-    return new BootHealthCheckHandler(applicationInfoManager, healthAggregator, healthIndicators);
+    return new BootHealthCheckHandler(applicationInfoManager, statusAggregator, healthIndicators);
   }
 
   private static class StaticProvider<T> implements Provider<T> {

--- a/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolver.kt
+++ b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolver.kt
@@ -129,6 +129,7 @@ class SpringEnvironmentConfigResolver(
     propertyNames
       .filter { it.startsWith("spinnaker.extensibility") }
       .map { it to getProperty(it) }
+      .filter{ (_,value)-> if (value is Map<*, *>) value.isNotEmpty() else true }
       .toMap()
 
   private inner class SystemConfigException(message: String) : SystemException(message)

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -173,13 +173,13 @@ class DefaultSqlConfiguration {
     }
 
   @Suppress("UndocumentedPublicFunction")
-  @Bean(destroyMethod = "close")
+  @Bean(destroyMethod = "")
   @ConditionalOnMissingBean(DSLContext::class)
   fun jooq(jooqConfiguration: DefaultConfiguration): DSLContext =
     DefaultDSLContext(jooqConfiguration)
 
   @Suppress("UndocumentedPublicFunction")
-  @Bean(destroyMethod = "close")
+  @Bean(destroyMethod = "")
   @Conditional(SecondaryPoolDialectCondition::class)
   fun secondaryJooq(
     connectionProvider: DataSourceConnectionProvider,

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -24,8 +24,8 @@ ext {
     spectator        : "1.0.6",
     spek             : "1.1.5",
     spek2            : "2.0.9",
-    springBoot       : "2.3.12.RELEASE",
-    springCloud      : "Hoxton.SR12",
+    springBoot       : "2.4.13",
+    springCloud      : "2020.0.5",
     springfoxSwagger : "2.9.2",
     swagger          : "1.5.20", //this should stay in sync with what springfoxSwagger expects
     // tomcat (v9.0.31) was included via spring boot and upgrading spring boot


### PR DESCRIPTION
Upgraded following dependencies along with spring boot to 2.4.13
springCloud : 2020.0.5

While building kork with upgrade, faced errors like:
`
> Task :kork-eureka:compileJava FAILED
/home/opsmx/spinnakerforkcodebase/kork/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaAutoConfiguration.java:30: error: cannot find symbol
import org.springframework.boot.actuate.health.HealthAggregator;
                                              ^
  symbol:   class HealthAggregator
  location: package org.springframework.boot.actuate.health
/home/opsmx/spinnakerforkcodebase/kork/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaAutoConfiguration.java:107: error: cannot find symbol
      HealthAggregator healthAggregator,
      ^
  symbol:   class HealthAggregator
  location: class EurekaAutoConfiguration
/home/opsmx/spinnakerforkcodebase/kork/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/BootHealthCheckHandler.java:25: error: cannot find symbol
import org.springframework.boot.actuate.health.CompositeHealthIndicator;
                                              ^
  symbol:   class CompositeHealthIndicator
  location: package org.springframework.boot.actuate.health
/home/opsmx/spinnakerforkcodebase/kork/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/BootHealthCheckHandler.java:26: error: cannot find symbol
import org.springframework.boot.actuate.health.HealthAggregator;
                                              ^
  symbol:   class HealthAggregator
  location: package org.springframework.boot.actuate.health
/home/opsmx/spinnakerforkcodebase/kork/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/BootHealthCheckHandler.java:40: error: cannot find symbol
      HealthAggregator aggregator,
      ^
  symbol:   class HealthAggregator
  location: class BootHealthCheckHandler
5 errors
`

`
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':kork-cloud-config-server:compileJava'.
> Could not resolve all files for configuration ':kork-cloud-config-server:compileClasspath'.
   > Could not find org.springframework.cloud:spring-cloud-aws-context:.
     Required by:
         project :kork-cloud-config-server
`

While running tests kork with upgrade, faced errors like:

`
java.lang.IllegalStateException: Failed to load ApplicationContext
        at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:132)
        at org.springframework.test.context.support.DefaultTestContext.getApplicationContext(DefaultTestContext.java:124)
        at org.springframework.test.context.web.ServletTestExecutionListener.setUpRequestContextIfNecessary(ServletTestExecutionListener.java:190)
        at org.springframework.test.context.web.ServletTestExecutionListener.prepareTestInstance(ServletTestExecutionListener.java:132)
        at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:248)
        at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.createTest(SpringJUnit4ClassRunner.java:227)
        at org.springframework.test.context.junit4.SpringJUnit4ClassRunner$1.runReflectiveCall(SpringJUnit4ClassRunner.java:289)
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'jooq' defined in class path resource [com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.class]: Invalid destruction signature; nested exception is org.springframework.beans.factory.support.BeanDefinitionValidationException: Could not find a destroy method named 'close' on bean with name 'jooq'
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:665)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
        at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
        at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
        at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
        at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208)
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:944)
        at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:918)
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583)
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:771)
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:763)
        at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:438)
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:339)
        at org.springframework.boot.test.context.SpringBootContextLoader.loadContext(SpringBootContextLoader.java:123)
        at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:99)
        at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:124)
        ... 71 more
Caused by: org.springframework.beans.factory.support.BeanDefinitionValidationException: Could not find a destroy method named 'close' on bean with name 'jooq'
        at org.springframework.beans.factory.support.DisposableBeanAdapter.<init>(DisposableBeanAdapter.java:125)
        at org.springframework.beans.factory.support.AbstractBeanFactory.registerDisposableBeanIfNecessary(AbstractBeanFactory.java:1935)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:661)
        ... 86 more
`