### PR TITLE
fix(tests): Introduce junit5 vintage engine for running junit4 test cases over junit5 and cleanup of useJUnitPlatform() from sub-modules in kork

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,15 @@ subprojects {
 
   if (it.name != "kork-bom" && it.name != "spinnaker-dependencies") {
     apply plugin: 'java-library'
+    test {
+      useJUnitPlatform {
+        includeEngines "spek2", "junit-vintage", "junit-jupiter"
+      }
+    }
     dependencies {
       annotationProcessor(platform(project(":spinnaker-dependencies")))
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+      testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
     }
   }
 }

--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -33,12 +33,6 @@ dependencies {
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
-test {
-  useJUnitPlatform {
-    includeEngines "junit-jupiter"
-  }
-}
-
 compileTestKotlin {
   kotlinOptions {
     languageVersion = "1.4"

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -35,12 +35,6 @@ dependencies {
   testRuntimeOnly "org.spekframework.spek2:spek-runner-junit5"
 }
 
-test {
-  useJUnitPlatform {
-    includeEngines "spek2", "junit-vintage", "junit-jupiter"
-  }
-}
-
 compileKotlin {
   kotlinOptions {
     languageVersion = "1.4"

--- a/kork-api/kork-api.gradle
+++ b/kork-api/kork-api.gradle
@@ -12,7 +12,3 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/kork-artifacts/kork-artifacts.gradle
+++ b/kork-artifacts/kork-artifacts.gradle
@@ -13,7 +13,3 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/kork-cloud-config-server/kork-cloud-config-server.gradle
+++ b/kork-cloud-config-server/kork-cloud-config-server.gradle
@@ -20,7 +20,3 @@ dependencies {
   testImplementation "org.mockito:mockito-core"
 
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/kork-config/kork-config.gradle
+++ b/kork-config/kork-config.gradle
@@ -17,7 +17,3 @@ dependencies {
   testImplementation "org.mockito:mockito-core"
 
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/kork-credentials-api/kork-credentials-api.gradle
+++ b/kork-credentials-api/kork-credentials-api.gradle
@@ -34,7 +34,3 @@ dependencies {
   testImplementation project(":kork-core")
   testImplementation "com.fasterxml.jackson.core:jackson-databind"
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/kork-credentials/kork-credentials.gradle
+++ b/kork-credentials/kork-credentials.gradle
@@ -35,7 +35,3 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/kork-expressions/kork-expressions.gradle
+++ b/kork-expressions/kork-expressions.gradle
@@ -2,10 +2,6 @@ apply plugin: "java-library"
 apply from: "$rootDir/gradle/lombok.gradle"
 apply from: "$rootDir/gradle/kotlin.gradle"
 
-test {
-  useJUnitPlatform()
-}
-
 dependencies {
   api(platform(project(":spinnaker-dependencies")))
 

--- a/kork-plugins-tck/kork-plugins-tck.gradle
+++ b/kork-plugins-tck/kork-plugins-tck.gradle
@@ -23,12 +23,6 @@ dependencies {
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 
-test {
-  useJUnitPlatform {
-    includeEngines("junit-jupiter", "junit-vintage")
-  }
-}
-
 detekt {
   ignoreFailures = false
 }

--- a/kork-secrets-aws/kork-secrets-aws.gradle
+++ b/kork-secrets-aws/kork-secrets-aws.gradle
@@ -21,7 +21,3 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-test"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/kork-sql-test/kork-sql-test.gradle
+++ b/kork-sql-test/kork-sql-test.gradle
@@ -16,7 +16,3 @@ dependencies {
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
   testRuntimeOnly "org.postgresql:postgresql"
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -48,7 +48,3 @@ dependencies {
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/selector/SelectableServiceSpec.groovy
+++ b/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/selector/SelectableServiceSpec.groovy
@@ -43,7 +43,7 @@ class SelectableServiceSpec extends Specification {
       [
         new ByAccountServiceSelector(oortService, 10, ["accountPattern": ".*internal.*"]),
         new ByApplicationServiceSelector(mortService, 10, ["applicationPattern": ".*spindemo.*"]),
-        new ByCloudProviderServiceSelector(oortService, 10, ["cloudProviders": ["kubernetes"]]),
+        new ByCloudProviderServiceSelector(oortService, 10, ["cloudProviders": [0: "kubernetes"]]),
         new ByExecutionTypeServiceSelector(oortService, 5, ["executionTypes": [0: "orchestration"]]),
         new ByOriginServiceSelector(instanceService, 20, ["origin": "deck", "executionTypes": [0: "orchestration"]]),
         new ByAuthenticatedUserServiceSelector(bakeryService, 25, ["users": [0: "user1@email.com", 1: ".*user2.*"]]),


### PR DESCRIPTION
Spring boot 2.4.x removed JUnit5 vintage engine from spring-boot-starter-test. 
[https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#junit-5s-vintage-engine-removed-from-spring-boot-starter-test] 
It is required for executing junit4 based test cases in kork. So, introducing junit-vintage-engine dependency in build.gradle, using testRuntimeOnly() as suggested in section 3.1 of https://junit.org/junit5/docs/5.6.2/user-guide/index.pdf

After applying this fix, coverage increased from 458 to 515 test case executions.

Clean up the call for test engines using `useJUnitPlatform()` from sub-modules, and placing it in build.gradle. As per the gradle docs, all test engines on the test runtime classpath will be used by sub modules. 
https://docs.gradle.org/6.8.1/userguide/java_testing.html#filtering_test_engine