### PR TITLE
fix & refactor(cloud-config-server): Issue with non-existing file/folder location used in spring cloud config server properties while upgrading spring boot 2.4.x.

### DIFF
--- a/kork-cloud-config-server/kork-cloud-config-server.gradle
+++ b/kork-cloud-config-server/kork-cloud-config-server.gradle
@@ -11,6 +11,7 @@ dependencies {
   implementation "org.springframework.cloud:spring-cloud-config-server"
   implementation "io.awspring.cloud:spring-cloud-aws-context:2.3.5"
 
+  testImplementation project(':kork-config')
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
@@ -18,5 +19,8 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.mockito:mockito-core"
 
-  testRuntimeOnly "org.slf4j:slf4j-simple"
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/kork-cloud-config-server/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigServerBootstrap.java
+++ b/kork-cloud-config-server/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigServerBootstrap.java
@@ -23,10 +23,11 @@ public class ConfigServerBootstrap {
     // of https://github.com/spring-cloud/spring-cloud-commons/issues/466
     defaultSystemProperty(
         "spring.cloud.bootstrap.location",
-        "classpath:/,classpath:/config/,file:./,file:./config/,/opt/spinnaker/config/,${user.home}/.spinnaker/");
+        "optional:classpath:/,optional:classpath:/config/,optional:file:./,optional:file:./config/,optional:/opt/spinnaker/config/,optional:${user.home}/.spinnaker/");
     defaultSystemProperty(
         "spring.cloud.bootstrap.name", "spinnakerconfig,${spring.application.name}config");
     defaultSystemProperty("spring.cloud.config.server.bootstrap", "true");
+    defaultSystemProperty("spring.cloud.bootstrap.enabled", "true");
   }
 
   private static void defaultSystemProperty(String key, String value) {

--- a/kork-cloud-config-server/src/test/java/com/netflix/spinnaker/kork/configserver/ConfigServerBootstrapTest.java
+++ b/kork-cloud-config-server/src/test/java/com/netflix/spinnaker/kork/configserver/ConfigServerBootstrapTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+public class ConfigServerBootstrapTest {
+  @Test
+  public void testConfigServerContextLoads() {
+    String dummyUserHome = "/foo/bar";
+    assertTrue(Files.notExists(Paths.get(dummyUserHome)));
+    ConfigServerTestApplication.execute(dummyUserHome);
+  }
+}

--- a/kork-cloud-config-server/src/test/java/com/netflix/spinnaker/kork/configserver/ConfigServerTestApplication.java
+++ b/kork-cloud-config-server/src/test/java/com/netflix/spinnaker/kork/configserver/ConfigServerTestApplication.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.configserver;
+
+import com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder;
+import java.util.Map;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+@SpringBootApplication
+@EnableConfigServer
+public class ConfigServerTestApplication {
+  public static final Map<String, Object> DEFAULT_PROPS_CLOUD =
+      new DefaultPropertiesBuilder()
+          .property("server.port", "0")
+          .build(); // For tomcat to pick randomly available port
+
+  public static void execute(String dummyUserHome) {
+    System.setProperty("user.home", dummyUserHome);
+    ConfigServerBootstrap.systemProperties("kork");
+    SpringApplication app = new SpringApplication(ConfigServerTestApplication.class);
+    app.setDefaultProperties(DEFAULT_PROPS_CLOUD);
+    app.run();
+  }
+}


### PR DESCRIPTION
With spring boot 2.4, spring cloud config server location properties will no longer fail silently if the file or folder does not exist. Now, requires prefix "optional:" for the location.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#config-file-processing-application-properties-and-yaml-files

Added testcase in support of code change to introduce "optional:" prefix for location properties.