### PR TITLE
feat(doNoEval): Default the “doNotEval” SPeL expression to ON

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
@@ -17,15 +17,17 @@
 package com.netflix.spinnaker.kork.expressions.config;
 
 import lombok.Data;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties(prefix = "expression")
 public class ExpressionProperties {
 
-  private final FeatureFlag doNotEvalSpel = new FeatureFlag();
+  private final FeatureFlag doNotEvalSpel = new FeatureFlag().setEnabled(true);
 
   @Data
+  @Accessors(chain = true)
   public static class FeatureFlag {
     private boolean enabled;
   }


### PR DESCRIPTION
Enabling “doNotEval” SPeL expression by default. This feature is disabled only when the flag is set explicitly to false.

Context reference ->  PR[ #1028](https://github.com/spinnaker/kork/pull/1028)