### PR TITLE
chore(deps): use version 9.0.62 of tomcat to resolve CVE-2021-43980, …

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -28,8 +28,10 @@ ext {
     springCloud      : "2020.0.5",
     springfoxSwagger : "2.9.2",
     swagger          : "1.5.20", //this should stay in sync with what springfoxSwagger expects
-    // spring boot 2.4.13 brings in 9.0.55, but leave this here to simplify fixing future CVEs.
-    tomcat           : "9.0.55"
+    // spring boot 2.4.13 brings in 9.0.55.  Use 9.0.62 to resolve
+    // CVE-2021-43980, CVE-2022-23181, CVE-2022-42252.  Spring boot 2.5.14
+    // brings in 9.0.63.
+    tomcat           : "9.0.62"
   ]
 }
 


### PR DESCRIPTION
…CVE-2022-23181, CVE-2022-42252

Here's a snippet of ./gradlew kork-tomcat:dependencies before this change:
```
+--- org.springframework.boot:spring-boot-starter-tomcat:2.4.13
|    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
|    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.55
|    +--- org.glassfish:jakarta.el:3.0.4
|    \--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.55
|         \--- org.apache.tomcat.embed:tomcat-embed-core:9.0.55
+--- org.springframework:spring-web:5.3.13 (*)
```
with this change:
```
+--- org.springframework.boot:spring-boot-starter-tomcat:2.4.13
|    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
|    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.55 -> 9.0.62
|    +--- org.glassfish:jakarta.el:3.0.4
|    \--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.55 -> 9.0.62
|         \--- org.apache.tomcat.embed:tomcat-embed-core:9.0.62
```