### PR TITLE
fix(config): Issue with non-existing file/folder location used in Spring properties while upgrading spring boot 2.4.x.

### DIFF
--- a/kork-config/kork-config.gradle
+++ b/kork-config/kork-config.gradle
@@ -16,5 +16,8 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.mockito:mockito-core"
 
-  testRuntimeOnly "org.slf4j:slf4j-simple"
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/kork-config/src/main/java/com/netflix/spinnaker/kork/boot/DefaultPropertiesBuilder.java
+++ b/kork-config/src/main/java/com/netflix/spinnaker/kork/boot/DefaultPropertiesBuilder.java
@@ -29,7 +29,7 @@ public class DefaultPropertiesBuilder {
     defaults.put("netflix.account", "${netflix.environment}");
     defaults.put("netflix.stack", "test");
     defaults.put("spring.config.name", "spinnaker,${spring.application.name}");
-    defaults.put("spring.config.additional-location", "${user.home}/.spinnaker/");
+    defaults.put("spring.config.import", "optional:${user.home}/.spinnaker/");
     defaults.put("spring.profiles.active", "${netflix.environment},local");
     // add the Spring Cloud Config "composite" profile to default to a configuration
     // source that won't prevent app startup if custom configuration is not provided

--- a/kork-config/src/test/java/com/netflix/spinnaker/kork/boot/DefaultPropertiesBuilderTest.java
+++ b/kork-config/src/test/java/com/netflix/spinnaker/kork/boot/DefaultPropertiesBuilderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.boot;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TestApplication.class)
+class DefaultPropertiesBuilderTest {
+  @Test
+  public void testContextLoads() {
+    String dummyUserHome = "/foo/bar";
+    assertTrue(Files.notExists(Paths.get(dummyUserHome)));
+    TestApplication.execute(dummyUserHome);
+  }
+}

--- a/kork-config/src/test/java/com/netflix/spinnaker/kork/boot/TestApplication.java
+++ b/kork-config/src/test/java/com/netflix/spinnaker/kork/boot/TestApplication.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.boot;
+
+import java.util.Map;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestApplication {
+  public static final Map<String, Object> DEFAULT_PROPS =
+      new DefaultPropertiesBuilder().property("server.port", "0").build();
+
+  public static void execute(String dummyUserHome) {
+    System.setProperty("user.home", dummyUserHome);
+    SpringApplication app = new SpringApplication(TestApplication.class);
+    app.setDefaultProperties(DEFAULT_PROPS);
+    app.run();
+  }
+}


### PR DESCRIPTION
With spring boot 2.4, spring location properties will no longer fail silently if the file or folder does not exist. Now, requires prefix "optional:" for the location.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#config-file-processing-application-properties-and-yaml-files

And introducing new spring additional data importing property suggested in the links below, to be used with Spring boot 2.4:

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-Config-Data-Migration-Guide

https://docs.spring.io/spring-boot/docs/2.4.0/reference/html/spring-boot-features.html#boot-features-external-config-files-importing