### PR TITLE
feat(tuning): Bump up default sizes

### DIFF
--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/ConnectionPoolProperties.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/ConnectionPoolProperties.kt
@@ -45,7 +45,7 @@ data class ConnectionPoolProperties(
   var connectionTimeoutMs: Long = TimeUnit.SECONDS.toMillis(5),
   var validationTimeoutMs: Long = TimeUnit.SECONDS.toMillis(5),
   var idleTimeoutMs: Long = TimeUnit.MINUTES.toMillis(3),
-  var maxLifetimeMs: Long = TimeUnit.SECONDS.toMillis(300),
+  var maxLifetimeMs: Long = TimeUnit.MINUTES.toMillis(5),
   var minIdle: Int = 5,
   var maxPoolSize: Int = 100,
   var default: Boolean = false,

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/ConnectionPoolProperties.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/ConnectionPoolProperties.kt
@@ -44,10 +44,10 @@ data class ConnectionPoolProperties(
   var password: String? = null,
   var connectionTimeoutMs: Long = TimeUnit.SECONDS.toMillis(5),
   var validationTimeoutMs: Long = TimeUnit.SECONDS.toMillis(5),
-  var idleTimeoutMs: Long = TimeUnit.MINUTES.toMillis(1),
-  var maxLifetimeMs: Long = TimeUnit.SECONDS.toMillis(30),
+  var idleTimeoutMs: Long = TimeUnit.MINUTES.toMillis(3),
+  var maxLifetimeMs: Long = TimeUnit.SECONDS.toMillis(300),
   var minIdle: Int = 5,
-  var maxPoolSize: Int = 20,
+  var maxPoolSize: Int = 100,
   var default: Boolean = false,
   var registerMBeans: Boolean = false
 )

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
@@ -25,10 +25,10 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty
 @Canonical
 @ConfigurationProperties(prefix="ok-http-client")
 class OkHttpClientConfigurationProperties {
-  long connectTimeoutMs = 15000
-  long readTimeoutMs = 20000
-  int maxRequests = 64
-  int maxRequestsPerHost = 5
+  long connectTimeoutMs = 5000
+  long readTimeoutMs = 120000
+  int maxRequests = 100
+  int maxRequestsPerHost = 100
 
   boolean propagateSpinnakerHeaders = true
 
@@ -41,8 +41,8 @@ class OkHttpClientConfigurationProperties {
   String trustStorePassword = 'changeit'
 
   String secureRandomInstanceType = "NativePRNGNonBlocking"
-
-  List<String> tlsVersions = ["TLSv1.2", "TLSv1.1"]
+  // TLS1.1 isn't supported in newer JVMs... do NOT try to add back - it's also insecure
+  List<String> tlsVersions = ["TLSv1.2", "TLSv1.3"]
   //Defaults from https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
   // with some extra ciphers (non SHA384/256) to support TLSv1.1 and some non EC ciphers
   List<String> cipherSuites = [
@@ -57,9 +57,7 @@ class OkHttpClientConfigurationProperties {
     "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
     "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
     "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
-    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"
+    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
   ]
 
   /**
@@ -71,7 +69,7 @@ class OkHttpClientConfigurationProperties {
 
   @Canonical
   static class ConnectionPoolProperties {
-    int maxIdleConnections = 5
+    int maxIdleConnections = 15
     int keepAliveDurationMs = 30000
   }
 


### PR DESCRIPTION
At any kind of scale, some of these settings are rather small.  Let's look at bumping some defaults to a TOUCH more conservative levels.  At least in ways that should NOT be 'negative" impact wise.  These are "max" vs. "min".  Open to discussion as well on the above!

ALSO tweaking certain other defaults including:
* Default disable TLS1.1 please!
* Default JDBC pool settings tuned a bit
* Default http request limits... since most services do calls to things like http://spin-clouddriver/ these are INSANELY small.  Let's fix!