### PR TITLE
chore(deps): use version 9.0.69 of tomcat to resolve CVE-2022-42252 and CVE-2022-45143

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -32,10 +32,11 @@ ext {
     springCloud      : "2020.0.6",
     springfoxSwagger : "2.9.2",
     swagger          : "1.5.20", //this should stay in sync with what springfoxSwagger expects
-    // spring boot 2.4.13 brings in 9.0.55.  Use 9.0.62 to resolve
-    // CVE-2021-43980, CVE-2022-23181, CVE-2022-42252.  Spring boot 2.5.14
-    // brings in 9.0.63.
-    tomcat           : "9.0.62"
+
+    // Spring boot 2.4.13 brings in 9.0.55.  Spring boot 2.5.14 brings in
+    // 9.0.63.  Use 9.0.69 to resolve CVE-2022-42252 and CVE-2022-45143.  Spring
+    // boot 2.6.14 and 2.7.6 bring in 9.0.69.
+    tomcat           : "9.0.69"
   ]
 }
 


### PR DESCRIPTION
Here's a snippet of ./gradlew kork-tomcat:dependencies before this change:
```
+--- org.springframework.boot:spring-boot-starter-tomcat:2.4.13
|    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
|    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.55 -> 9.0.62
|    +--- org.glassfish:jakarta.el:3.0.4
|    \--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.55 -> 9.0.62
|         \--- org.apache.tomcat.embed:tomcat-embed-core:9.0.62
```
and with this change:
```
+--- org.springframework.boot:spring-boot-starter-tomcat:2.4.13
|    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
|    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.55 -> 9.0.69
|    +--- org.glassfish:jakarta.el:3.0.4
|    \--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.55 -> 9.0.69
|         \--- org.apache.tomcat.embed:tomcat-embed-core:9.0.69
```