### PR TITLE
chore(dependencies): remove dependency on groovy-all from kork

### DIFF
--- a/kork-aws/kork-aws.gradle
+++ b/kork-aws/kork-aws.gradle
@@ -39,8 +39,8 @@ dependencies {
 
   runtimeOnly "com.amazonaws:aws-java-sdk-sts"
 
-  testImplementation "org.codehaus.groovy:groovy-all"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-engine"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-runner"
 }

--- a/kork-core/kork-core.gradle
+++ b/kork-core/kork-core.gradle
@@ -24,7 +24,7 @@ dependencies {
   implementation "com.netflix.spectator:spectator-ext-jvm"
   implementation "com.netflix.spectator:spectator-reg-micrometer"
 
-  testImplementation "org.codehaus.groovy:groovy-all"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation("org.mockito:mockito-core")
   testImplementation "org.spockframework:spock-core"
   testRuntimeOnly "cglib:cglib-nodep"

--- a/kork-exceptions/kork-exceptions.gradle
+++ b/kork-exceptions/kork-exceptions.gradle
@@ -6,7 +6,6 @@ dependencies {
   api(platform(project(":spinnaker-dependencies")))
   api "com.google.code.findbugs:jsr305"
 
-  testImplementation "org.codehaus.groovy:groovy-all"
   testImplementation "org.spockframework:spock-core"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"

--- a/kork-jedis/kork-jedis.gradle
+++ b/kork-jedis/kork-jedis.gradle
@@ -14,7 +14,6 @@ dependencies {
   testImplementation "com.hubspot.jinjava:jinjava"
   testImplementation project(":kork-core-tck")
   testImplementation project(":kork-jedis-test")
-  testImplementation "org.codehaus.groovy:groovy-all"
   testImplementation "org.spockframework:spock-core"
   testImplementation "junit:junit"
   testRuntimeOnly "cglib:cglib-nodep"

--- a/kork-pubsub-aws/kork-pubsub-aws.gradle
+++ b/kork-pubsub-aws/kork-pubsub-aws.gradle
@@ -33,7 +33,6 @@ dependencies {
   api 'com.netflix.spectator:spectator-api'
   api 'org.slf4j:slf4j-api'
 
-  testImplementation "org.codehaus.groovy:groovy-all"
   testImplementation "org.spockframework:spock-core"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"

--- a/kork-security/kork-security.gradle
+++ b/kork-security/kork-security.gradle
@@ -13,7 +13,6 @@ dependencies {
   implementation "com.google.guava:guava"
   implementation "org.slf4j:slf4j-api"
 
-  testImplementation("org.codehaus.groovy:groovy-all")
   testImplementation "org.spockframework:spock-core"
   testRuntimeOnly "ch.qos.logback:logback-classic"
   testRuntimeOnly "cglib:cglib-nodep"

--- a/kork-telemetry/kork-telemetry.gradle
+++ b/kork-telemetry/kork-telemetry.gradle
@@ -8,7 +8,6 @@ dependencies {
   api "com.netflix.spectator:spectator-api"
   api "com.github.ben-manes.caffeine:guava"
 
-  testImplementation "org.codehaus.groovy:groovy-all"
   testImplementation "com.hubspot.jinjava:jinjava"
   testImplementation "org.spockframework:spock-core"
   testRuntimeOnly "cglib:cglib-nodep"

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -11,7 +11,6 @@ ext {
     bouncycastle     : "1.70",
     brave            : "5.12.3",
     gcp              : "25.3.0",
-    groovy           : "2.5.15", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
     jooq             : "3.13.6",
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
@@ -152,7 +151,6 @@ dependencies {
     api("org.apache.commons:commons-exec:1.3")
     api("org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}")
     api("org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}")
-    api("org.codehaus.groovy:groovy-all:${versions.groovy}")
     api("org.jetbrains:annotations:19.0.0")
     api("org.spekframework.spek2:spek-dsl-jvm:${versions.spek2}")
     api("org.spekframework.spek2:spek-runner-junit5:${versions.spek2}")


### PR DESCRIPTION
Removed `groovy-all` from kork-exception, kork-security, kork-pubsub-aws, kork-telemetry, kork-jedis, kork-aws, kork-core and spinnaker-depndencies.