### PR TITLE
feat(build): make the modules that kork-runtime includes configurable

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ kotlinVersion=1.4.32
 org.gradle.parallel=true
 spinnakerGradleVersion=8.23.0
 targetJava11=true
+includeRuntimes=actuator,core,eureka,retrofit,secrets-aws,secrets-gcp,stackdriver,swagger,tomcat,web

--- a/kork-runtime/kork-runtime.gradle
+++ b/kork-runtime/kork-runtime.gradle
@@ -1,12 +1,6 @@
 dependencies {
-  runtimeOnly(project(":kork-actuator"))
-  runtimeOnly(project(":kork-core"))
-  runtimeOnly(project(":kork-eureka"))
-  runtimeOnly(project(":kork-retrofit"))
-  runtimeOnly(project(":kork-secrets-aws"))
-  runtimeOnly(project(":kork-secrets-gcp"))
-  runtimeOnly(project(":kork-stackdriver"))
-  runtimeOnly(project(":kork-swagger"))
-  runtimeOnly(project(":kork-tomcat"))
-  runtimeOnly(project(":kork-web"))
+  // Add each included runtime project as a runtime dependency
+  gradle.includedRuntimeProjects.each {
+    runtimeOnly project(it)
+  }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -81,3 +81,6 @@ def setBuildFile(project) {
 rootProject.children.forEach {
   setBuildFile(it)
 }
+
+// Set as an ext variable so that build scripts can access it
+gradle.ext.includedRuntimeProjects = includeRuntimes.split(',').collect{ ':kork-' + it.toLowerCase() }


### PR DESCRIPTION
To reduce code size and exposure to vulnerabilities when certain modules aren't being used.  Note that this doesn't actually change anything, but it makes it easier to do so.