### PR TITLE
fix(cve): Remove CVE-2022-23457 caused by esapi library version 2.1.0.1 that is resolved transitively trough spring-security-saml-dsl-core

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -194,5 +194,9 @@ dependencies {
       because "1.9.15 is resolved transitively through Groovy, removes CVE-2021-36374, CVE-2021-36373, CVE-2020-11979, CVE-2020-15250"
     }
 
+    api('org.owasp.esapi:esapi:2.3.0.0') {
+      because '2.1.0.1 is resolved transitively through spring-security-saml-dsl-core, removes CVE-2022-23457'
+    }
+
   }
 }


### PR DESCRIPTION
**Before applying the constraint**
```
 ./gradlew gate-saml:dependencyInsight --dependency esapi                

> Task :gate-saml:dependencyInsight
org.owasp.esapi:esapi:2.1.0.1
   variant "compile" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-api
      org.gradle.libraryelements     = jar (compatible with: classes+resources)
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 11
   ]

org.owasp.esapi:esapi:2.1.0.1
\--- org.springframework.security.extensions:spring-security-saml2-core:1.0.9.RELEASE
     +--- compileClasspath (requested org.springframework.security.extensions:spring-security-saml2-core)
     +--- io.spinnaker.kork:kork-bom:7.153.0
     |    \--- compileClasspath
     \--- org.springframework.security.extensions:spring-security-saml-dsl-core:1.0.5.RELEASE (requested org.springframework.security.extensions:spring-security-saml2-core:1.0.4.RELEASE)
          +--- compileClasspath (requested org.springframework.security.extensions:spring-security-saml-dsl-core)
          \--- io.spinnaker.kork:kork-bom:7.153.0 (*)

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.
```

**After applying the constraint**
```
./gradlew gate-saml:dependencyInsight --dependency esapi

> Task :gate-saml:dependencyInsight
org.owasp.esapi:esapi:2.3.0.0
   variant "compile" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-api
      org.gradle.libraryelements     = jar (compatible with: classes+resources)
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 11
   ]
   Selection reasons:
      - By constraint
      - Forced

org.owasp.esapi:esapi:2.3.0.0
\--- io.spinnaker.kork:kork-bom:0.1.0-SNAPSHOT
     \--- compileClasspath (requested io.spinnaker.kork:kork-bom:7.153.0)

org.owasp.esapi:esapi:2.1.0.1 -> 2.3.0.0
\--- org.springframework.security.extensions:spring-security-saml2-core:1.0.9.RELEASE
     +--- compileClasspath (requested org.springframework.security.extensions:spring-security-saml2-core)
     +--- io.spinnaker.kork:kork-bom:0.1.0-SNAPSHOT
     |    \--- compileClasspath (requested io.spinnaker.kork:kork-bom:7.153.0)
     \--- org.springframework.security.extensions:spring-security-saml-dsl-core:1.0.5.RELEASE (requested org.springframework.security.extensions:spring-security-saml2-core:1.0.4.RELEASE)
          +--- compileClasspath (requested org.springframework.security.extensions:spring-security-saml-dsl-core)
          \--- io.spinnaker.kork:kork-bom:0.1.0-SNAPSHOT (*)

(*) - dependencies omitted (listed previously)

```
