### PR TITLE
chore(deps): use version 2.12.7.20221012 of com.fasterxml.jackson:jac…

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -54,7 +54,7 @@ dependencies {
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
   api(platform("org.junit:junit-bom:5.6.3"))
-  api(platform("com.fasterxml.jackson:jackson-bom:2.12.6.20220326"))
+  api(platform("com.fasterxml.jackson:jackson-bom:2.12.7.20221012"))
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))


### PR DESCRIPTION
…kson-bom to resolve CVE-2022-42003, CVE-2022-42004

See https://github.com/FasterXML/jackson-databind/issues/3590 and https://github.com/FasterXML/jackson-databind/issues/3582 for details.