### PR TITLE
test(plugins): Issue loading empty properties by kork plugin module while upgrading spring boot 2.4.x

### DIFF
--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolverTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/SpringEnvironmentConfigResolverTest.kt
@@ -22,6 +22,8 @@ import dev.minutest.rootContext
 import io.mockk.every
 import io.mockk.mockk
 import java.net.URL
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.core.env.ConfigurableEnvironment
 import org.springframework.core.env.MapPropertySource
 import org.springframework.core.env.MutablePropertySources
@@ -35,7 +37,14 @@ import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import strikt.assertions.isSuccess
 
+@SpringBootTest(
+  properties = ["spring.config.location=classpath:testplugin/plugin-empty-config.yml"],
+  classes = [com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentConfigResolver::class]
+)
 class SpringEnvironmentConfigResolverTest : JUnit5Minutests {
+
+  @Autowired
+  lateinit var configResolver: SpringEnvironmentConfigResolver
 
   fun tests() = rootContext<Fixture> {
     fixture {
@@ -138,6 +147,16 @@ class SpringEnvironmentConfigResolverTest : JUnit5Minutests {
             .isNotNull()
             .get { url }.isEqualTo(URL("http://localhost:9000"))
         }
+    }
+
+    test("loading repository with empty config") {
+      expectThat(
+        configResolver.resolve(
+          RepositoryConfigCoordinates(),
+          object : TypeReference<HashMap<String, PluginRepositoryProperties>>() {}
+        )
+      )
+        .isA<Map<String,String>>()
     }
   }
 

--- a/kork-plugins/src/test/resources/testplugin/plugin-empty-config.yml
+++ b/kork-plugins/src/test/resources/testplugin/plugin-empty-config.yml
@@ -1,0 +1,3 @@
+spinnaker:
+  extensibility:
+    repositories: {}


### PR DESCRIPTION
During upgrade of spring boot from 2.3.x to 2.4.x, encountered the below runtime error while running any spinnaker component (here logs are of fiat component) :

```
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `java.util.HashMap` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('{}')
 at [Source: UNKNOWN; line: -1, column: -1]
        at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:63)
        at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1588)
        at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1213)
        at com.fasterxml.jackson.databind.deser.std.StdDeserializer._deserializeFromString(StdDeserializer.java:311)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:444)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:32)
        at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
        at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4569)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2823)
        at com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentConfigResolver$resolve$4.invoke(SpringEnvironmentConfigResolver.kt:83)
        at com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentConfigResolver$resolve$4.invoke(SpringEnvironmentConfigResolver.kt:52)
        at com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentConfigResolver.resolveInternal(SpringEnvironmentConfigResolver.kt:104)
```
The root cause is processing of "{}" empty config as null map while reading properties in spring boot 2.3.x, where as in 2.4.x it is consumed as ""{}"" string.

The halyard injects spinnaker.extensibility config for plugins (as blank, if no plugin available) in each component configuration given below:
```
spinnaker:
  extensibility:
    plugins: {}
    repositories: {}
    plugins-root-path: /opt/fiat/plugins
    strict-plugin-loading: false
```

There is no test case available to detect and pass for empty config.

Adding the test case for empty plugin repository config. This test case expects to pass with spring boot 2.3.x and will fail with upgrade of spring boot 2.4.x.