### PR TITLE
fix(selectors): fix type cast error on cloud provider selector

### DIFF
--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByCloudProviderServiceSelector.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByCloudProviderServiceSelector.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.kork.web.selector;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -51,7 +50,7 @@ public class ByCloudProviderServiceSelector implements ServiceSelector {
       Object service, Integer priority, Map<String, Object> config) {
     this.service = service;
     this.priority = priority;
-    this.cloudProviders = new HashSet<>((List<String>) config.get("cloudProviders"));
+    this.cloudProviders = new HashSet<>(((Map<String, String>) config.get("cloudProviders")).values());
   }
 
   @Override

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByCloudProviderServiceSelector.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector/ByCloudProviderServiceSelector.java
@@ -50,7 +50,8 @@ public class ByCloudProviderServiceSelector implements ServiceSelector {
       Object service, Integer priority, Map<String, Object> config) {
     this.service = service;
     this.priority = priority;
-    this.cloudProviders = new HashSet<>(((Map<String, String>) config.get("cloudProviders")).values());
+    this.cloudProviders =
+        new HashSet<>(((Map<String, String>) config.get("cloudProviders")).values());
   }
 
   @Override


### PR DESCRIPTION
Last comment in https://github.com/spinnaker/kork/pull/967 for background.

As it turns out, `List<String>` doesn't work, and Orca blows up in spectacular fashion. My guess is because the constructor arg is a `Map<String, Object>`, Jackson doesn't know how to handle the `Object` and defaults to `LinkedHashMap`.

I don't want to break existing configs, so just fixing this selector class to use a `Map`. Eurgh.

cc @dbyron-sf 