### PR TITLE
chore(dependencies): use version 3.21.12 of com.google.protobuf

### DIFF
--- a/kork-proto/kork-proto.gradle
+++ b/kork-proto/kork-proto.gradle
@@ -12,7 +12,7 @@ dependencies {
 protobuf {
   protoc {
     // TODO: figure out how to reference version in BOM.
-    artifact = "com.google.protobuf:protoc:3.19.4"
+    artifact = "com.google.protobuf:protoc:3.21.12"
   }
 }
 

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -19,7 +19,7 @@ ext {
     // 1.2.11 from https://jira.qos.ch/browse/LOGBACK-1623 so stick with 1.2.10
     // until 1.2.12 appears.
     logback          : "1.2.10",
-    protobuf         : "3.19.4",
+    protobuf         : "3.21.12",
     okhttp           : "2.7.5", // CVE-2016-2402
     okhttp3          : "3.14.9",
     openapi          : "1.3.9", // this needs to be kept in sync with spring boot as it pulls in the spring-boot-dependencies BOM
@@ -62,6 +62,7 @@ dependencies {
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
+  api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))
   api(platform("com.google.cloud:libraries-bom:${versions.gcp}"))
   api(platform("com.google.cloud:google-cloud-secretmanager:2.1.7"))
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
@@ -69,7 +70,6 @@ dependencies {
   api(platform("org.spockframework:spock-bom:1.3-groovy-2.5"))
   api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:1.5.17"))
   api(platform("org.testcontainers:testcontainers-bom:1.16.2"))
-  api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))
   api(platform("io.arrow-kt:arrow-stack:${versions.arrow}"))
 
   constraints {


### PR DESCRIPTION
to resolve CVE-2022-3171 (fixed in 3.19.6) and CVE-2022-3509 (fixed in 3.21.7) and to stay up to date.  3.21.12 is currently the latest version, published 14-dec-2022.

Move com.google.protobuf:protobuf-bom above com.google.cloud:libraries-bom so it takes precedence.  Otherwise some transitive dependencies of libraries-bom override the versions in protobuf-bom.