### PR TITLE
feat(retrofit): add getErrorBodyAs() method to SpinnakerServerException

### DIFF
--- a/kork-retrofit/kork-retrofit.gradle
+++ b/kork-retrofit/kork-retrofit.gradle
@@ -24,4 +24,5 @@ dependencies {
   testImplementation "com.squareup.okhttp3:mockwebserver"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
+  testImplementation "com.squareup.retrofit2:converter-gson:2.9.0"
 }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
@@ -73,6 +73,7 @@ public class RetrofitException extends RuntimeException {
     if (response == null) {
       return null;
     }
+
     Converter<ResponseBody, T> converter = retrofit.responseBodyConverter(type, new Annotation[0]);
     try {
       return converter.convert(response.errorBody());

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
@@ -70,7 +70,7 @@ public class RetrofitException extends RuntimeException {
    *     the specified {@code type}.
    */
   public <T> T getBodyAs(Class<T> type) {
-    if (response == null) {
+    if (response == null || response.errorBody() == null) {
       return null;
     }
 

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
@@ -69,8 +69,8 @@ public class RetrofitException extends RuntimeException {
    * @throws RuntimeException wrapping the underlying IOException if unable to convert the body to
    *     the specified {@code type}.
    */
-  public <T> T getErrorBodyAs(Class<T> type) {
-    if (response == null || response.errorBody() == null) {
+  public <T> T getBodyAs(Class<T> type) {
+    if (response == null) {
       return null;
     }
     Converter<ResponseBody, T> converter = retrofit.responseBodyConverter(type, new Annotation[0]);

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import lombok.Getter;
 import retrofit.RetrofitError;
@@ -35,6 +37,8 @@ public class SpinnakerServerException extends SpinnakerException {
    */
   private final String rawMessage;
 
+  private final Map<String, Object> errorBodyAs;
+
   /**
    * Parses the message from the {@link RetrofitErrorResponseBody} of a {@link RetrofitError}.
    *
@@ -46,6 +50,7 @@ public class SpinnakerServerException extends SpinnakerException {
         (RetrofitErrorResponseBody) e.getBodyAs(RetrofitErrorResponseBody.class);
     this.rawMessage =
         Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse(e.getMessage());
+    this.errorBodyAs = (Map<String, Object>) e.getBodyAs(HashMap.class);
   }
 
   public SpinnakerServerException(RetrofitException e) {
@@ -68,6 +73,11 @@ public class SpinnakerServerException extends SpinnakerException {
   public SpinnakerServerException(String message, Throwable cause) {
     super(message, cause);
     rawMessage = null;
+    errorBodyAs = null;
+  }
+
+  public Map<String, Object> getErrorBodyAs() {
+    return errorBodyAs;
   }
 
   @Override

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -16,15 +16,10 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import lombok.Getter;
 import retrofit.RetrofitError;
 
 /** An exception that exposes the message of a {@link RetrofitError}, or a custom message. */
@@ -37,33 +32,34 @@ public class SpinnakerServerException extends SpinnakerException {
    */
   private final String rawMessage;
 
-  /* RetrofitError's response body derived as map or null if response not provided in RetrofitError or custom  message has been provided*/
+  /* retrofit's response body derived as map or null if response not provided or custom message has been provided */
   private final Map<String, Object> responseBody;
 
   /**
-   * Parses the message from the {@link RetrofitErrorResponseBody} and parses response of a {@link
-   * RetrofitError} responseBody.
+   * Parse the response body of {@link RetrofitError} as json into responseBody and extract the
+   * message property as rawMessage
    *
    * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
    */
   public SpinnakerServerException(RetrofitError e) {
     super(e.getCause());
-    RetrofitErrorResponseBody body =
-        (RetrofitErrorResponseBody) e.getBodyAs(RetrofitErrorResponseBody.class);
-    this.rawMessage =
-        Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse(e.getMessage());
     this.responseBody = (Map<String, Object>) e.getBodyAs(HashMap.class);
+    this.rawMessage =
+        responseBody != null
+            ? (String) responseBody.getOrDefault("message", e.getMessage())
+            : e.getMessage();
   }
 
   /**
-   * Parses the Error response body of {@link RetrofitException} as responseBody.
+   * Parse the response body of {@link RetrofitException} as json into responseBody and extract the
+   * message property as rawMessage.
    *
    * @param e The {@link RetrofitException} thrown by an invocation of the {@link
    *     retrofit2.Retrofit}
    */
   public SpinnakerServerException(RetrofitException e) {
     super(e.getCause());
-    this.responseBody = e.getErrorBodyAs(HashMap.class);
+    this.responseBody = e.getBodyAs(HashMap.class);
     this.rawMessage =
         responseBody != null
             ? (String) responseBody.getOrDefault("message", e.getMessage())
@@ -99,22 +95,6 @@ public class SpinnakerServerException extends SpinnakerException {
 
   final String getRawMessage() {
     return rawMessage;
-  }
-
-  @Getter
-  // Use JsonIgnoreProperties because some responses contain properties that
-  // cannot be mapped to the RetrofitErrorResponseBody class.  If the default
-  // JacksonConverter (with no extra configurations) is used to deserialize the
-  // response body and properties other than "message" exist in the JSON
-  // response, there will be an UnrecognizedPropertyException.
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  private static final class RetrofitErrorResponseBody {
-    private final String message;
-
-    @JsonCreator
-    RetrofitErrorResponseBody(@JsonProperty("message") String message) {
-      this.message = message;
-    }
   }
 
   @Override

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -37,11 +37,12 @@ public class SpinnakerServerException extends SpinnakerException {
    */
   private final String rawMessage;
 
-  /* RetrofitError's response body derived as map or null if response not provided in RetrofitError */
+  /* RetrofitError's response body derived as map or null if response not provided in RetrofitError or custom  message has been provided*/
   private final Map<String, Object> responseBody;
 
   /**
-   * Parses the message from the {@link RetrofitErrorResponseBody} of a {@link RetrofitError}.
+   * Parses the message from the {@link RetrofitErrorResponseBody} and parses response of a {@link
+   * RetrofitError} responseBody.
    *
    * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
    */
@@ -54,12 +55,19 @@ public class SpinnakerServerException extends SpinnakerException {
     this.responseBody = (Map<String, Object>) e.getBodyAs(HashMap.class);
   }
 
+  /**
+   * Parses the Error response body of {@link RetrofitException} as responseBody.
+   *
+   * @param e The {@link RetrofitException} thrown by an invocation of the {@link
+   *     retrofit2.Retrofit}
+   */
   public SpinnakerServerException(RetrofitException e) {
     super(e.getCause());
-    RetrofitErrorResponseBody body =
-        (RetrofitErrorResponseBody) e.getErrorBodyAs(RetrofitErrorResponseBody.class);
+    this.responseBody = e.getErrorBodyAs(HashMap.class);
     this.rawMessage =
-        Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse(e.getMessage());
+        responseBody != null
+            ? (String) responseBody.getOrDefault("message", e.getMessage())
+            : e.getMessage();
   }
 
   /**

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -37,7 +37,8 @@ public class SpinnakerServerException extends SpinnakerException {
    */
   private final String rawMessage;
 
-  private final Map<String, Object> errorBodyAs;
+  /* RetrofitError's response body derived as map or null if response not provided in RetrofitError */
+  private final Map<String, Object> responseBody;
 
   /**
    * Parses the message from the {@link RetrofitErrorResponseBody} of a {@link RetrofitError}.
@@ -50,7 +51,7 @@ public class SpinnakerServerException extends SpinnakerException {
         (RetrofitErrorResponseBody) e.getBodyAs(RetrofitErrorResponseBody.class);
     this.rawMessage =
         Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse(e.getMessage());
-    this.errorBodyAs = (Map<String, Object>) e.getBodyAs(HashMap.class);
+    this.responseBody = (Map<String, Object>) e.getBodyAs(HashMap.class);
   }
 
   public SpinnakerServerException(RetrofitException e) {
@@ -73,11 +74,11 @@ public class SpinnakerServerException extends SpinnakerException {
   public SpinnakerServerException(String message, Throwable cause) {
     super(message, cause);
     rawMessage = null;
-    errorBodyAs = null;
+    responseBody = null;
   }
 
-  public Map<String, Object> getErrorBodyAs() {
-    return errorBodyAs;
+  public Map<String, Object> getResponseBody() {
+    return responseBody;
   }
 
   @Override

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/ByteArrayConverterFactoryTestUtil.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/ByteArrayConverterFactoryTestUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+public class ByteArrayConverterFactoryTestUtil extends Converter.Factory {
+  private ByteArrayConverterFactoryTestUtil() {}
+
+  public static ByteArrayConverterFactoryTestUtil create() {
+    return new ByteArrayConverterFactoryTestUtil();
+  }
+
+  @Override
+  public Converter<ResponseBody, ?> responseBodyConverter(
+      Type type, Annotation[] annotations, Retrofit retrofit) {
+    if (type == byte[].class) {
+      return new Converter<ResponseBody, byte[]>() {
+        @Override
+        public byte[] convert(ResponseBody value) throws IOException {
+          return value.bytes();
+        }
+      };
+    }
+    return null;
+  }
+
+  @Override
+  public Converter<?, RequestBody> requestBodyConverter(
+      Type type,
+      Annotation[] parameterAnnotations,
+      Annotation[] methodAnnotations,
+      Retrofit retrofit) {
+    if (type == byte[].class) {
+      return new Converter<byte[], RequestBody>() {
+        @Override
+        public RequestBody convert(byte[] value) throws IOException {
+          return RequestBody.create(MediaType.parse("application/octet-stream"), value);
+        }
+      };
+    }
+    return null;
+  }
+}

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+public class RetrofitExceptionTest {
+
+  private static Retrofit retrofit2Service;
+
+  private static String responseBodyString;
+
+  @BeforeAll
+  public static void setupOnce() throws Exception {
+
+    Map<String, String> responseBodyMap = new HashMap<>();
+    responseBodyMap.put("timestamp", "123123123123");
+    responseBodyMap.put("message", "Something happened error message");
+    responseBodyString = new ObjectMapper().writeValueAsString(responseBodyMap);
+
+    retrofit2Service =
+        new Retrofit.Builder()
+            .baseUrl("http://localhost:8987/")
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build();
+  }
+
+  @Test
+  public void testHttpException() {
+    RetrofitException retrofitException =
+        RetrofitException.httpError(
+            Response.error(
+                404,
+                ResponseBody.create(
+                    MediaType.parse("application/json" + "; charset=utf-8"), responseBodyString)),
+            retrofit2Service);
+
+    Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
+    assertEquals("Something happened error message", responseBody.get("message"));
+  }
+
+  @Test
+  public void testResponseBodyWithNullContent() {
+    String nullobj = null;
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            ResponseBody.create(MediaType.parse("application/json" + "; charset=utf-8"), nullobj));
+  }
+
+  @Test
+  public void testResponseWithNullResponseBody() {
+    assertThrows(NullPointerException.class, () -> Response.error(404, null));
+  }
+
+  @Test
+  public void testHttpConversionFail() {
+    RetrofitException retrofitException =
+        RetrofitException.httpError(
+            Response.error(
+                404,
+                ResponseBody.create(
+                    MediaType.parse("application/json" + "; charset=utf-8"),
+                    "{\"name\"=\"test\"}")),
+            retrofit2Service);
+
+    assertThrows(RuntimeException.class, () -> retrofitException.getBodyAs(HashMap.class));
+  }
+
+  @Test
+  public void testNetworkError() {
+    RetrofitException retrofitException =
+        RetrofitException.networkError(new IOException("io exception occured"));
+    Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
+    assertEquals(null, responseBody);
+  }
+
+  @Test
+  public void testServerException() {
+    MediaType.get("application/json; charset=utf-8");
+    RetrofitException retrofitException =
+        RetrofitException.unexpectedError(new NullPointerException("np"));
+    Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
+    assertEquals(null, responseBody);
+  }
+}

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -78,6 +79,16 @@ public class RetrofitExceptionTest {
   @Test
   public void testResponseWithNullResponseBody() {
     assertThrows(NullPointerException.class, () -> Response.error(404, null));
+  }
+
+  @Test
+  public void testRetrofitExceptionWithSuccessfulResponse() {
+    Response<String> response = Response.success(responseBodyString);
+    RetrofitException retrofitException =
+        new RetrofitException("hello", response, null /* exception */, retrofit2Service);
+
+    Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
+    assertNull(responseBody);
   }
 
   @Test

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
@@ -68,20 +68,6 @@ public class RetrofitExceptionTest {
   }
 
   @Test
-  public void testResponseBodyWithNullContent() {
-    String nullobj = null;
-    assertThrows(
-        NullPointerException.class,
-        () ->
-            ResponseBody.create(MediaType.parse("application/json" + "; charset=utf-8"), nullobj));
-  }
-
-  @Test
-  public void testResponseWithNullResponseBody() {
-    assertThrows(NullPointerException.class, () -> Response.error(404, null));
-  }
-
-  @Test
   public void testRetrofitExceptionWithSuccessfulResponse() {
     Response<String> response = Response.success(responseBodyString);
     RetrofitException retrofitException =

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Netflix, Inc.
+ * Copyright 2023 OpsMx, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
@@ -68,16 +68,6 @@ public class RetrofitExceptionTest {
   }
 
   @Test
-  public void testRetrofitExceptionWithSuccessfulResponse() {
-    Response<String> response = Response.success(responseBodyString);
-    RetrofitException retrofitException =
-        new RetrofitException("hello", response, null /* exception */, retrofit2Service);
-
-    Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
-    assertNull(responseBody);
-  }
-
-  @Test
   public void testHttpConversionFail() {
     RetrofitException retrofitException =
         RetrofitException.httpError(

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
@@ -110,7 +110,7 @@ public class RetrofitExceptionTest {
     RetrofitException retrofitException =
         RetrofitException.networkError(new IOException("io exception occured"));
     Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
-    assertEquals(null, responseBody);
+    assertNull(responseBody);
   }
 
   @Test
@@ -119,6 +119,6 @@ public class RetrofitExceptionTest {
     RetrofitException retrofitException =
         RetrofitException.unexpectedError(new NullPointerException("np"));
     Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
-    assertEquals(null, responseBody);
+    assertNull(responseBody);
   }
 }

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
@@ -16,20 +16,15 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.GsonBuilder;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
@@ -37,10 +32,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import retrofit2.Call;
-import retrofit2.Converter;
 import retrofit2.Response;
 import retrofit2.Retrofit;
-import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 public class RetrofitExceptionTest {
@@ -48,6 +41,15 @@ public class RetrofitExceptionTest {
   private static Retrofit retrofit2Service;
 
   private static String responseBodyString;
+
+  private final String validJsonResponseBodyString = "{\"name\":\"test\"}";
+
+  // An invalid json response body by replacing the colon(:) with an equals(=) symbol.
+  private final String invalidJsonResponseBodyString = "{\"name\"=\"test\"}";
+
+  // Create a responseBody with invalid or incomplete Json or jsonlist contents.
+  String invalidContentJsonBodyString =
+      "{\"android\": [ {\"ver\":\"1.5\",\"name\":\"Cupcace\",\"api\":\"level3\",\"pic\":\"ba";
 
   @BeforeAll
   public static void setupOnce() throws Exception {
@@ -65,101 +67,140 @@ public class RetrofitExceptionTest {
   }
 
   @Test
-  public void testHttpException() {
-    RetrofitException retrofitException =
-        RetrofitException.httpError(
-            Response.error(
-                404,
-                ResponseBody.create(
-                    MediaType.parse("application/json" + "; charset=utf-8"), responseBodyString)),
-            retrofit2Service);
+  public void testHttpSuccessResponseReturns200ServerBodyNullErrorBody() {
+    // Test for 200 to 299 responses.
+    Response<String> response = Response.success(validJsonResponseBodyString);
 
-    Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
-    assertEquals("Something happened error message", responseBody.get("message"));
+    // Assert that the response is not successful
+    assertTrue(response.isSuccessful());
+
+    // Assert the response code
+    assertEquals(200, response.code());
+
+    // Assert the response body is correct.
+    String responseBody = response.body();
+    assertNotNull(responseBody);
+
+    // returns the body as-is returned by server.
+    assertEquals(validJsonResponseBodyString, responseBody);
+
+    // Assert the response body
+    ResponseBody errorBody = response.errorBody();
+    assertNull(errorBody);
   }
 
   @Test
-  public void testHttpConversionFail() {
+  public void testNetworkWithIOExceptionReturnsNullErrorBodyWithServerError() {
+    // Assume the server returned IOException
+    IOException ioException = new IOException("custom IOException");
+
+    // Use networkError RetrofitException for IOException.
+    RetrofitException retrofitException = RetrofitException.networkError(ioException);
+
+    Map<String, String> responseBodyMap = retrofitException.getBodyAs(HashMap.class);
+    assertNull(responseBodyMap);
+
+    // Retrofit2Exception contains  error message which response returned.
+    assertEquals("custom IOException", retrofitException.getMessage());
+
+    // Since the server has thrown an IOException, hence the cause can be retrieved.
+    assertNotNull(retrofitException.getCause());
+
+    // Check if the request encountered an IOException
+    Throwable serverException = retrofitException.getCause();
+    assertTrue(serverException instanceof IOException);
+  }
+
+  @Test
+  public void testUnexpectedWithNullExceptionReturnsNullErrorBodyWithServerError() {
+    // Assume the server returned NullPointerException
+    NullPointerException nullPointerException =
+        new NullPointerException("custom NullPointerException");
+
+    // Use unexpectedError RetrofitException for non-IOExceptions like NullPointerException.
+    RetrofitException retrofitException = RetrofitException.unexpectedError(nullPointerException);
+
+    Map<String, String> responseBodyMap = retrofitException.getBodyAs(HashMap.class);
+    assertNull(responseBodyMap);
+
+    // Retrofit2Exception contains  error message which response returned.
+    assertEquals("custom NullPointerException", retrofitException.getMessage());
+
+    // Since the server has thrown an NullPointerException, hence the cause can be retrieved.
+    assertNotNull(retrofitException.getCause());
+
+    // Check if the request encountered an NullPointerException
+    Throwable serverException = retrofitException.getCause();
+    assertTrue(serverException instanceof NullPointerException);
+  }
+
+  @Test
+  public void test4xxInvalidJsonBodyConversionExceptionWithMessageAndNoCause() {
     RetrofitException retrofitException =
         RetrofitException.httpError(
             Response.error(
-                404,
+                HttpStatus.NOT_FOUND.value(),
                 ResponseBody.create(
                     MediaType.parse("application/json" + "; charset=utf-8"),
-                    "{\"name\"=\"test\"}")),
+                    invalidJsonResponseBodyString)),
             retrofit2Service);
 
-    // Gives MalformedJsonException or JsonEOFException or IllegalStateException, or
+    // Gives JsonParseException, or MalformedJsonException,
+    // or JsonEOFException or IllegalStateException, or
     // some other exception for json parsing, which is a type of RuntimeException.
     assertThrows(RuntimeException.class, () -> retrofitException.getBodyAs(HashMap.class));
+
+    // Retrofit2Exception contains 404 error message which response returned.
+    assertEquals("404 Response.error()", retrofitException.getMessage());
+
+    // Since server did not return any Exception like IOException or NullPointerException,
+    // hence the cause is null.
+    assertNull(retrofitException.getCause());
   }
 
   @Test
-  public void testNetworkError() {
+  public void testNetwork500InvalidJsonToNullBodyMessageAndCause() {
+    // Assume the server returned IOException
+    IOException networkException = new IOException("custom IOException");
+
+    // Create network RetrofitException
+    RetrofitException retrofitException = RetrofitException.networkError(networkException);
+
+    // The response body is null same as network RetrofitError .
+    assertNull(retrofitException.getBodyAs(HashMap.class));
+
+    // Retrofit2Exception contains the IOException error message which the response had returned.
+    assertEquals("custom IOException", retrofitException.getMessage());
+
+    // Since the server has thrown an IOException, hence the cause can be retrieved.
+    assertNotNull(retrofitException.getCause());
+  }
+
+  @Test
+  public void test4xxValidJsonToHashMapWithMessageAndNoCause() {
     RetrofitException retrofitException =
-        RetrofitException.networkError(new IOException("io exception occured"));
+        RetrofitException.httpError(
+            Response.error(
+                HttpStatus.NOT_FOUND.value(),
+                ResponseBody.create(
+                    MediaType.parse("application/json" + "; charset=utf-8"),
+                    validJsonResponseBodyString)),
+            retrofit2Service);
+
+    // successfully allows to parse the response body.
     Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
-    assertNull(responseBody);
+    assertEquals("test", responseBody.get("name"));
+
+    // Retrofit2Exception contains 404 error message which response returned.
+    assertEquals("404 Response.error()", retrofitException.getMessage());
+
+    // Since server did not return any Exception like IOException or NullPointerException,
+    // hence the cause is null.
+    assertNull(retrofitException.getCause());
   }
 
   @Test
-  public void testServerException() {
-    MediaType.get("application/json; charset=utf-8");
-    RetrofitException retrofitException =
-        RetrofitException.unexpectedError(new NullPointerException("np"));
-    Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
-    assertNull(responseBody);
-  }
-
-  @Test
-  public void test2xxSuccessResponseWithType() {
-    // Test for 200 to 299 responses.
-    Response<String> response = Response.success(responseBodyString);
-    String body = response.body();
-    assertNotNull(body);
-
-    // Assert the response body
-    ResponseBody errorBody = response.errorBody();
-    assertNull(errorBody);
-    assertThrows(
-        NullPointerException.class, () -> RetrofitException.httpError(response, retrofit2Service));
-  }
-
-  @Test
-  public void test2xxSuccessResponseWithWildcard() {
-    // Test for 200 to 299 responses.
-
-    Retrofit retrofit2 =
-        new Retrofit.Builder()
-            .baseUrl("http://localhost:8987/")
-            .addConverterFactory(JacksonConverterFactory.create())
-            .build();
-
-    Response<?> response = Response.success(responseBodyString);
-    assertNotNull(response);
-    String body = (String) response.body();
-    assertNotNull(body);
-
-    // Assert the response body
-    ResponseBody errorBody = response.errorBody();
-    assertNull(errorBody);
-    assertThrows(
-        NullPointerException.class, () -> RetrofitException.httpError(response, retrofit2));
-  }
-
-  @Test
-  public void test401UnauthorizedHttpError() throws Exception {
-    // create simple json body contents
-    Map<String, String> contentBodyMap = new HashMap<>();
-    contentBodyMap.put("timestamp", "123123123123");
-    contentBodyMap.put("message", "Something happened error message");
-    String contentJsonBodyString = new ObjectMapper().writeValueAsString(contentBodyMap);
-
-    this.testApiServiceForJsonResponse(contentBodyMap, contentJsonBodyString);
-  }
-
-  @Test
-  public void testNullBodyContentFor4xxHttpError() throws Exception {
+  public void testHttp4xxNullBodyContentThrowsException() throws Exception {
     final String contentJsonBodyString = null;
 
     // Test we cannot create a responseBody with null contents
@@ -171,7 +212,7 @@ public class RetrofitExceptionTest {
   }
 
   @Test
-  public void testNullResponseBodyFor4xxHttpError() throws Exception {
+  public void testHttp4xxNullBodyThrowsException() throws Exception {
 
     // We cannot create a response with null ResponseBody
     assertThrows(
@@ -179,51 +220,25 @@ public class RetrofitExceptionTest {
   }
 
   @Test
-  public void testInvalidJsonResponseBodyFor4xxHttpError() throws Exception {
-    // Create a responseBody with invalid or incomplete Json contents.
-    // It allows the API service call to execute but gives MalformedJsonException
-    // error when reading the body from the retrofitException into the HashMap.
-    String invalidContentJsonBodyString = "{\"name\":\"te";
-    Map<String, String> expectedContentBodyMap = new HashMap<>();
-    expectedContentBodyMap.put("name", "test");
+  public void testHttp4xxInvalidJsonlistBodyContentThrowsException() throws Exception {
 
-    // verify it throws MalformedJsonException
-    try {
-      this.testApiServiceForJsonResponse(expectedContentBodyMap, invalidContentJsonBodyString);
-    } catch (Exception exception) {
-      assertTrue(exception.getMessage().contains("com.google.gson.stream.MalformedJsonException"));
-    }
+    RetrofitException retrofitException =
+        RetrofitException.httpError(
+            Response.error(
+                HttpStatus.NOT_FOUND.value(),
+                ResponseBody.create(
+                    MediaType.parse("application/json" + "; charset=utf-8"),
+                    invalidContentJsonBodyString)),
+            retrofit2Service);
+
+    // Gives the json parsing exception depending on the json and the ConverterFactory added to
+    // retrofit2
+    // However, all the exceptions are of the type RuntimeException.
+    assertThrows(RuntimeException.class, () -> retrofitException.getBodyAs(HashMap.class));
   }
 
   @Test
-  public void testInvalidJsonListResponseBodyFor4xxHttpError() throws Exception {
-    // Create a responseBody with invalid or incomplete Json or jsonlist contents.
-    // It allows the API service call to execute but gives error when reading the body from the
-    // retrofitException into the HashMap.
-    // But it gives com.fasterxml.jackson.core.io.JsonEOFException if we use a
-    // JacksonConverterFactory.
-    // GsonConverterFactory will give a more detailed com.google.gson.stream.MalformedJsonException.
-    String invalidContentJsonBodyString =
-        "{\"android\": [ {\"ver\":\"1.5\",\"name\":\"Cupcace\",\"api\":\"level3\",\"pic\":\"ba";
-
-    // Use the valid string to create a map from the json list, otherwise it will give
-    // MalformedJsonException here itself.
-    // Added lenient option to allow invalid json strings also
-    com.google.gson.Gson gson = new GsonBuilder().setLenient().create();
-    Map contentBodyMap = gson.fromJson(responseBodyString, Map.class);
-    assertNotNull(contentBodyMap);
-
-    try {
-      this.testApiServiceForJsonResponse(contentBodyMap, invalidContentJsonBodyString);
-    } catch (RuntimeException exception) {
-      // Gives java.lang.MalformedJsonException or some other exception for json parsing, which is a
-      // type of RuntimeException
-      assertTrue(exception.getMessage().contains("com.google.gson.stream.MalformedJsonException"));
-    }
-  }
-
-  @Test
-  public void testByteArrayWithConverterFor4xxHttpError() throws Exception {
+  public void testHttp4xxParseByteArrayBodyContentUsingConverter() throws Exception {
     // Create a responseBody with byte array contents.
     // It allows the API service call to execute but gives MalformedJsonException
     // error when reading the body from the retrofitException into the HashMap.
@@ -258,183 +273,6 @@ public class RetrofitExceptionTest {
 
     for (int i = 0; i < byteArray.length; i++) {
       assertEquals(byteArray[i], actualResponseBodyContent[i]);
-    }
-  }
-
-  private void testApiServiceForJsonResponse(Map expectedContentBodyMap, String jsonContentString)
-      throws IOException {
-    // default converter is gson when factory list is null
-    this.testApiServiceForJsonResponse(expectedContentBodyMap, jsonContentString, null);
-  }
-
-  private void testApiServiceForJsonResponse(
-      Map expectedContentBodyMap,
-      String jsonContentString,
-      List<Converter.Factory> converterFactoryList)
-      throws IOException {
-    // Here we have randomly picked 401 - UNAUTHORIZED error.
-    // However, our main intent is to check the RetrofitException behaviour for different response
-    // bodies.
-
-    // validate contents cannot be null, otherwise it gives NullPointerException
-    assertNotNull(jsonContentString);
-
-    String invalidContentJsonBodyString = (String) jsonContentString;
-    // validate contents cannot be null, otherwise it gives NullPointerException
-    ResponseBody responseBody =
-        ResponseBody.create(
-            MediaType.parse("application/json" + "; charset=utf-8"), invalidContentJsonBodyString);
-
-    // validate responseBody cannot be null, otherwise it gives NullPointerException
-    assertNotNull(responseBody);
-
-    Response<?> actualResponse = Response.error(HttpStatus.UNAUTHORIZED.value(), responseBody);
-    assertNotNull(actualResponse);
-
-    // assert response body is null
-    String actualBody = (String) actualResponse.body();
-    assertNull(actualBody);
-
-    // Assert the error body is there
-    ResponseBody errorBody = actualResponse.errorBody();
-    assertNotNull(errorBody);
-
-    // create a builder
-    Retrofit.Builder customRetrofitBuilder =
-        new Retrofit.Builder().baseUrl("http://localhost:8987/");
-
-    // Use default as GsonConverterFactory if not specified,  for json list with lenient option to
-    // allow invalid json strings also
-    if (converterFactoryList == null || converterFactoryList.size() == 0) {
-      com.google.gson.Gson gson = new GsonBuilder().setLenient().create();
-      converterFactoryList = new ArrayList<>();
-      converterFactoryList.add(GsonConverterFactory.create(gson));
-    }
-    // Here, order is important. Retrofit2 first parses with first converter.
-    // If it fails with first converter, then tries to parse with next.
-    for (Converter.Factory factory : converterFactoryList) {
-      customRetrofitBuilder.addConverterFactory(factory);
-    }
-
-    // build the retrofit2.
-    Retrofit customRetrofit = customRetrofitBuilder.build();
-
-    // get the retrofit2 http exception from the actual response
-    RetrofitException retrofitException =
-        RetrofitException.httpError(actualResponse, customRetrofit);
-    assertNull(retrofitException.getCause());
-    assertEquals(retrofitException.getMessage(), "401 Response.error()");
-
-    // validate the body contents in the exception
-    try {
-      // hashmap for json body
-      Map actualResponseBodyContentMap = retrofitException.getBodyAs(HashMap.class);
-
-      assertNotNull(actualResponseBodyContentMap);
-      assertEquals(actualResponseBodyContentMap.size(), expectedContentBodyMap.size());
-
-      // validate data by comparing eg
-      // assertEquals(actualResponseBodyContentMap.get("name"), expectedContentBodyMap.get("test"));
-      for (Object key : expectedContentBodyMap.keySet()) {
-        assertEquals(expectedContentBodyMap.get(key), actualResponseBodyContentMap.get(key));
-      }
-    } catch (RuntimeException exception) {
-      // Gives java.lang.IllegalStateException or some other exception for json parsing, which is a
-      // type of RuntimeException
-      throw exception;
-    }
-  }
-
-  @Test
-  public void testNetworkException() throws IOException {
-    // create an IOException.
-    IOException networkException = new IOException("Network Exception");
-
-    // Assume server returned some abrupt  INTERNAL_SERVER_ERROR exception when it got above
-    // IOException.
-    // The body details are not nullable
-    ResponseBody body =
-        ResponseBody.create(
-            MediaType.parse("application/json" + "; charset=utf-8"), "{\"name\":\"test\"}");
-    Response<?> actualResponse = Response.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), body);
-    assertNotNull(actualResponse);
-    networkException.initCause(new retrofit2.HttpException(actualResponse));
-
-    // Now we try to parse the retrofit2 network exception from the actual response
-    RetrofitException retrofitException = RetrofitException.networkError(networkException);
-    assertNotNull(retrofitException.getCause());
-    String cause = retrofitException.getCause().getMessage();
-    String localizedMessage = retrofitException.getCause().getLocalizedMessage();
-
-    String type = this.getTypeOfNetworkError(cause, localizedMessage);
-    assertEquals(type, "UNKOWN_IOEXCEPTION_WHILE_SERVER_COMMUNICATION");
-
-    Map<String, String> responseBodyMap = retrofitException.getBodyAs(HashMap.class);
-    assertNull(responseBodyMap);
-  }
-
-  private String getTypeOfNetworkError(String cause, String localizedMessage) {
-
-    // use of the message.
-    String type = "UNKOWN_IOEXCEPTION_WHILE_SERVER_COMMUNICATION";
-    String[] array1 = {
-      "Unable to resolve host",
-      "Invalid sequence",
-      "Illegal character",
-      "was not verified",
-      "Connection closed by peer",
-      "host == null",
-      "CertPathValidatorException"
-    };
-    String[] array2 = {"timeout", "timed out", "failed to connect", "was not verified"};
-    if (cause == null && localizedMessage == null) {
-      type = "ERROR_NO_RESPONSE";
-    } else if (Arrays.asList(array1).contains(cause)) {
-      type = "ERROR_UNABLE_TO_RESOLVE_HOST";
-    } else if (cause.contains("Network unavailable")) {
-      type = "ERROR_CONNECTION_OFFLINE";
-    } else if (Arrays.asList(array2).contains(cause)) {
-      type = "ERROR_CONNECTION_TIMEOUT";
-    }
-    return type;
-  }
-
-  @Test
-  public void testOrderOfConverterFactory() throws JsonProcessingException {
-    // Order of adding the converter factories while retrofit2 building is important.
-    // It gives com.fasterxml.jackson.core.io.JsonEOFException if we use a JacksonConverterFactory.
-    // But if we add GsonConverterFactory, it gives a more detailed
-    // com.google.gson.stream.MalformedJsonException.
-    // Retrofit2 parses first with GsonConverterFactory then JacksonConverterFactory.
-
-    // Intentionally remove last 5 characters to make it an invalid json.
-    String invalidContentJsonBodyString = "{\"name\":\"te";
-    Map<String, String> expectedContentBodyMap = new HashMap<>();
-    expectedContentBodyMap.put("name", "test");
-
-    // Create a GsonConverterFactory to parse the json body from the RetrofitException into a
-    // HashMap.
-    List<Converter.Factory> converterFactoryList1 = new ArrayList<>();
-    // Use GsonConverterFactory uses lenient option to allow invalid json strings also.
-    com.google.gson.Gson gson = new GsonBuilder().setLenient().create();
-    converterFactoryList1.add(GsonConverterFactory.create(gson));
-    converterFactoryList1.add(JacksonConverterFactory.create());
-    try {
-      this.testApiServiceForJsonResponse(
-          expectedContentBodyMap, invalidContentJsonBodyString, converterFactoryList1);
-    } catch (Exception exception) {
-      assertTrue(exception.getMessage().contains("com.google.gson.stream.MalformedJsonException"));
-    }
-
-    // Now reverse the order of factories in the list by adding gson after jackson.
-    List<Converter.Factory> converterFactoryList2 = new ArrayList<>();
-    converterFactoryList2.add(JacksonConverterFactory.create());
-    converterFactoryList2.add(GsonConverterFactory.create(gson));
-    try {
-      this.testApiServiceForJsonResponse(
-          expectedContentBodyMap, invalidContentJsonBodyString, converterFactoryList2);
-    } catch (Exception exception) {
-      assertTrue(exception.getMessage().contains("com.fasterxml.jackson.core.io.JsonEOFException"));
     }
   }
 

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
@@ -16,20 +16,31 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.GsonBuilder;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import retrofit2.Call;
+import retrofit2.Converter;
 import retrofit2.Response;
 import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 public class RetrofitExceptionTest {
@@ -78,6 +89,8 @@ public class RetrofitExceptionTest {
                     "{\"name\"=\"test\"}")),
             retrofit2Service);
 
+    // Gives MalformedJsonException or JsonEOFException or IllegalStateException, or
+    // some other exception for json parsing, which is a type of RuntimeException.
     assertThrows(RuntimeException.class, () -> retrofitException.getBodyAs(HashMap.class));
   }
 
@@ -96,5 +109,337 @@ public class RetrofitExceptionTest {
         RetrofitException.unexpectedError(new NullPointerException("np"));
     Map<String, String> responseBody = retrofitException.getBodyAs(HashMap.class);
     assertNull(responseBody);
+  }
+
+  @Test
+  public void test2xxSuccessResponseWithType() {
+    // Test for 200 to 299 responses.
+    Response<String> response = Response.success(responseBodyString);
+    String body = response.body();
+    assertNotNull(body);
+
+    // Assert the response body
+    ResponseBody errorBody = response.errorBody();
+    assertNull(errorBody);
+    assertThrows(
+        NullPointerException.class, () -> RetrofitException.httpError(response, retrofit2Service));
+  }
+
+  @Test
+  public void test2xxSuccessResponseWithWildcard() {
+    // Test for 200 to 299 responses.
+
+    Retrofit retrofit2 =
+        new Retrofit.Builder()
+            .baseUrl("http://localhost:8987/")
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build();
+
+    Response<?> response = Response.success(responseBodyString);
+    assertNotNull(response);
+    String body = (String) response.body();
+    assertNotNull(body);
+
+    // Assert the response body
+    ResponseBody errorBody = response.errorBody();
+    assertNull(errorBody);
+    assertThrows(
+        NullPointerException.class, () -> RetrofitException.httpError(response, retrofit2));
+  }
+
+  @Test
+  public void test401UnauthorizedHttpError() throws Exception {
+    // create simple json body contents
+    Map<String, String> contentBodyMap = new HashMap<>();
+    contentBodyMap.put("timestamp", "123123123123");
+    contentBodyMap.put("message", "Something happened error message");
+    String contentJsonBodyString = new ObjectMapper().writeValueAsString(contentBodyMap);
+
+    this.testApiServiceForJsonResponse(contentBodyMap, contentJsonBodyString);
+  }
+
+  @Test
+  public void testNullBodyContentFor4xxHttpError() throws Exception {
+    final String contentJsonBodyString = null;
+
+    // Test we cannot create a responseBody with null contents
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            ResponseBody.create(
+                MediaType.parse("application/json" + "; charset=utf-8"), contentJsonBodyString));
+  }
+
+  @Test
+  public void testNullResponseBodyFor4xxHttpError() throws Exception {
+
+    // We cannot create a response with null ResponseBody
+    assertThrows(
+        NullPointerException.class, () -> Response.error(HttpStatus.UNAUTHORIZED.value(), null));
+  }
+
+  @Test
+  public void testInvalidJsonResponseBodyFor4xxHttpError() throws Exception {
+    // Create a responseBody with invalid or incomplete Json contents.
+    // It allows the API service call to execute but gives MalformedJsonException
+    // error when reading the body from the retrofitException into the HashMap.
+    String invalidContentJsonBodyString = "{\"name\":\"te";
+    Map<String, String> expectedContentBodyMap = new HashMap<>();
+    expectedContentBodyMap.put("name", "test");
+
+    // verify it throws MalformedJsonException
+    try {
+      this.testApiServiceForJsonResponse(expectedContentBodyMap, invalidContentJsonBodyString);
+    } catch (Exception exception) {
+      assertTrue(exception.getMessage().contains("com.google.gson.stream.MalformedJsonException"));
+    }
+  }
+
+  @Test
+  public void testInvalidJsonListResponseBodyFor4xxHttpError() throws Exception {
+    // Create a responseBody with invalid or incomplete Json or jsonlist contents.
+    // It allows the API service call to execute but gives error when reading the body from the
+    // retrofitException into the HashMap.
+    // But it gives com.fasterxml.jackson.core.io.JsonEOFException if we use a
+    // JacksonConverterFactory.
+    // GsonConverterFactory will give a more detailed com.google.gson.stream.MalformedJsonException.
+    String invalidContentJsonBodyString =
+        "{\"android\": [ {\"ver\":\"1.5\",\"name\":\"Cupcace\",\"api\":\"level3\",\"pic\":\"ba";
+
+    // Use the valid string to create a map from the json list, otherwise it will give
+    // MalformedJsonException here itself.
+    // Added lenient option to allow invalid json strings also
+    com.google.gson.Gson gson = new GsonBuilder().setLenient().create();
+    Map contentBodyMap = gson.fromJson(responseBodyString, Map.class);
+    assertNotNull(contentBodyMap);
+
+    try {
+      this.testApiServiceForJsonResponse(contentBodyMap, invalidContentJsonBodyString);
+    } catch (RuntimeException exception) {
+      // Gives java.lang.MalformedJsonException or some other exception for json parsing, which is a
+      // type of RuntimeException
+      assertTrue(exception.getMessage().contains("com.google.gson.stream.MalformedJsonException"));
+    }
+  }
+
+  @Test
+  public void testByteArrayWithConverterFor4xxHttpError() throws Exception {
+    // Create a responseBody with byte array contents.
+    // It allows the API service call to execute but gives MalformedJsonException
+    // error when reading the body from the retrofitException into the HashMap.
+    byte[] byteArray = {0x12, 0x34, 0x56, 0x78};
+
+    ResponseBody responseBody =
+        ResponseBody.create(MediaType.parse("application/octet-stream"), byteArray);
+    Response<?> actualResponse = Response.error(HttpStatus.UNAUTHORIZED.value(), responseBody);
+    assertNull(actualResponse.body());
+    ResponseBody errorBody = actualResponse.errorBody();
+    assertNotNull(errorBody);
+
+    // add the ByteArrayConverterFactoryTestUtil to convert response body to bytes.
+    Retrofit customRetrofit =
+        new Retrofit.Builder()
+            .baseUrl("http://localhost:8987/")
+            .addConverterFactory(ByteArrayConverterFactoryTestUtil.create())
+            .build();
+
+    // get the retrofit2 http exception from the actual response
+    RetrofitException retrofitException =
+        RetrofitException.httpError(actualResponse, customRetrofit);
+    assertNull(retrofitException.getCause());
+    assertEquals(retrofitException.getMessage(), "401 Response.error()");
+
+    // hashmap for json body
+    // Without the ByteArrayConverterFactoryTestUtil, and with only GsonConverterFactory,
+    // the getBodyAs() will give a com.fasterxml.jackson.core.JsonParseException
+    byte[] actualResponseBodyContent = retrofitException.getBodyAs(byte[].class);
+    assertNotNull(actualResponseBodyContent);
+    assertEquals(actualResponseBodyContent.length, byteArray.length);
+
+    for (int i = 0; i < byteArray.length; i++) {
+      assertEquals(byteArray[i], actualResponseBodyContent[i]);
+    }
+  }
+
+  private void testApiServiceForJsonResponse(Map expectedContentBodyMap, String jsonContentString)
+      throws IOException {
+    // default converter is gson when factory list is null
+    this.testApiServiceForJsonResponse(expectedContentBodyMap, jsonContentString, null);
+  }
+
+  private void testApiServiceForJsonResponse(
+      Map expectedContentBodyMap,
+      String jsonContentString,
+      List<Converter.Factory> converterFactoryList)
+      throws IOException {
+    // Here we have randomly picked 401 - UNAUTHORIZED error.
+    // However, our main intent is to check the RetrofitException behaviour for different response
+    // bodies.
+
+    // validate contents cannot be null, otherwise it gives NullPointerException
+    assertNotNull(jsonContentString);
+
+    String invalidContentJsonBodyString = (String) jsonContentString;
+    // validate contents cannot be null, otherwise it gives NullPointerException
+    ResponseBody responseBody =
+        ResponseBody.create(
+            MediaType.parse("application/json" + "; charset=utf-8"), invalidContentJsonBodyString);
+
+    // validate responseBody cannot be null, otherwise it gives NullPointerException
+    assertNotNull(responseBody);
+
+    Response<?> actualResponse = Response.error(HttpStatus.UNAUTHORIZED.value(), responseBody);
+    assertNotNull(actualResponse);
+
+    // assert response body is null
+    String actualBody = (String) actualResponse.body();
+    assertNull(actualBody);
+
+    // Assert the error body is there
+    ResponseBody errorBody = actualResponse.errorBody();
+    assertNotNull(errorBody);
+
+    // create a builder
+    Retrofit.Builder customRetrofitBuilder =
+        new Retrofit.Builder().baseUrl("http://localhost:8987/");
+
+    // Use default as GsonConverterFactory if not specified,  for json list with lenient option to
+    // allow invalid json strings also
+    if (converterFactoryList == null || converterFactoryList.size() == 0) {
+      com.google.gson.Gson gson = new GsonBuilder().setLenient().create();
+      converterFactoryList = new ArrayList<>();
+      converterFactoryList.add(GsonConverterFactory.create(gson));
+    }
+    // Here, order is important. Retrofit2 first parses with first converter.
+    // If it fails with first converter, then tries to parse with next.
+    for (Converter.Factory factory : converterFactoryList) {
+      customRetrofitBuilder.addConverterFactory(factory);
+    }
+
+    // build the retrofit2.
+    Retrofit customRetrofit = customRetrofitBuilder.build();
+
+    // get the retrofit2 http exception from the actual response
+    RetrofitException retrofitException =
+        RetrofitException.httpError(actualResponse, customRetrofit);
+    assertNull(retrofitException.getCause());
+    assertEquals(retrofitException.getMessage(), "401 Response.error()");
+
+    // validate the body contents in the exception
+    try {
+      // hashmap for json body
+      Map actualResponseBodyContentMap = retrofitException.getBodyAs(HashMap.class);
+
+      assertNotNull(actualResponseBodyContentMap);
+      assertEquals(actualResponseBodyContentMap.size(), expectedContentBodyMap.size());
+
+      // validate data by comparing eg
+      // assertEquals(actualResponseBodyContentMap.get("name"), expectedContentBodyMap.get("test"));
+      for (Object key : expectedContentBodyMap.keySet()) {
+        assertEquals(expectedContentBodyMap.get(key), actualResponseBodyContentMap.get(key));
+      }
+    } catch (RuntimeException exception) {
+      // Gives java.lang.IllegalStateException or some other exception for json parsing, which is a
+      // type of RuntimeException
+      throw exception;
+    }
+  }
+
+  @Test
+  public void testNetworkException() throws IOException {
+    // create an IOException.
+    IOException networkException = new IOException("Network Exception");
+
+    // Assume server returned some abrupt  INTERNAL_SERVER_ERROR exception when it got above
+    // IOException.
+    // The body details are not nullable
+    ResponseBody body =
+        ResponseBody.create(
+            MediaType.parse("application/json" + "; charset=utf-8"), "{\"name\":\"test\"}");
+    Response<?> actualResponse = Response.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), body);
+    assertNotNull(actualResponse);
+    networkException.initCause(new retrofit2.HttpException(actualResponse));
+
+    // Now we try to parse the retrofit2 network exception from the actual response
+    RetrofitException retrofitException = RetrofitException.networkError(networkException);
+    assertNotNull(retrofitException.getCause());
+    String cause = retrofitException.getCause().getMessage();
+    String localizedMessage = retrofitException.getCause().getLocalizedMessage();
+
+    String type = this.getTypeOfNetworkError(cause, localizedMessage);
+    assertEquals(type, "UNKOWN_IOEXCEPTION_WHILE_SERVER_COMMUNICATION");
+
+    Map<String, String> responseBodyMap = retrofitException.getBodyAs(HashMap.class);
+    assertNull(responseBodyMap);
+  }
+
+  private String getTypeOfNetworkError(String cause, String localizedMessage) {
+
+    // use of the message.
+    String type = "UNKOWN_IOEXCEPTION_WHILE_SERVER_COMMUNICATION";
+    String[] array1 = {
+      "Unable to resolve host",
+      "Invalid sequence",
+      "Illegal character",
+      "was not verified",
+      "Connection closed by peer",
+      "host == null",
+      "CertPathValidatorException"
+    };
+    String[] array2 = {"timeout", "timed out", "failed to connect", "was not verified"};
+    if (cause == null && localizedMessage == null) {
+      type = "ERROR_NO_RESPONSE";
+    } else if (Arrays.asList(array1).contains(cause)) {
+      type = "ERROR_UNABLE_TO_RESOLVE_HOST";
+    } else if (cause.contains("Network unavailable")) {
+      type = "ERROR_CONNECTION_OFFLINE";
+    } else if (Arrays.asList(array2).contains(cause)) {
+      type = "ERROR_CONNECTION_TIMEOUT";
+    }
+    return type;
+  }
+
+  @Test
+  public void testOrderOfConverterFactory() throws JsonProcessingException {
+    // Order of adding the converter factories while retrofit2 building is important.
+    // It gives com.fasterxml.jackson.core.io.JsonEOFException if we use a JacksonConverterFactory.
+    // But if we add GsonConverterFactory, it gives a more detailed
+    // com.google.gson.stream.MalformedJsonException.
+    // Retrofit2 parses first with GsonConverterFactory then JacksonConverterFactory.
+
+    // Intentionally remove last 5 characters to make it an invalid json.
+    String invalidContentJsonBodyString = "{\"name\":\"te";
+    Map<String, String> expectedContentBodyMap = new HashMap<>();
+    expectedContentBodyMap.put("name", "test");
+
+    // Create a GsonConverterFactory to parse the json body from the RetrofitException into a
+    // HashMap.
+    List<Converter.Factory> converterFactoryList1 = new ArrayList<>();
+    // Use GsonConverterFactory uses lenient option to allow invalid json strings also.
+    com.google.gson.Gson gson = new GsonBuilder().setLenient().create();
+    converterFactoryList1.add(GsonConverterFactory.create(gson));
+    converterFactoryList1.add(JacksonConverterFactory.create());
+    try {
+      this.testApiServiceForJsonResponse(
+          expectedContentBodyMap, invalidContentJsonBodyString, converterFactoryList1);
+    } catch (Exception exception) {
+      assertTrue(exception.getMessage().contains("com.google.gson.stream.MalformedJsonException"));
+    }
+
+    // Now reverse the order of factories in the list by adding gson after jackson.
+    List<Converter.Factory> converterFactoryList2 = new ArrayList<>();
+    converterFactoryList2.add(JacksonConverterFactory.create());
+    converterFactoryList2.add(GsonConverterFactory.create(gson));
+    try {
+      this.testApiServiceForJsonResponse(
+          expectedContentBodyMap, invalidContentJsonBodyString, converterFactoryList2);
+    } catch (Exception exception) {
+      assertTrue(exception.getMessage().contains("com.fasterxml.jackson.core.io.JsonEOFException"));
+    }
+  }
+
+  interface Retrofit2Service {
+    @retrofit2.http.GET("/retrofit2")
+    Call<String> foo();
   }
 }

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
@@ -22,9 +22,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.GsonBuilder;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -32,12 +39,16 @@ import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.SocketPolicy;
+import org.json.JSONException;
+import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import retrofit2.Call;
+import retrofit2.Response;
 import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 public class SpinnakerRetrofit2ErrorHandleTest {
@@ -48,6 +59,8 @@ public class SpinnakerRetrofit2ErrorHandleTest {
 
   private static String responseBodyString;
 
+  private static okhttp3.OkHttpClient okHttpClient;
+
   @BeforeAll
   public static void setupOnce() throws Exception {
 
@@ -56,14 +69,16 @@ public class SpinnakerRetrofit2ErrorHandleTest {
     responseBodyMap.put("message", "Something happened error message");
     responseBodyString = new ObjectMapper().writeValueAsString(responseBodyMap);
 
+    okHttpClient =
+        new OkHttpClient.Builder()
+            .callTimeout(1, TimeUnit.SECONDS)
+            .connectTimeout(1, TimeUnit.SECONDS)
+            .build();
+
     retrofit2Service =
         new Retrofit.Builder()
             .baseUrl(mockWebServer.url("/").toString())
-            .client(
-                new OkHttpClient.Builder()
-                    .callTimeout(1, TimeUnit.SECONDS)
-                    .connectTimeout(1, TimeUnit.SECONDS)
-                    .build())
+            .client(okHttpClient)
             .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
             .addConverterFactory(JacksonConverterFactory.create())
             .build()
@@ -76,8 +91,10 @@ public class SpinnakerRetrofit2ErrorHandleTest {
   }
 
   @Test
-  public void testRetrofitNotFoundIsNotRetryable() {
-
+  public void testRetrofit404NotFoundIsNotRetryable() {
+    // We check the retryable strategy for 4xx errors.
+    // Test the 404 status code is not retryable.
+    // Let us assume that the server responded with 404-NOT_FOUND.
     mockWebServer.enqueue(
         new MockResponse()
             .setResponseCode(HttpStatus.NOT_FOUND.value())
@@ -89,11 +106,13 @@ public class SpinnakerRetrofit2ErrorHandleTest {
   }
 
   @Test
-  public void testRetrofitBadRequestIsNotRetryable() {
-
+  public void testRetrofit400BadRequestIsNotRetryable() {
+    // We check the retryable strategy for 4xx errors.
+    // Test the 400-BadRequest is not retryable.
+    // Let us assume that the server responded with  400-BAD_REQUEST.
     mockWebServer.enqueue(
         new MockResponse()
-            .setResponseCode(HttpStatus.NOT_FOUND.value())
+            .setResponseCode(HttpStatus.BAD_REQUEST.value())
             .setBody(responseBodyString));
     SpinnakerHttpException spinnakerHttpException =
         assertThrows(SpinnakerHttpException.class, () -> retrofit2Service.getRetrofit2().execute());
@@ -102,8 +121,9 @@ public class SpinnakerRetrofit2ErrorHandleTest {
   }
 
   @Test
-  public void testRetrofitOtherClientErrorHasNullRetryable() {
-
+  public void testRetrofit410ClientErrorHasNullRetryable() {
+    // We check the retryable strategy for 4xx errors. We expect that the retryable can be null.
+    // Test a random 410 - Gone, a CLIENT_ERROR which does not have retryable.
     mockWebServer.enqueue(
         new MockResponse().setResponseCode(HttpStatus.GONE.value()).setBody(responseBodyString));
     SpinnakerHttpException spinnakerHttpException =
@@ -114,19 +134,28 @@ public class SpinnakerRetrofit2ErrorHandleTest {
   @Test
   public void testRetrofitSimpleSpinnakerNetworkException() {
     mockWebServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
-
-    assertThrows(SpinnakerNetworkException.class, () -> retrofit2Service.getRetrofit2().execute());
+    SpinnakerNetworkException exception =
+        assertThrows(
+            SpinnakerNetworkException.class, () -> retrofit2Service.getRetrofit2().execute());
+    String cause = exception.getCause().getMessage();
+    assertNotNull(cause);
+    assertNull(exception.getRetryable());
+    assertTrue(cause.contains("timeout"));
   }
 
   @Test
   public void testRetrofitSimpleSpinnakerServerException() {
     mockWebServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    assertThrows(SpinnakerServerException.class, () -> retrofit2Service.getRetrofit2().execute());
+    SpinnakerServerException exception =
+        assertThrows(
+            SpinnakerServerException.class, () -> retrofit2Service.getRetrofit2().execute());
+    String cause = exception.getCause().getMessage();
+    assertNotNull(cause);
+    assertNull(exception.getRetryable());
   }
 
   @Test
-  public void testResponseHeadersInException() {
-
+  public void testResponseHeadersIn404NotFoundException() {
     // Check response headers are retrievable from a SpinnakerHttpException
     mockWebServer.enqueue(
         new MockResponse()
@@ -137,6 +166,30 @@ public class SpinnakerRetrofit2ErrorHandleTest {
         assertThrows(SpinnakerHttpException.class, () -> retrofit2Service.getRetrofit2().execute());
     assertTrue(spinnakerHttpException.getHeaders().containsKey("Test"));
     assertTrue(spinnakerHttpException.getHeaders().get("Test").contains("true"));
+  }
+
+  @Test
+  public void testResponse401UnauthorizedCode() {
+    // Check response headers are retrievable from 401-UNAUTHORIZED SpinnakerHttpException
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(HttpStatus.UNAUTHORIZED.value())
+            .setBody(responseBodyString)
+            .setHeader("Authorization", "InvalidToken"));
+
+    // make actual API call
+    SpinnakerHttpException exception =
+        assertThrows(SpinnakerHttpException.class, () -> retrofit2Service.getRetrofit2().execute());
+
+    // 401-UNAUTHORIZED is not retryable
+    assertNull(exception.getRetryable());
+
+    // assert the headers
+    assertTrue(exception.getHeaders().containsKey("Authorization"));
+    assertTrue(exception.getHeaders().get("Authorization").contains("InvalidToken"));
+
+    // Assert the expected error code (401)
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), exception.getResponseCode());
   }
 
   @Test
@@ -165,6 +218,179 @@ public class SpinnakerRetrofit2ErrorHandleTest {
         illegalArgumentException.getMessage());
   }
 
+  @Test
+  public void test200ResponseWithValidJson() throws Exception {
+    // create a simple json string
+    String responseBodyString = "{\"name\":\"test\"}";
+    // mock successful response with a simple json string
+    MockResponse mockResponse = new MockResponse().setBody(responseBodyString);
+    mockWebServer.enqueue(mockResponse);
+
+    // execute the custom retrofit service api which returns a map
+    Response<Map<String, Object>> retrofit2Response =
+        retrofit2Service.testCustomApiServiceForJsonResponse().execute();
+
+    // verify successful response
+    Assert.assertTrue(retrofit2Response.isSuccessful());
+    assertNotNull(retrofit2Response.body());
+    assertNull(retrofit2Response.errorBody());
+
+    // validate the response
+    Map<String, Object> retrofitResponseBody = retrofit2Response.body();
+    assertTrue(retrofitResponseBody.get("name").equals("test"));
+  }
+
+  @Test
+  public void test200ResponseWithInvalidJson() throws Exception {
+    // create a simple invalid json string
+    // "{\"name\":\"te";// incomplete json gives com.fasterxml.jackson.core.io.JsonEOFException
+    String responseBodyString =
+        "{\"name\"=\"test\"}"; // com.fasterxml.jackson.core.JsonParseException
+
+    // mock successful response with this invalid json string
+    MockResponse jsonMockResponse = new MockResponse().setBody(responseBodyString);
+    mockWebServer.enqueue(jsonMockResponse);
+
+    Call call = retrofit2Service.testCustomApiServiceForJsonResponse();
+    // verify it throws exception while parsing the body.
+    SpinnakerNetworkException spinnakerNetworkException =
+        assertThrows(SpinnakerNetworkException.class, () -> call.execute());
+    assertNull(spinnakerNetworkException.getRetryable());
+    assertNull(spinnakerNetworkException.getResponseBody());
+    assertNotNull(spinnakerNetworkException.getCause());
+    assertTrue(
+        spinnakerNetworkException
+            .getCause()
+            .toString()
+            .contains("com.fasterxml.jackson.core.JsonParseException"));
+  }
+
+  @Test
+  public void test200ResponseWithValidJsonList() throws Exception {
+    // Actual Test - the quotes on attribute and value are required, else it will give
+    // MalformedJsonException
+    String responseBodyString =
+        "{\"android\": [ {\"ver\":\"1.5\",\"name\":\"Cupcace\",\"api\":\"level3\",\"pic\":\"bane.jpg\"}]}";
+
+    // In retrofit2 we can add multiple converters instead of overriding existing converters.
+    //  Internally, Retrofit parses the response in specified order and proceeds to check next
+    // converter if it fails.
+    // Use GsonConverterFactory for json list with lenient option to allow invalid json strings also
+    com.google.gson.Gson gson = new GsonBuilder().setLenient().create();
+    Retrofit retrofit =
+        new Retrofit.Builder()
+            .baseUrl(mockWebServer.url("/"))
+            .client(okHttpClient)
+            .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
+            .addConverterFactory(JacksonConverterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .build();
+    Retrofit2Service retrofit2Service2 = retrofit.create(Retrofit2Service.class);
+
+    MockResponse jsonMockResponse = new MockResponse().setBody(responseBodyString);
+    mockWebServer.enqueue(jsonMockResponse);
+    Response<Map<String, Object>> jsonRetrofit2Response =
+        retrofit2Service2.testCustomApiServiceForJsonResponse().execute();
+    Assert.assertTrue(jsonRetrofit2Response.isSuccessful());
+    assertNotNull(jsonRetrofit2Response.body());
+    assertNull(jsonRetrofit2Response.errorBody());
+  }
+
+  @Test
+  void test200ResponseWithValidByteArray() throws Exception {
+    // To test byte[] response we have to create the custom converter to convert the ResponseBody to
+    // a byte[]:
+    Retrofit retrofit =
+        new Retrofit.Builder()
+            .baseUrl(mockWebServer.url("/"))
+            .client(okHttpClient)
+            .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
+            .addConverterFactory(ByteArrayConverterFactoryTestUtil.create())
+            .build();
+    Retrofit2Service retrofit2Service2 = retrofit.create(Retrofit2Service.class);
+
+    // create a mock response with byte string
+    byte[] byteArray = {0x12, 0x34, 0x56, 0x78};
+    String byteBodyString = new String(byteArray, StandardCharsets.UTF_8);
+    MockResponse byteMockResponse = new MockResponse().setBody(byteBodyString);
+    mockWebServer.enqueue(byteMockResponse);
+
+    // execute the retrofit2 API service call
+    Response<byte[]> byteRetrofit2Response =
+        retrofit2Service2.testCustomApiServiceForByteResponse().execute();
+
+    // check the retrofit2 response
+    Assert.assertTrue(byteRetrofit2Response.isSuccessful());
+    assertNotNull(byteRetrofit2Response.body());
+    assertNull(byteRetrofit2Response.errorBody());
+
+    // validate the data from retrofit2 response
+    byte[] responseBodyByteArray = byteRetrofit2Response.body();
+    assertEquals(byteArray.length, responseBodyByteArray.length);
+    for (int i = 0; i < byteArray.length; i++) {
+      assertEquals(byteArray[i], responseBodyByteArray[i]);
+    }
+  }
+
+  private Retrofit getMockRetrofit() {
+    // mock the retrofit2.Retrofit class  without values
+    Retrofit mockretrofit = mock(Retrofit.class);
+
+    // mock the Retrofit builder behavior
+    Retrofit.Builder b = mock(Retrofit.Builder.class);
+    when(b.baseUrl(mockWebServer.url("/"))).thenReturn(b);
+    when(b.client(okHttpClient)).thenReturn(b);
+    when(b.addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance()))
+        .thenReturn(b);
+    when(b.build()).thenReturn(mockretrofit);
+    return mockretrofit;
+  }
+
+  @Test
+  void test200ResponseWithNullBody() throws IOException, JSONException {
+
+    // We have to mock Retrofit, Retrofit2Service and Call<String> to test this scenario.
+    // This is because when(mockObjectOnly).then(any()) is mandatory, means when() uses only a
+    // mockObject.
+
+    Retrofit mockretrofit = getMockRetrofit();
+    Retrofit2Service mockRetrofit2Service = getMockRetrofit2Service(mockretrofit);
+    Call<String> mockCall = getMockRetrofit2Call(mockRetrofit2Service);
+
+    // Finally mock the behavior of the mockCall.execute() behavior.
+    // Response.success(null) simulates a successful response with a null body
+    when(mockCall.execute()).thenReturn(Response.success(null));
+
+    // execute the retrofit2 API service call
+    Call<String> call = mockRetrofit2Service.getRetrofit2();
+    Response<String> retrofitResponse = call.execute();
+
+    // check that both the response body and error body are null
+    Assert.assertTrue(retrofitResponse.isSuccessful());
+    assertNull(retrofitResponse.body());
+    assertNull(retrofitResponse.errorBody());
+
+    // Verify that the network call was executed
+    verify(mockRetrofit2Service.getRetrofit2(), times(1)).execute();
+  }
+
+  private Call<String> getMockRetrofit2Call(Retrofit2Service mockRetrofit2Service) {
+    // mock the Call<String> class without values
+    Call<String> mockCall = mock(Call.class);
+    // mock the  mockRetrofit2Service.getRetrofit2() network call behavior.
+    when(mockRetrofit2Service.getRetrofit2()).thenReturn(mockCall);
+    return mockCall;
+  }
+
+  private Retrofit2Service getMockRetrofit2Service(Retrofit mockretrofit) {
+    // mock the Retrofit2Service class without values
+    Retrofit2Service mockRetrofit2Service = mock(Retrofit2Service.class);
+    // mock the method behavior mockRetrofit2Service.create() behavior
+    when(mockretrofit.create(Retrofit2Service.class)).thenReturn(mockRetrofit2Service);
+
+    return mockRetrofit2Service;
+  }
+
   interface Retrofit2Service {
     @retrofit2.http.GET("/retrofit2")
     Call<String> getRetrofit2();
@@ -174,6 +400,15 @@ public class SpinnakerRetrofit2ErrorHandleTest {
 
     @retrofit2.http.GET("/retrofit2/wrongReturnType")
     DummyWithExecute testWrongReturnType();
+
+    // Add the API service method to test for a successful 200-OK byte array retrofit2 response
+    @retrofit2.http.GET("/retrofit2/testByteArray")
+    Call<byte[]> testCustomApiServiceForByteResponse();
+
+    // Add the API service method to test for a successful 200-OK json/gson/jsonlist retrofit2
+    // response
+    @retrofit2.http.GET("/retrofit2/jsonresponse")
+    Call<Map<String, Object>> testCustomApiServiceForJsonResponse();
   }
 
   interface DummyWithExecute {


### PR DESCRIPTION
add the getErrorBodyAs() method to SpinnakerServerException which returns the error response body as Map to handle the exception.