### PR TITLE
chore(dependencies): use version 4.13.0 of liquibase to address CVE-2022-0839

### DIFF
--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlMigrationProperties.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlMigrationProperties.kt
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.kork.sql.config
 
+import liquibase.GlobalConfiguration
+
 /**
  * Defines the configuration properties for connecting to a SQL database for schema migration purposes.
  *
@@ -23,11 +25,13 @@ package com.netflix.spinnaker.kork.sql.config
  * @param password The password to authenticate the [user]
  * @param driver The JDBC driver name
  * @param additionalChangeLogs A list of additional change log paths. This is useful for libraries and extensions.
+ * @param duplicateFileMode How to handle multiple files being found in the search path that have duplicate paths.
  */
 data class SqlMigrationProperties(
   var jdbcUrl: String? = null,
   var user: String? = null,
   var password: String? = null,
   var driver: String? = null,
-  var additionalChangeLogs: List<String> = mutableListOf()
+  var additionalChangeLogs: List<String> = mutableListOf(),
+  var duplicateFileMode: GlobalConfiguration.DuplicateFileMode = GlobalConfiguration.DUPLICATE_FILE_MODE.defaultValue
 )

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt
@@ -16,6 +16,8 @@
 package com.netflix.spinnaker.kork.sql.migration
 
 import com.netflix.spinnaker.kork.sql.config.SqlMigrationProperties
+import liquibase.GlobalConfiguration
+import liquibase.Scope
 import javax.sql.DataSource
 import liquibase.integration.spring.SpringLiquibase
 import org.springframework.jdbc.datasource.SingleConnectionDataSource
@@ -52,6 +54,7 @@ class SpringLiquibaseProxy(
     super.afterPropertiesSet()
 
     // Then if anything else has been defined, do that afterwards
+    Scope.child(GlobalConfiguration.DUPLICATE_FILE_MODE.getKey(), sqlMigrationProperties.duplicateFileMode) {
     (sqlMigrationProperties.additionalChangeLogs + korkAdditionalChangelogs)
       .map {
         SpringLiquibase().apply {
@@ -64,6 +67,7 @@ class SpringLiquibaseProxy(
       .forEach {
         it.afterPropertiesSet()
       }
+    }
   }
 
   private fun createDataSource(): DataSource =

--- a/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt
+++ b/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt
@@ -36,6 +36,13 @@ import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 
+// Without sql.migration.duplicateFileMode=WARN, liquibase complains:
+//
+// Found 2 files with the path 'classpath:db/healthcheck.yml':
+//  - file:/src/spinnaker/kork/kork-sql/build/resources/main/db/healthcheck.yml
+//  - jar:file:/src/spinnaker/kork/kork-sql/build/libs/kork-sql.jar!/db/healthcheck.yml
+//
+// Since we know the files are identical, WARN mode is OK.
 @RunWith(SpringRunner::class)
 @SpringBootTest(
   classes = [StartupTestApp::class],
@@ -43,6 +50,7 @@ import strikt.assertions.isNotNull
     "sql.enabled=true",
     "sql.migration.jdbcUrl=jdbc:h2:mem:test",
     "sql.migration.dialect=H2",
+    "sql.migration.duplicateFileMode=WARN",
     "sql.connectionPool.jdbcUrl=jdbc:h2:mem:test",
     "sql.connectionPool.dialect=H2"
   ]

--- a/kork-sql/src/test/resources/application-test.yml
+++ b/kork-sql/src/test/resources/application-test.yml
@@ -26,10 +26,12 @@ sql:
     jdbcUrl: "jdbc:h2:mem:test"
     user:
     password:
+    duplicateFileMode: WARN
   secondaryMigration:
     jdbcUrl: "jdbc:h2:mem:test"
     user:
     password:
+    duplicateFileMode: WARN
 ---
 
 spring:
@@ -52,3 +54,4 @@ sql:
     jdbcUrl: "jdbc:h2:mem:test"
     user:
     password:
+    duplicateFileMode: WARN

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -146,7 +146,7 @@ dependencies {
     api("org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}")
     api("org.codehaus.groovy:groovy-all:${versions.groovy}")
     api("org.jetbrains:annotations:19.0.0")
-    api("org.liquibase:liquibase-core:4.13.0")
+    api("org.liquibase:liquibase-core:4.19.0")
     api("org.spekframework.spek2:spek-dsl-jvm:${versions.spek2}")
     api("org.spekframework.spek2:spek-runner-junit5:${versions.spek2}")
     api("org.jetbrains.spek:spek-api:${versions.spek}")
@@ -168,7 +168,9 @@ dependencies {
     // when we upgrade to spring boot 2.6.x.  It's safe to upgrade beyond 1.29
     // with spring boot >= 2.6.12.  See
     // https://github.com/spring-projects/spring-boot/issues/32228#issue-136185850.0.
-    api("org.yaml:snakeyaml:1.27")
+    api("org.yaml:snakeyaml:1.27") {
+      force = true // because liquibase 4.19.0 would otherwise bring in snakeyaml 1.33
+    }
     api("org.springdoc:springdoc-openapi-webmvc-core:${versions.openapi}")
     api("org.springdoc:springdoc-openapi-kotlin:${versions.openapi}")
     api("org.springframework.boot:spring-boot-configuration-processor:${versions.springBoot}")

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -146,6 +146,7 @@ dependencies {
     api("org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}")
     api("org.codehaus.groovy:groovy-all:${versions.groovy}")
     api("org.jetbrains:annotations:19.0.0")
+    api("org.liquibase:liquibase-core:4.13.0")
     api("org.spekframework.spek2:spek-dsl-jvm:${versions.spek2}")
     api("org.spekframework.spek2:spek-runner-junit5:${versions.spek2}")
     api("org.jetbrains.spek:spek-api:${versions.spek}")


### PR DESCRIPTION
introduce SqlMigrationProperty.duplicateFileMode to prevent test failures in SpringStartupTests.  See https://github.com/liquibase/liquibase/issues/2818 for background.
