### PR TITLE
fix(artifact/gitrepo): resolve symlink clean error

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -124,7 +124,7 @@ dependencies {
     api("com.sun.xml.bind:jaxb-impl:2.3.2")
     api("com.vdurmont:semver4j:3.1.0")
     api("commons-configuration:commons-configuration:1.8")
-    api("commons-io:commons-io:2.7")
+    api("commons-io:commons-io:2.11.0")
     // CVE's in 3.2.1
     api("commons-collections:commons-collections:[3.2.2,3.3)")
     api("de.danielbechler:java-object-diff:0.95")


### PR DESCRIPTION
Bump `commons-io` to `2.11.0` which fixed the cleaning
 directory behavior when there is symlink.
    
In version `2.7.0` the delete directory will first check
if the file exists with `Files.exists`, then issue a deleting with
`File.deleteIfExists`. However when it's a symlink, the default
behavior for `Files.exists` is to follow link, if the file/directory
the symlink pointing to has been deleted, the symlink itself will not
be deleted, this will causes error with `deleteDirectory` when there
is still symlink left in the directory.
    
In the newer version will add `NOFOLLOW_LINK` option on the `File.exists`
check, therefore it will work as expected.