### PR TITLE
feat(selectors): add account pattern and cloud provider selectors

### DIFF
--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByAccountServiceSelector.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByAccountServiceSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2022 JPMorgan Chase & Co
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,18 @@
 
 package com.netflix.spinnaker.kork.web.selector;
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
+import java.util.regex.Pattern;
 
-public class ByExecutionTypeServiceSelector implements ServiceSelector {
+public class ByAccountServiceSelector implements ServiceSelector {
   private final Object service;
   private final int priority;
-  private final Set<String> executionTypes;
+  private final Pattern accountPattern;
 
-  @SuppressWarnings("unchecked")
-  public ByExecutionTypeServiceSelector(
-      Object service, Integer priority, Map<String, Object> config) {
+  public ByAccountServiceSelector(Object service, Integer priority, Map<String, Object> config) {
     this.service = service;
     this.priority = priority;
-    this.executionTypes =
-        new HashSet<>(((Map<String, String>) config.get("executionTypes")).values());
+    this.accountPattern = Pattern.compile((String) config.get("accountPattern"));
   }
 
   @Override
@@ -46,6 +42,10 @@ public class ByExecutionTypeServiceSelector implements ServiceSelector {
 
   @Override
   public boolean supports(SelectableService.Criteria criteria) {
-    return executionTypes.contains(criteria.getExecutionType());
+    if (criteria.getAccount() == null) {
+      return false;
+    }
+
+    return accountPattern.matcher(criteria.getAccount().toLowerCase()).matches();
   }
 }

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByAuthenticatedUserServiceSelector.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByAuthenticatedUserServiceSelector.java
@@ -28,12 +28,13 @@ public class ByAuthenticatedUserServiceSelector implements ServiceSelector {
   private final int priority;
   private final List<Pattern> userPatterns;
 
+  @SuppressWarnings("unchecked")
   public ByAuthenticatedUserServiceSelector(
       Object service, Integer priority, Map<String, Object> config) {
     this.service = service;
     this.priority = priority;
 
-    Collection<String> users = new HashSet(((Map<String, String>) config.get("users")).values());
+    Collection<String> users = new HashSet<>(((Map<String, String>) config.get("users")).values());
     this.userPatterns = users.stream().map(Pattern::compile).collect(Collectors.toList());
   }
 

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByCloudProviderServiceSelector.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByCloudProviderServiceSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2022 JPMorgan Chase & Co
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -20,18 +20,18 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class ByExecutionTypeServiceSelector implements ServiceSelector {
+public class ByCloudProviderServiceSelector implements ServiceSelector {
   private final Object service;
   private final int priority;
-  private final Set<String> executionTypes;
+  private final Set<String> cloudProviders;
 
   @SuppressWarnings("unchecked")
-  public ByExecutionTypeServiceSelector(
+  public ByCloudProviderServiceSelector(
       Object service, Integer priority, Map<String, Object> config) {
     this.service = service;
     this.priority = priority;
-    this.executionTypes =
-        new HashSet<>(((Map<String, String>) config.get("executionTypes")).values());
+    this.cloudProviders =
+        new HashSet<>(((Map<String, String>) config.get("cloudProviders")).values());
   }
 
   @Override
@@ -46,6 +46,6 @@ public class ByExecutionTypeServiceSelector implements ServiceSelector {
 
   @Override
   public boolean supports(SelectableService.Criteria criteria) {
-    return executionTypes.contains(criteria.getExecutionType());
+    return cloudProviders.contains(criteria.getCloudProvider());
   }
 }

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByLocationServiceSelector.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByLocationServiceSelector.java
@@ -25,10 +25,11 @@ public class ByLocationServiceSelector implements ServiceSelector {
   private final Object service;
   private final Set<String> locations;
 
+  @SuppressWarnings("unchecked")
   public ByLocationServiceSelector(Object service, Integer priority, Map<String, Object> config) {
     this.service = service;
     this.priority = priority;
-    this.locations = new HashSet(((Map<String, String>) config.get("locations")).values());
+    this.locations = new HashSet<>(((Map<String, String>) config.get("locations")).values());
   }
 
   @Override

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByOriginServiceSelector.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByOriginServiceSelector.java
@@ -27,13 +27,14 @@ public class ByOriginServiceSelector implements ServiceSelector {
   private final String origin;
   private final Set<String> executionTypes;
 
+  @SuppressWarnings("unchecked")
   public ByOriginServiceSelector(Object service, Integer priority, Map<String, Object> config) {
     this.service = service;
     this.priority = priority;
     this.origin = (String) config.get("origin");
 
     if (config.containsKey("executionTypes")) {
-      executionTypes = new HashSet(((Map<String, String>) config.get("executionTypes")).values());
+      executionTypes = new HashSet<>(((Map<String, String>) config.get("executionTypes")).values());
     } else {
       executionTypes = new HashSet<>(Arrays.asList("pipeline", "orchestration"));
     }

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/SelectableService.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/SelectableService.java
@@ -27,23 +27,28 @@ public class SelectableService<T> {
   }
 
   public T getService(Criteria criteria) {
-    Assert.notNull(criteria);
+    Assert.notNull(criteria, "Criteria is required to select a service");
 
     return serviceSelectors.stream()
         .filter(it -> it.supports(criteria))
-        .sorted((a, b) -> b.getPriority() - a.getPriority())
-        .findFirst()
+        .min((a, b) -> b.getPriority() - a.getPriority())
         .map(ServiceSelector::getService)
         .orElse(serviceSelectors.get(0).getService());
   }
 
   public static class Criteria {
+    private String account;
     private String application;
     private String authenticatedUser;
+    private String cloudProvider;
     private String executionType;
     private String executionId;
     private String origin;
     private String location;
+
+    public String getAccount() {
+      return account;
+    }
 
     public String getApplication() {
       return application;
@@ -51,6 +56,10 @@ public class SelectableService<T> {
 
     public String getAuthenticatedUser() {
       return authenticatedUser;
+    }
+
+    public String getCloudProvider() {
+      return cloudProvider;
     }
 
     public String getExecutionType() {
@@ -69,6 +78,11 @@ public class SelectableService<T> {
       return location;
     }
 
+    public Criteria withAccount(String account) {
+      this.account = account;
+      return this;
+    }
+
     public Criteria withApplication(String application) {
       this.application = application;
       return this;
@@ -76,6 +90,11 @@ public class SelectableService<T> {
 
     public Criteria withAuthenticatedUser(String user) {
       this.authenticatedUser = user;
+      return this;
+    }
+
+    public Criteria withCloudProvider(String cloudProvider) {
+      this.cloudProvider = cloudProvider;
       return this;
     }
 

--- a/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/selector/SelectableServiceSpec.groovy
+++ b/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/selector/SelectableServiceSpec.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.kork.web.selector
 
 import spock.lang.Shared
 import spock.lang.Specification
-import spock.lang.Unroll;
+import spock.lang.Unroll
 
 class SelectableServiceSpec extends Specification {
   @Shared
@@ -37,11 +37,13 @@ class SelectableServiceSpec extends Specification {
   def bakeryService = "bakery"
 
   @Unroll
-  def "should lookup service by application or executionType"() {
+  def "should lookup service by configured criteria"() {
     given:
     def selectableService = new SelectableService(
       [
+        new ByAccountServiceSelector(oortService, 10, ["accountPattern": ".*internal.*"]),
         new ByApplicationServiceSelector(mortService, 10, ["applicationPattern": ".*spindemo.*"]),
+        new ByCloudProviderServiceSelector(oortService, 10, ["cloudProviders": [0: "kubernetes"]]),
         new ByExecutionTypeServiceSelector(oortService, 5, ["executionTypes": [0: "orchestration"]]),
         new ByOriginServiceSelector(instanceService, 20, ["origin": "deck", "executionTypes": [0: "orchestration"]]),
         new ByAuthenticatedUserServiceSelector(bakeryService, 25, ["users": [0: "user1@email.com", 1: ".*user2.*"]]),
@@ -70,6 +72,8 @@ class SelectableServiceSpec extends Specification {
     [application: "spintest", executionType: "orchestration", origin: "api", authenticatedUser: "user1@email.com"]       || bakeryService    // user selector is highest priority
     [application: "spintest", executionType: "orchestration", origin: "api", authenticatedUser: "user2@random.com"]      || bakeryService    // user selector is highest priority
     [location: "us-east-1"]                                                                                              || bakeryService    // selects by location
+    [account: "kubernetes-internal-2"]                                                                                   || oortService      // selects by account pattern
+    [cloudProvider: "kubernetes"]                                                                                        || oortService      // selects by cloud provider
   }
 
   def "should default to all execution types if none configured (by origin selector)"() {
@@ -79,8 +83,10 @@ class SelectableServiceSpec extends Specification {
 
   private static SelectableService.Criteria criteriaWithParams(Map<String, String> params) {
     return new SelectableService.Criteria()
+      .withAccount(params.account)
       .withApplication(params.application)
       .withAuthenticatedUser(params.authenticatedUser)
+      .withCloudProvider(params.cloudProvider)
       .withOrigin(params.origin)
       .withExecutionType(params.executionType)
       .withExecutionId(params.executionId)


### PR DESCRIPTION
Adds ServiceSelector implementations for selecting services by an account name pattern or cloud provider.

https://github.com/spinnaker/spinnaker/issues/6651