### PR TITLE
feat(retrofit): Add getHeaders() method to SpinnakerHttpException

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -28,6 +28,7 @@ import retrofit.client.Response;
 @NonnullByDefault
 public class SpinnakerHttpException extends SpinnakerServerException {
   private final Response response;
+  private HttpHeaders headers;
 
   public SpinnakerHttpException(RetrofitError e) {
     super(e);
@@ -56,8 +57,10 @@ public class SpinnakerHttpException extends SpinnakerServerException {
   }
 
   public HttpHeaders getHeaders() {
-    HttpHeaders headers = new HttpHeaders();
-    response.getHeaders().forEach(header -> headers.add(header.getName(), header.getValue()));
+    if (headers == null) {
+      headers = new HttpHeaders();
+      response.getHeaders().forEach(header -> headers.add(header.getName(), header.getValue()));
+    }
     return headers;
   }
 

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -17,9 +17,8 @@
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
-import java.util.List;
+import org.springframework.http.HttpHeaders;
 import retrofit.RetrofitError;
-import retrofit.client.Header;
 import retrofit.client.Response;
 
 /**
@@ -56,8 +55,10 @@ public class SpinnakerHttpException extends SpinnakerServerException {
     return response.getStatus();
   }
 
-  public List<Header> getHeaders() {
-    return response.getHeaders();
+  public HttpHeaders getHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    response.getHeaders().forEach(header -> headers.add(header.getName(), header.getValue()));
+    return headers;
   }
 
   @Override

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -17,7 +17,9 @@
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.List;
 import retrofit.RetrofitError;
+import retrofit.client.Header;
 import retrofit.client.Response;
 
 /**
@@ -52,6 +54,10 @@ public class SpinnakerHttpException extends SpinnakerServerException {
 
   public int getResponseCode() {
     return response.getStatus();
+  }
+
+  public List<Header> getHeaders() {
+    return response.getHeaders();
   }
 
   @Override

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -16,7 +16,11 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
 import retrofit.RestAdapter;
 import retrofit.RetrofitError;
-import retrofit.client.Header;
 import retrofit.client.Response;
 import retrofit.converter.JacksonConverter;
 import retrofit.http.GET;
@@ -156,14 +155,14 @@ public class SpinnakerRetrofitErrorHandlerTest {
   @Test
   public void testResponseHeadersInException() {
     // Check response headers are retrievable from a SpinnakerHttpException
-    Header testHeader = new Header("Test", "true");
     mockWebServer.enqueue(
         new MockResponse()
             .setResponseCode(HttpStatus.BAD_REQUEST.value())
             .setHeader("Test", "true"));
     SpinnakerHttpException spinnakerHttpException =
         assertThrows(SpinnakerHttpException.class, () -> retrofitService.getFoo());
-    assertTrue(spinnakerHttpException.getHeaders().contains(testHeader));
+    assertTrue(spinnakerHttpException.getHeaders().containsKey("Test"));
+    assertTrue(spinnakerHttpException.getHeaders().get("Test").contains("true"));
   }
 
   @Test

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -16,10 +16,7 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,6 +34,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
 import retrofit.RestAdapter;
 import retrofit.RetrofitError;
+import retrofit.client.Header;
 import retrofit.client.Response;
 import retrofit.converter.JacksonConverter;
 import retrofit.http.GET;
@@ -149,6 +147,19 @@ public class SpinnakerRetrofitErrorHandlerTest {
     SpinnakerHttpException spinnakerHttpException =
         assertThrows(SpinnakerHttpException.class, () -> retrofitService.getFoo());
     assertNull(spinnakerHttpException.getRetryable());
+  }
+
+  @Test
+  public void testResponseHeadersInException() {
+    // Check response headers are retrievable from a SpinnakerHttpException
+    Header testHeader = new Header("Test", "true");
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(HttpStatus.BAD_REQUEST.value())
+            .setHeader("Test", "true"));
+    SpinnakerHttpException spinnakerHttpException =
+        assertThrows(SpinnakerHttpException.class, () -> retrofitService.getFoo());
+    assertTrue(spinnakerHttpException.getHeaders().contains(testHeader));
   }
 
   @Test


### PR DESCRIPTION
This PR adds a `getHeaders()` method to `SpinnakerHttpException` so that the response headers for an HTTP request can be examined during exception handling. This is needed as part of the effort to [consume SpinnakerRetrofitHandler in each service](https://github.com/spinnaker/spinnaker/issues/5473).