### PR TITLE
refactor(SpinnakerHttpException): created a method which return status code

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
-import lombok.Getter;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
 
@@ -25,7 +24,6 @@ import retrofit.client.Response;
  * An exception that exposes the {@link Response} of a given HTTP {@link RetrofitError} and a detail
  * message that extracts useful information from the {@link Response}.
  */
-@Getter
 @NonnullByDefault
 public class SpinnakerHttpException extends SpinnakerServerException {
   private final Response response;
@@ -49,7 +47,11 @@ public class SpinnakerHttpException extends SpinnakerServerException {
   public SpinnakerHttpException(String message, SpinnakerHttpException cause) {
     super(message, cause);
     // Note that getRawMessage() is null in this case.
-    this.response = cause.getResponse();
+    this.response = cause.response;
+  }
+
+  public int getResponseCode() {
+    return response.getStatus();
   }
 
   @Override

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlers.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlers.java
@@ -63,7 +63,7 @@ public class SpinnakerRetrofitExceptionHandlers extends BaseExceptionHandlers {
     // We made an http request that failed and nothing else handled that
     // failure, so generate our response based on the response we received.
     storeException(request, response, e);
-    int status = e.getResponse().getStatus();
+    int status = e.getResponseCode();
     // Log server errors as errors, but client errors as debug to avoid filling
     // up the logs with someone else's problem.
     HttpStatus httpStatus = HttpStatus.resolve(status);


### PR DESCRIPTION
Created a new method getResponseCode which will return status code of SpinnakerHttpException.
Removed to the getResponse method as all the services using the method to get the Status code only so getResponseCode method will get used instead of getResponse().getStatus()