### PR TITLE
chore(deps): specify version 1.29 of org.yaml:snakeyaml to stay partially up to date

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -157,6 +157,7 @@ dependencies {
     api("org.objenesis:objenesis:2.5.1")
     api("org.pf4j:pf4j:3.2.0")
     api("org.pf4j:pf4j-update:2.3.0")
+    api("org.yaml:snakeyaml:1.29") // safe to upgrade beyond 1.29 with spring boot >= 2.6.12.  See https://github.com/spring-projects/spring-boot/issues/32228#issue-1361858500.
     api("org.springdoc:springdoc-openapi-webmvc-core:${versions.openapi}")
     api("org.springdoc:springdoc-openapi-kotlin:${versions.openapi}")
     api("org.springframework.boot:spring-boot-configuration-processor:${versions.springBoot}")


### PR DESCRIPTION
It would be nice to jump all the way to 1.33 to get all the way up to date, and to resolve these CVEs:

CVE-2022-25857 (1.31), CVE-2022-38749 (1.31), CVE-2022-38750 (1.31), CVE-2022-38751 (1.32) and CVE-2022-38752 (1.32).

However, https://github.com/spring-projects/spring-boot/issues/32228#issue-1361858500 says to stick with 1.29 until >= 2.6.12, as [the commit that resolved that issue](https://github.com/spring-projects/spring-boot/commit/724f9ebf7107d99ac9bae4204b4f7c6444a49e03) went in to 2.6.12.

Note that spring boot 2.4.13 brings in version 1.27 (see https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.4.13/spring-boot-dependencies-2.4.13.pom).

2.5.14 brings in 1.28 (see https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.5.14/spring-boot-dependencies-2.5.14.pom)
2.6.13 brings in 1.29 (see https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.6.13/spring-boot-dependencies-2.6.13.pom)
2.7.5 brings in 1.30 (see https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.5/spring-boot-dependencies-2.7.5.pom)

Note also that snakeyaml 1.32 introduces a default 3MB limit (see https://bitbucket.org/snakeyaml/snakeyaml/pull-requests/22).  If, for example, clouddriver-local.yml is bigger than that, perhaps due to a large number of accounts,  clouddriver fails to start.