### PR TITLE
fix(expression): toJson throws an exception for valid json.

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java
@@ -194,12 +194,7 @@ public class ExpressionsSupport {
      */
     public static String toJson(Object o) {
       try {
-        String converted = mapper.writeValueAsString(o);
-        if (converted != null && converted.contains("${")) {
-          throw new SpelHelperFunctionException("result for toJson cannot contain an expression");
-        }
-
-        return converted;
+        return mapper.writeValueAsString(o);
       } catch (Exception e) {
         throw new SpelHelperFunctionException(format("#toJson(%s) failed", o.toString()), e);
       }

--- a/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupportTest.java
+++ b/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupportTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ExpressionsSupportTest {
+
+  @Test
+  public void testToJson() {
+    Map<String, Object> testInput = Collections.singletonMap("owner", "managed-by-${profile}");
+
+    String result = ExpressionsSupport.JsonExpressionFunctionProvider.toJson(testInput);
+
+    assertEquals("{\"owner\":\"managed-by-${profile}\"}", result);
+  }
+}


### PR DESCRIPTION
**What?**

`toJson` method throws an exception for valid JSON when `${}` expression is defined as a string value e.g.

```json
{
  "owner": "managed-by-${profile}"
}
```

We expect that the conversion of valid JSON will occur without any errors.