### PR TITLE
Add some missing credentials and secrets APIs

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/JsonTypeNameParser.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/JsonTypeNameParser.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.jackson;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Parses {@link JsonTypeName} annotations on classes to determine the type discriminator used in
+ * {@link ObjectMapperSubtypeConfigurer}.
+ */
+@Log4j2
+@RequiredArgsConstructor
+public class JsonTypeNameParser implements NamedTypeParser {
+  private final boolean strictSerialization;
+
+  @Nullable
+  @Override
+  public NamedType parse(@Nonnull Class<?> type) {
+    JsonTypeName nameAnnotation = type.getAnnotation(JsonTypeName.class);
+    if (nameAnnotation == null || "".equals(nameAnnotation.value())) {
+      String message =
+          "Subtype " + type.getSimpleName() + " does not have a JsonTypeName annotation";
+      if (strictSerialization) {
+        throw new InvalidSubtypeConfigurationException(message);
+      }
+      log.warn(message);
+      return null;
+    }
+
+    return new NamedType(type, nameAnnotation.value());
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/NamedTypeParser.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/NamedTypeParser.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.jackson;
+
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Parses a class to determine its type discriminator. */
+public interface NamedTypeParser {
+
+  /**
+   * Parses the given class and returns a NamedType if a type discriminator can be found or null
+   * otherwise.
+   */
+  @Nullable
+  NamedType parse(@Nonnull Class<?> type);
+}

--- a/kork-core/src/test/java/com/netflix/spinnaker/kork/jackson/NamedTypeParserTest.java
+++ b/kork-core/src/test/java/com/netflix/spinnaker/kork/jackson/NamedTypeParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.jackson;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class NamedTypeParserTest {
+  @Test
+  void customNamedTypeDiscriminator() throws JsonProcessingException {
+    var mapper = new ObjectMapper();
+    NamedTypeParser parser =
+        type ->
+            Optional.ofNullable(type.getAnnotation(TypeDiscriminator.class))
+                .map(TypeDiscriminator::value)
+                .map(name -> new NamedType(type, name))
+                .orElse(null);
+
+    new ObjectMapperSubtypeConfigurer(parser)
+        .registerSubtype(
+            mapper,
+            new ObjectMapperSubtypeConfigurer.ClassSubtypeLocator(
+                UncleType.class, List.of("com.netflix.spinnaker.kork.jackson")));
+
+    assertEquals("{\"kind\":\"niece\"}", mapper.writeValueAsString(new NieceType()));
+  }
+}
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@interface TypeDiscriminator {
+  String value();
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+abstract class UncleType {}
+
+@TypeDiscriminator("niece")
+class NieceType extends UncleType {}

--- a/kork-credentials-api/kork-credentials-api.gradle
+++ b/kork-credentials-api/kork-credentials-api.gradle
@@ -31,6 +31,8 @@ dependencies {
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
+  testImplementation project(":kork-core")
+  testImplementation "com.fasterxml.jackson.core:jackson-databind"
 }
 
 test {

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsType.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.kork.annotations.Beta;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a {@link CredentialsDefinition} implementation class to indicate its type discriminator
+ * when serialization and deserializing credentials definitions.
+ */
+@Beta
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CredentialsType {
+  /** The type discriminator to use for the annotated class. */
+  String value();
+}

--- a/kork-credentials-api/src/test/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionMixin.java
+++ b/kork-credentials-api/src/test/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionMixin.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+interface CredentialsDefinitionMixin {}

--- a/kork-credentials-api/src/test/java/com/netflix/spinnaker/credentials/definition/CredentialsTypeTest.java
+++ b/kork-credentials-api/src/test/java/com/netflix/spinnaker/credentials/definition/CredentialsTypeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.netflix.spinnaker.kork.jackson.NamedTypeParser;
+import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class CredentialsTypeTest {
+  @Test
+  void typeDiscriminatorUsage() throws JsonProcessingException {
+    var mapper = new ObjectMapper();
+    mapper.addMixIn(CredentialsDefinition.class, CredentialsDefinitionMixin.class);
+    new ObjectMapperSubtypeConfigurer(new CredentialsTypeParser())
+        .registerSubtype(
+            mapper,
+            new ObjectMapperSubtypeConfigurer.ClassSubtypeLocator(
+                CredentialsDefinition.class, List.of(getClass().getPackageName())));
+
+    CredentialsDefinition definition =
+        mapper.readValue("{\"type\":\"test\",\"name\":\"success\"}", CredentialsDefinition.class);
+    assertThat(definition).isInstanceOf(TestCredentialsDefinition.class);
+    assertThat(definition.getName()).isEqualTo("success");
+  }
+
+  static class CredentialsTypeParser implements NamedTypeParser {
+    @Nullable
+    @Override
+    public NamedType parse(@Nonnull Class<?> type) {
+      CredentialsType annotation = type.getAnnotation(CredentialsType.class);
+      if (annotation == null || annotation.value().isEmpty()) {
+        return null;
+      }
+      return new NamedType(type, annotation.value());
+    }
+  }
+}

--- a/kork-credentials-api/src/test/java/com/netflix/spinnaker/credentials/definition/TestCredentialsDefinition.java
+++ b/kork-credentials-api/src/test/java/com/netflix/spinnaker/credentials/definition/TestCredentialsDefinition.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@CredentialsType("test")
+@Value
+@Builder
+@Jacksonized
+public class TestCredentialsDefinition implements CredentialsDefinition {
+  String name;
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/EncryptedSecret.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/EncryptedSecret.java
@@ -24,6 +24,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * EncryptedSecrets contain an engineIdentifier and named parameters. EncryptedSecrets can be used
@@ -40,6 +41,7 @@ import lombok.Setter;
  */
 @EqualsAndHashCode
 @NoArgsConstructor
+@Log4j2
 public class EncryptedSecret {
 
   public static final String ENCRYPTED_STRING_PREFIX = "encrypted:";
@@ -81,6 +83,7 @@ public class EncryptedSecret {
     try {
       return Optional.of(new EncryptedSecret((String) value));
     } catch (InvalidSecretFormatException e) {
+      log.warn("Tried to parse invalid encrypted secret URI '{}'", value, e);
       return Optional.empty();
     }
   }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/EncryptedSecret.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/EncryptedSecret.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.kork.secrets;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -66,6 +68,21 @@ public class EncryptedSecret {
       return new EncryptedSecret(secretConfig);
     }
     return null;
+  }
+
+  /**
+   * Tries to parse the provided value as an EncryptedSecret if possible or returns an empty
+   * Optional otherwise.
+   */
+  public static Optional<EncryptedSecret> tryParse(@Nullable Object value) {
+    if (!(value instanceof String && isEncryptedSecret((String) value))) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(new EncryptedSecret((String) value));
+    } catch (InvalidSecretFormatException e) {
+      return Optional.empty();
+    }
   }
 
   protected void update(String secretConfig) {

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManager.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManager.java
@@ -17,9 +17,11 @@
 package com.netflix.spinnaker.kork.secrets.user;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
 import com.netflix.spinnaker.kork.secrets.SecretEngine;
 import com.netflix.spinnaker.kork.secrets.SecretEngineRegistry;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -49,5 +51,33 @@ public class UserSecretManager {
     }
     engine.validate(reference);
     return engine.decrypt(reference);
+  }
+
+  /**
+   * Fetches and decrypts the given parsed external secret reference encoded as bytes. External
+   * secrets are secrets available through {@link EncryptedSecret} URIs.
+   *
+   * @param reference parsed external secret reference to fetch
+   * @return the decrypted external secret
+   */
+  public byte[] getExternalSecret(EncryptedSecret reference) {
+    String engineIdentifier = reference.getEngineIdentifier();
+    SecretEngine engine = registry.getEngine(engineIdentifier);
+    if (engine == null) {
+      throw new SecretDecryptionException("Unknown secret engine identifier: " + engineIdentifier);
+    }
+    engine.validate(reference);
+    return engine.decrypt(reference);
+  }
+
+  /**
+   * Fetches and decrypts the given parsed external secret reference encoded as a string. External
+   * secrets are secrets available through {@link EncryptedSecret} URIs.
+   *
+   * @param reference parsed external secret reference to fetch
+   * @return the decrypted external secret string
+   */
+  public String getExternalSecretString(EncryptedSecret reference) {
+    return new String(getExternalSecret(reference), StandardCharsets.UTF_8);
   }
 }

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/EncryptedSecretTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/EncryptedSecretTest.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.kork.secrets;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,6 +58,8 @@ public class EncryptedSecretTest {
     String secretConfig = "encrypted:s3!first:key!second:another-valu:e!3rd:yetAnothervalue";
     EncryptedSecret encryptedSecret = EncryptedSecret.parse(secretConfig);
     assertEquals("s3", encryptedSecret.getEngineIdentifier());
+    EncryptedSecret tryEncrypted = EncryptedSecret.tryParse(secretConfig).orElseThrow();
+    assertEquals(encryptedSecret, tryEncrypted);
   }
 
   @Test
@@ -106,5 +109,10 @@ public class EncryptedSecretTest {
         "Invalid encrypted secret format, keys and values must be delimited by ':'");
     EncryptedSecret encryptedSecret = new EncryptedSecret();
     encryptedSecret.update("encrypted:s3!foobar");
+  }
+
+  @Test
+  public void tryParseReturnsEmptyOnInvalidSecretFormat() {
+    assertFalse(EncryptedSecret.tryParse("encrypted:s3!foobar").isPresent());
   }
 }

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManagerTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManagerTest.java
@@ -17,8 +17,10 @@
 package com.netflix.spinnaker.kork.secrets.user;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import com.netflix.spinnaker.kork.secrets.SecretConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,5 +48,13 @@ public class UserSecretManagerTest {
     var ref = UserSecretReference.parse("secret://noop?foo=bar");
     var userSecret = userSecretManager.getUserSecret(ref);
     assertEquals("bar", userSecret.getSecretString("foo"));
+  }
+
+  @Test
+  public void getTestExternalSecret() {
+    var ref = EncryptedSecret.parse("encrypted:noop!v:test");
+    assertNotNull(ref);
+    var secret = userSecretManager.getExternalSecretString(ref);
+    assertEquals("test", secret);
   }
 }


### PR DESCRIPTION
- `@CredentialsType` type discriminator
- External secret APIs in `UserSecretManager` (based on `EncryptedSecret` to be analogous to `UserSecret`)