### PR TITLE
feat(secrets): Add CacheManager support to secret engines

### DIFF
--- a/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerClientProvider.java
+++ b/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerClientProvider.java
@@ -17,8 +17,9 @@
 package com.netflix.spinnaker.kork.secrets.engines;
 
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import java.util.Map;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 
+@NonnullByDefault
 public interface SecretsManagerClientProvider {
   /**
    * Gets a configured AWS Secrets Manager client for the provided secret parameters. These
@@ -26,5 +27,5 @@ public interface SecretsManagerClientProvider {
    * com.netflix.spinnaker.kork.secrets.EncryptedSecret} or {@link
    * com.netflix.spinnaker.kork.secrets.user.UserSecretReference} URI.
    */
-  AWSSecretsManager getClientForSecretParameters(Map<String, String> parameters);
+  AWSSecretsManager getClientForRegionAndSecret(String region, String secret);
 }

--- a/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerConfiguration.java
+++ b/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerConfiguration.java
@@ -26,9 +26,6 @@ public class SecretsManagerConfiguration {
   @ConditionalOnMissingBean
   @Bean
   public SecretsManagerClientProvider secretsManagerClientProvider() {
-    return parameters ->
-        AWSSecretsManagerClientBuilder.standard()
-            .withRegion(parameters.get(SecretsManagerSecretEngine.SECRET_REGION))
-            .build();
+    return (region, secret) -> AWSSecretsManagerClientBuilder.standard().withRegion(region).build();
   }
 }

--- a/kork-secrets-aws/src/test/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerSecretEngineIntegrationTest.java
+++ b/kork-secrets-aws/src/test/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerSecretEngineIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.kork.secrets.engines;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
@@ -118,7 +118,7 @@ public class SecretsManagerSecretEngineIntegrationTest {
 
     @Bean
     public SecretsManagerClientProvider localstackClientProvider(LocalStackContainer container) {
-      return (params) ->
+      return (region, secret) ->
           AWSSecretsManagerClientBuilder.standard()
               .withEndpointConfiguration(
                   container.getEndpointConfiguration(LocalStackContainer.Service.SECRETSMANAGER))

--- a/kork-secrets-gcp/src/main/java/com/netflix/spinnaker/kork/secrets/engines/GcsSecretEngine.java
+++ b/kork-secrets-gcp/src/main/java/com/netflix/spinnaker/kork/secrets/engines/GcsSecretEngine.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -38,7 +39,11 @@ public class GcsSecretEngine extends AbstractStorageSecretEngine {
   private static final String IDENTIFIER = "gcs";
   private static final String APPLICATION_NAME = "Spinnaker";
 
-  private final AtomicReference<Storage> googleStorage = new AtomicReference();
+  private final AtomicReference<Storage> googleStorage = new AtomicReference<>();
+
+  public GcsSecretEngine(CacheManager cacheManager) {
+    super(cacheManager.getCache(IDENTIFIER));
+  }
 
   public String identifier() {
     return IDENTIFIER;
@@ -58,10 +63,9 @@ public class GcsSecretEngine extends AbstractStorageSecretEngine {
   }
 
   @Override
-  protected InputStream downloadRemoteFile(EncryptedSecret encryptedSecret) {
-
-    String bucket = encryptedSecret.getParams().get(STORAGE_BUCKET);
-    String objName = encryptedSecret.getParams().get(STORAGE_FILE_URI);
+  protected InputStream downloadRemoteFile(CacheKey cacheKey) throws IOException {
+    String bucket = cacheKey.getBucket();
+    String objName = cacheKey.getFile();
 
     log.info("Getting contents of object {} from bucket {}", objName, bucket);
 

--- a/kork-secrets/kork-secrets.gradle
+++ b/kork-secrets/kork-secrets.gradle
@@ -9,6 +9,7 @@ dependencies {
   api project(":kork-security")
   api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
   api "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
+  api "org.springframework.boot:spring-boot-starter-cache"
   implementation "org.springframework.boot:spring-boot-autoconfigure"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.yaml:snakeyaml"

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretConfiguration.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretConfiguration.java
@@ -29,6 +29,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -65,5 +68,11 @@ public class SecretConfiguration {
   @Bean
   public UserSecretSerdeFactory userSecretSerdeFactory(ObjectProvider<UserSecretSerde> serdes) {
     return new UserSecretSerdeFactory(serdes);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public CacheManager fallbackCacheManager() {
+    return new ConcurrentMapCacheManager();
   }
 }


### PR DESCRIPTION
Using a `CacheManager` bean from Spring, this updates the `SecretEngine` implementations to use named `Cache`s from said cache manager. A default fallback bean is provided.