### PR TITLE
fix(web): properly handle an empty MDC in MdcCopyingAsyncTaskExecutor

### DIFF
--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/MdcCopyingAsyncTaskExecutor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/context/MdcCopyingAsyncTaskExecutor.java
@@ -46,11 +46,12 @@ public class MdcCopyingAsyncTaskExecutor implements AsyncTaskExecutor {
 
   private Runnable wrapWithContext(final Runnable task) {
     Map<String, String> contextMap = MDC.getCopyOfContextMap();
-    if (contextMap == null) {
-      return task;
-    }
     return () -> {
-      MDC.setContextMap(contextMap);
+      if (contextMap == null) {
+        MDC.clear();
+      } else {
+        MDC.setContextMap(contextMap);
+      }
       task.run();
     };
   }


### PR DESCRIPTION
This is a corner case that's unlikely to happen, but we may as well fix it.