### PR TITLE
fix(kork-secrets-aws): Fix default client bean configuration

### DIFF
--- a/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerConfiguration.java
+++ b/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerConfiguration.java
@@ -16,18 +16,19 @@
 
 package com.netflix.spinnaker.kork.secrets.engines;
 
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import java.util.Map;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-@Component
-@ConditionalOnMissingBean(SecretsManagerClientProvider.class)
-public class DefaultSecretsManagerClientProvider implements SecretsManagerClientProvider {
-  @Override
-  public AWSSecretsManager getClientForSecretParameters(Map<String, String> parameters) {
-    String region = parameters.get(SecretsManagerSecretEngine.SECRET_REGION);
-    return AWSSecretsManagerClientBuilder.standard().withRegion(region).build();
+@Configuration
+public class SecretsManagerConfiguration {
+  @ConditionalOnMissingBean
+  @Bean
+  public SecretsManagerClientProvider secretsManagerClientProvider() {
+    return parameters ->
+        AWSSecretsManagerClientBuilder.standard()
+            .withRegion(parameters.get(SecretsManagerSecretEngine.SECRET_REGION))
+            .build();
   }
 }

--- a/kork-secrets-aws/src/test/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerConfigurationTest.java
+++ b/kork-secrets-aws/src/test/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerConfigurationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets.engines;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.netflix.spinnaker.kork.secrets.SecretConfiguration;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = SecretConfiguration.class)
+@RequiredArgsConstructor
+class SecretsManagerConfigurationTest {
+  @Autowired SecretsManagerSecretEngine engine;
+
+  @Test
+  void contextLoads() {
+    assertNotNull(engine);
+  }
+}


### PR DESCRIPTION
This fixes a problem with the default configuration when used in other services.