### PR TITLE
fix(jedis): get reference to delegate's internal pool

### DIFF
--- a/kork-jedis/kork-jedis.gradle
+++ b/kork-jedis/kork-jedis.gradle
@@ -10,10 +10,12 @@ dependencies {
   api "com.netflix.spectator:spectator-api"
 
   implementation "com.fasterxml.jackson.core:jackson-databind"
+  implementation "org.apache.commons:commons-lang3"
 
   testImplementation "com.hubspot.jinjava:jinjava"
   testImplementation project(":kork-core-tck")
   testImplementation project(":kork-jedis-test")
+  testImplementation "org.mockito:mockito-core"
   testImplementation "org.spockframework:spock-core"
   testImplementation "junit:junit"
   testRuntimeOnly "cglib:cglib-nodep"

--- a/kork-jedis/src/test/java/com/netflix/spinnaker/kork/jedis/telemetry/InstrumentedJedisPoolTest.java
+++ b/kork-jedis/src/test/java/com/netflix/spinnaker/kork/jedis/telemetry/InstrumentedJedisPoolTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 THL A29 Limited, a Tencent company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.jedis.telemetry;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import com.netflix.spectator.api.Registry;
+import org.junit.Test;
+import redis.clients.jedis.JedisPool;
+
+public class InstrumentedJedisPoolTest {
+
+  private Registry registry = mock(Registry.class);
+
+  private JedisPool jedisPool = new JedisPool();
+
+  private InstrumentedJedisPool instrumentedJedisPool =
+      new InstrumentedJedisPool(registry, jedisPool);
+
+  @Test
+  public void getInternalPoolReference() {
+    assertNotNull(instrumentedJedisPool.getInternalPoolReference());
+  }
+}


### PR DESCRIPTION
The internalPool field is declared in JedisPool's super class, getDeclaredField("internalPool") could not get internalPool field from super class.