### PR TITLE
chore(dependencies): fix CVE-2020-36518 by upgrading com.fasterxml.ja…

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -55,7 +55,7 @@ dependencies {
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
   api(platform("org.junit:junit-bom:5.6.3"))
-  api(platform("com.fasterxml.jackson:jackson-bom:2.12.6"))
+  api(platform("com.fasterxml.jackson:jackson-bom:2.12.6.20220326"))
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))


### PR DESCRIPTION
…ckson:jackson-bom to 2.12.6.20220326

see https://github.com/FasterXML/jackson-databind/issues/2816