### PR TITLE
chore(dependencies): remove dependency on groovy-all in non-test configurations

### DIFF
--- a/kork-aws/kork-aws.gradle
+++ b/kork-aws/kork-aws.gradle
@@ -24,7 +24,7 @@ dependencies {
   api "com.amazonaws:aws-java-sdk-core"
   api "com.amazonaws:aws-java-sdk-sns"
   api "com.amazonaws:aws-java-sdk-sqs"
-  api "org.codehaus.groovy:groovy-all"
+  api "org.codehaus.groovy:groovy"
   api "com.hubspot.jinjava:jinjava"
   api "com.jcraft:jsch.agentproxy.jsch"
   api "com.jcraft:jsch.agentproxy.connector-factory"
@@ -39,6 +39,7 @@ dependencies {
 
   runtimeOnly "com.amazonaws:aws-java-sdk-sts"
 
+  testImplementation "org.codehaus.groovy:groovy-all"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-runner"

--- a/kork-core-tck/kork-core-tck.gradle
+++ b/kork-core-tck/kork-core-tck.gradle
@@ -7,6 +7,6 @@ dependencies {
   implementation(project(":kork-core"))
   implementation(project(":kork-exceptions"))
 
-  implementation("org.codehaus.groovy:groovy-all")
+  implementation("org.codehaus.groovy:groovy")
   implementation("org.spockframework:spock-core")
 }

--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -14,7 +14,7 @@ dependencies {
   api project(":kork-core")
   api project(":kork-security")
   api project(":kork-exceptions")
-  api "org.codehaus.groovy:groovy-all"
+  api "org.codehaus.groovy:groovy"
   api "org.springframework.boot:spring-boot-starter-web"
   api "org.springframework.boot:spring-boot-starter-security"
   api "org.springframework.security:spring-security-core"


### PR DESCRIPTION
Removing this large dependency is generally good.  The specific motivation in this case is to get `org.testng:testng:7.4.0` out of shipping code, since it's vulnerable to CVE-2022-4065.