### PR TITLE
fix(dependencies): use snakeyaml 1.27

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -157,7 +157,17 @@ dependencies {
     api("org.objenesis:objenesis:2.5.1")
     api("org.pf4j:pf4j:3.2.0")
     api("org.pf4j:pf4j-update:2.3.0")
-    api("org.yaml:snakeyaml:1.29") // safe to upgrade beyond 1.29 with spring boot >= 2.6.12.  See https://github.com/spring-projects/spring-boot/issues/32228#issue-1361858500.
+
+    // snakeyaml 1.29 fails to parse yaml (including some k8s manifests), so
+    // stick with 1.27 since that's what spring boot 2.4.13 uses.
+    // https://github.com/spring-projects/spring-boot/issues/30159#issuecomment-1125969155
+    // has details, including that snakeyaml 1.28 doesn't suffer from this bug.
+    // We could remove this specification altogether, and move to 1.28 along
+    // with spring boot 2.5, but I'd rather pin it here to avoid hitting the bug
+    // when we upgrade to spring boot 2.6.x.  It's safe to upgrade beyond 1.29
+    // with spring boot >= 2.6.12.  See
+    // https://github.com/spring-projects/spring-boot/issues/32228#issue-136185850.0.
+    api("org.yaml:snakeyaml:1.27")
     api("org.springdoc:springdoc-openapi-webmvc-core:${versions.openapi}")
     api("org.springdoc:springdoc-openapi-kotlin:${versions.openapi}")
     api("org.springframework.boot:spring-boot-configuration-processor:${versions.springBoot}")


### PR DESCRIPTION
to avoid ArrayOutOfBoundsException parsing some yaml (including k8s manifests) with snakeyaml 1.29.  See https://github.com/spring-projects/spring-boot/issues/30159#issuecomment-1125969155 for details.