### PR TITLE
feat(secrets): Add credentials masking in JSON

### DIFF
--- a/kork-credentials/kork-credentials.gradle
+++ b/kork-credentials/kork-credentials.gradle
@@ -22,6 +22,7 @@ dependencies {
   api project(":kork-annotations")
   implementation(platform(project(":spinnaker-dependencies")))
   implementation "org.springframework.boot:spring-boot"
+  implementation 'org.springframework.boot:spring-boot-starter-json'
   implementation 'javax.annotation:javax.annotation-api'
   implementation 'org.slf4j:slf4j-api'
 

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/jackson/Sensitive.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/jackson/Sensitive.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.jackson;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+import java.lang.annotation.*;
+
+/**
+ * Indicates that a field is considered sensitive and should not be serialized unless it's a secret
+ * reference. Secret references are URIs of the form {@code encrypted:...} or {@code secret://...}
+ * as documented in kork-secrets. This is useful for preventing accidental secret leakage when
+ * displaying credentials definitions or storing them.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Documented
+@JacksonAnnotation
+public @interface Sensitive {}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/jackson/SensitiveAutoConfiguration.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/jackson/SensitiveAutoConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.jackson;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Adds {@link SensitiveSerializer} as a bean automatically when this module is on the classpath.
+ */
+@Configuration
+@EnableConfigurationProperties(SensitiveProperties.class)
+@Import(SensitiveSerializer.class)
+public class SensitiveAutoConfiguration {}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/jackson/SensitiveProperties.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/jackson/SensitiveProperties.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.jackson;
+
+import java.util.regex.Pattern;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("credentials.masking")
+@Data
+public class SensitiveProperties {
+  /** Configure the pattern to use for matching likely sensitive property names. */
+  // note: `(?i)` makes the rest of the pattern case-insensitive
+  // https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html#CASE_INSENSITIVE
+  private Pattern sensitivePropertyNamePattern =
+      Pattern.compile("(?i)pass(word|phrase)|(api|access)?token|.*(private|secret|access)key.*");
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/jackson/SensitiveSerializer.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/jackson/SensitiveSerializer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import com.fasterxml.jackson.databind.ser.std.StringSerializer;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.jackson.JsonComponent;
+
+/**
+ * Sensitive string serializer for Jackson. Used to help prevent accidental leakage of sensitive
+ * secrets. Properties annotated with {@link Sensitive} or having a likely-sensitive property name
+ * inside a {@link CredentialsDefinition}-derived class will be replaced with {@code null} during
+ * serialization.
+ */
+@Log4j2
+@JsonComponent
+public class SensitiveSerializer extends StdScalarSerializer<String>
+    implements ContextualSerializer {
+
+  private final StringSerializer defaultStringSerializer = new StringSerializer();
+  private final SensitiveProperties properties;
+
+  public SensitiveSerializer(SensitiveProperties properties) {
+    super(String.class);
+    this.properties = properties;
+  }
+
+  @Override
+  public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property)
+      throws JsonMappingException {
+    if (property == null) {
+      return defaultStringSerializer;
+    }
+    Sensitive sensitive = property.getAnnotation(Sensitive.class);
+    if (sensitive != null) {
+      return this;
+    }
+    Class<?> declaringClass = property.getMember().getDeclaringClass();
+    if (CredentialsDefinition.class.isAssignableFrom(declaringClass)) {
+      String name = property.getName();
+      Matcher matcher = properties.getSensitivePropertyNamePattern().matcher(name);
+      if (matcher.matches()) {
+        log.warn(
+            "Encountered likely sensitive property name '{}.{}'. Ignoring this property for serialization.",
+            declaringClass.getName(),
+            name);
+        return this;
+      }
+    }
+    return defaultStringSerializer;
+  }
+
+  @Override
+  public void serialize(String value, JsonGenerator gen, SerializerProvider provider)
+      throws IOException {
+    if (value.startsWith("secret://")
+        || value.startsWith("encrypted:")
+        || value.startsWith("encryptedFile:")) {
+      gen.writeString(value);
+    } else {
+      gen.writeNull();
+    }
+  }
+}

--- a/kork-credentials/src/main/resources/META-INF/spring.factories
+++ b/kork-credentials/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.netflix.spinnaker.credentials.jackson.SensitiveAutoConfiguration

--- a/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/jackson/SensitiveAccount.java
+++ b/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/jackson/SensitiveAccount.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.jackson;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@CredentialsType("sensitive")
+@Value
+@Builder
+@Jacksonized
+public class SensitiveAccount implements CredentialsDefinition {
+  @Nonnull String name;
+  String username;
+  @Sensitive String password;
+  String token;
+}

--- a/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/jackson/SensitiveSerializerTest.java
+++ b/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/jackson/SensitiveSerializerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SensitiveSerializerTest {
+  private ObjectMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ObjectMapper();
+    SimpleModule module = new SimpleModule();
+    module.addSerializer(String.class, new SensitiveSerializer(new SensitiveProperties()));
+    mapper.registerModule(module);
+  }
+
+  @Test
+  void masksExplicitSensitiveFields() throws JsonProcessingException {
+    SensitiveAccount account =
+        SensitiveAccount.builder().name("alfred").username("fred").password("hunter2").build();
+    assertThat(mapper.writeValueAsString(account))
+        .contains(account.getName(), account.getUsername())
+        .doesNotContain(account.getPassword());
+  }
+
+  @Test
+  void masksImplicitSensitiveFieldsInCredentialsDefinition() throws JsonProcessingException {
+    SensitiveAccount account =
+        SensitiveAccount.builder()
+            .name("betty")
+            .username("bet")
+            .token(UUID.randomUUID().toString())
+            .build();
+    assertThat(mapper.writeValueAsString(account))
+        .contains(account.getName(), account.getUsername())
+        .doesNotContain(account.getToken());
+  }
+
+  @Test
+  void doesNotMaskSecretReferences() throws JsonProcessingException {
+    SensitiveAccount account =
+        SensitiveAccount.builder()
+            .name("charlie")
+            .username("chancery")
+            .password("secret://chest?k=gold")
+            .build();
+    assertThat(mapper.writeValueAsString(account))
+        .contains(account.getName(), account.getUsername(), account.getPassword());
+  }
+}


### PR DESCRIPTION
This adds a new `Sensitive` annotation to explicitly mark fields as sensitive. A sensitive field will not be serialized to JSON unless its value is a `secret://...` URI to avoid leaking credentials. This serializer also provides a configurable regular expression to match against `CredentialsDefinition` property names to mark them as likely sensitive which applies masking in addition to logging a warning so that the affected class can be updated.