### PR TITLE
feat(doNoEval): default doNotEval SPeL expression to On

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlinVersion=1.4.32
 org.gradle.parallel=true
-spinnakerGradleVersion=8.25.0
+spinnakerGradleVersion=8.26.0
 targetJava11=true
 includeRuntimes=actuator,core,eureka,retrofit,secrets-aws,secrets-gcp,stackdriver,swagger,tomcat,web

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.kork.expressions.config;
 
 import lombok.Data;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
@@ -26,12 +27,8 @@ public class ExpressionProperties {
   private final FeatureFlag doNotEvalSpel = new FeatureFlag().setEnabled(true);
 
   @Data
+  @Accessors(chain = true)
   public static class FeatureFlag {
     private boolean enabled;
-
-    public FeatureFlag setEnabled(boolean enabled) {
-      this.enabled = enabled;
-      return this;
-    }
   }
 }

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
@@ -27,6 +27,6 @@ public class ExpressionProperties {
 
   @Data
   public static class FeatureFlag {
-    private boolean enabled;
+    private boolean enabled = true;
   }
 }

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
@@ -25,8 +25,13 @@ public class ExpressionProperties {
 
   private final FeatureFlag doNotEvalSpel = new FeatureFlag();
 
+  public FeatureFlag getDoNotEvalSpel() {
+    doNotEvalSpel.setEnabled(true);
+    return doNotEvalSpel;
+  }
+
   @Data
   public static class FeatureFlag {
-    private boolean enabled = true;
+    private boolean enabled;
   }
 }

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
@@ -23,15 +23,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "expression")
 public class ExpressionProperties {
 
-  private final FeatureFlag doNotEvalSpel = new FeatureFlag();
-
-  public FeatureFlag getDoNotEvalSpel() {
-    doNotEvalSpel.setEnabled(true);
-    return doNotEvalSpel;
-  }
+  private final FeatureFlag doNotEvalSpel = new FeatureFlag().setEnabled(true);
 
   @Data
   public static class FeatureFlag {
     private boolean enabled;
+
+    public FeatureFlag setEnabled(boolean enabled) {
+      this.enabled = enabled;
+      return this;
+    }
   }
 }


### PR DESCRIPTION
Enabling “doNotEval” SPeL expression by default. This feature is disabled only when the flag is set explicitly to false.

The "doNotEval" SpEL helper makes it possible to skip SpEL evaluation in other SpEL helpers e.g. toJson as it is described in 
[Next release preview](https://spinnaker.io/docs/releases/next-release-preview/#donoteval-spel-helper) documentation. 

One reason is that a SpEL expression failure appears while using Terraformer to serialize data from a Terraform Plan execution.  The execution creates a JSON object instead of a JSON string.
The cause is that the SpEL processor in Spinnaker throws a null value if the SpEL expression has ${ in it, and is visible in Spinnaker's code [here](https://github.com/spinnaker/kork/blob/d895e2b820baadc0986dd4451e7b18f030a9a865/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupport.java#L198)

Also, if the users are using an older Terraform version (<= 0.12), then it is also using the template provider from Terraform.
The template provider exposes data sources to use templates to generate strings for other Terraform resources or outputs.

❗️ HashiCorp has deprecated the template provider since v0.12 the announcement is [here](https://registry.terraform.io/providers/hashicorp/template/latest/docs)

Users should use the [template file](https://www.terraform.io/language/functions/templatefile?_ga=2.68579986.223689003.1655389310-554336950.1655389310) function instead

Relates to: [BOB-30735](https://armory.atlassian.net/browse/BOB-30735)