### PR TITLE
fix(dependencies): remove version constraint on dependency google-auth-library-oauth2-http

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -74,7 +74,6 @@ dependencies {
     api("cglib:cglib-nodep:3.3.0")
     api("com.amazonaws:aws-java-sdk:${versions.aws}")
     api("com.google.api-client:google-api-client:1.30.10") // TODO: Track update for CVE-2020-7692, reanalysis pending.
-    api("com.google.auth:google-auth-library-oauth2-http:0.18.0")
     api("com.google.apis:google-api-services-admin-directory:directory_v1-rev105-1.25.0")
     api("com.google.apis:google-api-services-cloudbuild:v1-rev836-1.25.0")
     api("com.google.apis:google-api-services-compute:alpha-rev20200526-1.30.9")


### PR DESCRIPTION
With the implementation of secret manager (https://github.com/spinnaker/spinnaker/issues/6666), there is a need to upgrade the version of google-auth-library-oauth2-http library which was introduced as part of gcs secret engine implementation. With the removal of the this dependency constraint, GCS secret engine continue to work without any issue.