### PR TITLE
feat(spel): add doNotEval method to restrict expressions evaluation for an object

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/NotEvaluableExpression.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/NotEvaluableExpression.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions;
+
+/**
+ * An instance of this class is used as the return value from the {@code doNotEval} SpEL helper
+ * which makes it possible to skip SpEL evaluation in other SpEL helpers e.g. {@code toJson}.
+ *
+ * <p>For example, in the evaluation context is defined only {@code fileMap} object:
+ *
+ * <pre>{@code
+ * Map<String, Object> fileMap = Collections.singletonMap("owner", "managed-by-${team}");
+ * }</pre>
+ *
+ * <p>An exception will be thrown in attempt to get JSON because of {@code fileMap} contains SpEL
+ * inside.
+ *
+ * <pre>{@code
+ * ${#toJson(fileMap)}
+ * }</pre>
+ *
+ * <p>In the given case {@code fileMap} contains SpEL for another tool e.g. Terraform. Use {@code
+ * doNotEval} to let Spinnaker know that this SpEL should be evaluated by a different tool. No
+ * exceptions are thrown this way.
+ *
+ * <pre>{@code
+ * ${#toJson(#doNotEval(fileMap))}
+ * }</pre>
+ */
+public class NotEvaluableExpression {
+
+  private final Object expression;
+
+  public NotEvaluableExpression(Object expression) {
+    this.expression = expression;
+  }
+
+  public Object getExpression() {
+    return expression;
+  }
+}

--- a/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupportTest.java
+++ b/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupportTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.expressions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.ParserContext;
+import org.springframework.expression.common.TemplateParserContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+public class ExpressionsSupportTest {
+  private final ExpressionParser parser = new SpelExpressionParser();
+  private final ParserContext parserContext = new TemplateParserContext("${", "}");
+
+  @Test
+  public void testToJsonWhenExpression() {
+    Map<String, Object> testInput = Collections.singletonMap("owner", "managed-by-${team}");
+
+    assertThrows(
+        SpelHelperFunctionException.class,
+        () -> ExpressionsSupport.JsonExpressionFunctionProvider.toJson(testInput));
+  }
+
+  @Test
+  public void testToJsonWhenNotEvaluableExpression() {
+    Map<String, Object> testInput = Collections.singletonMap("owner", "managed-by-${team}");
+    NotEvaluableExpression notEvaluableExpression =
+        ExpressionsSupport.FlowExpressionFunctionProvider.doNotEval(testInput);
+
+    String result =
+        ExpressionsSupport.JsonExpressionFunctionProvider.toJson(notEvaluableExpression);
+
+    assertEquals("{\"owner\":\"managed-by-${team}\"}", result);
+  }
+
+  @Test
+  public void testToJsonWhenExpressionAndEvaluationContext() {
+    Map<String, Object> testContext =
+        Collections.singletonMap(
+            "file_json", Collections.singletonMap("owner", "managed-by-${team}"));
+    String testInput = "${#toJson(#doNotEval(file_json))}";
+
+    String evaluated =
+        new ExpressionTransform(parserContext, parser, Function.identity())
+            .transformString(
+                testInput,
+                new ExpressionsSupport(null).buildEvaluationContext(testContext, true),
+                new ExpressionEvaluationSummary());
+
+    assertThat(evaluated).isEqualTo("{\"owner\":\"managed-by-${team}\"}");
+  }
+
+  @Test
+  public void testToJsonWhenComposedExpressionAndEvaluationContext() {
+    Map<String, Object> testContext =
+        Collections.singletonMap(
+            "file_json",
+            Collections.singletonMap("json_file", "${#toJson(#doNotEval(file_json))}"));
+    String testInput = "${#toJson(#doNotEval(file_json))}";
+
+    String evaluated =
+        new ExpressionTransform(parserContext, parser, Function.identity())
+            .transformString(
+                testInput,
+                new ExpressionsSupport(null).buildEvaluationContext(testContext, true),
+                new ExpressionEvaluationSummary());
+
+    assertThat(evaluated).isEqualTo("{\"json_file\":\"${#toJson(#doNotEval(file_json))}\"}");
+  }
+}


### PR DESCRIPTION
**What?**

Spinnaker supports [the expression functions](https://github.com/spinnaker/kork/blob/a4617ed929ca34a2216449425ab5b54b5ac271d5/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java#L55) e.g. `toJson`, `toBase64`, `fromBase64` and other. At the moment, `toJson` method [throws an exception](https://github.com/spinnaker/kork/blob/a4617ed929ca34a2216449425ab5b54b5ac271d5/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java#L198-L200) for valid JSON when `${}` expression is defined as a string value

```java
String converted = mapper.writeValueAsString(o);
if (converted != null && converted.contains("${")) {
  throw new SpelHelperFunctionException("result for toJson cannot contain an expression");
}
```

We have a use case where `toJson` method needs to convert such objects without any errors:

```json
{
  "owner": "managed-by-${team}"
}
```

**Solution**:
Introduce a new SpEL `doNotEval` method that wraps incoming JSON object with `NotEvaluableExpression` class. `toJson` method (and others in the future) will not do expressions evaluation or throw any exceptions for instances of `NotEvaluableExpression` class.

**How to use?**

```
${#toJson(#doNotEval(#stage('Terraform Show').outputs.status.outputs.show.planfile_json))}
```