### PR TITLE
chore(dependencies): use tomcat 9.0.55 to match spring boot 2.4.13

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -28,12 +28,8 @@ ext {
     springCloud      : "2020.0.5",
     springfoxSwagger : "2.9.2",
     swagger          : "1.5.20", //this should stay in sync with what springfoxSwagger expects
-    // tomcat (v9.0.31) was included via spring boot and upgrading spring boot
-    // from 2.2.5.RELEASE (tomcat v9.0.31 used here) to 2.5.0 (tomcat v9.0.48)
-    // makes a few breaking changes, requires adding new dependencies, and
-    // changing code. So instead updating tomcat to v9.0.48 as a workaround
-    // until we move spring boot to at least v2.5.0.
-    tomcat           : "9.0.48"
+    // spring boot 2.4.13 brings in 9.0.55, but leave this here to simplify fixing future CVEs.
+    tomcat           : "9.0.55"
   ]
 }
 


### PR DESCRIPTION
https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.4.13/spring-boot-dependencies-2.4.13.pom