### PR TITLE
fix(dependencies): include aws-java-sdk-sts

### DIFF
--- a/kork-secrets-aws/kork-secrets-aws.gradle
+++ b/kork-secrets-aws/kork-secrets-aws.gradle
@@ -11,6 +11,8 @@ dependencies {
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.boot:spring-boot-autoconfigure"
 
+  runtimeOnly "com.amazonaws:aws-java-sdk-sts"
+
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.mockito:mockito-junit-jupiter"


### PR DESCRIPTION
When running the service in an environment requires to assume into another role to fetch the required secrets, it will require the `aws-java-sdk-sts`. This happens when the service is running as EKS pod with service account associated with an IAM role.