### PR TITLE
chore(gha): replace deprecated set-output commands with environment files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           . .github/workflows/release_info.sh ${{ github.event.repository.full_name }}
-          echo ::set-output name=CHANGELOG::$(echo -e "${CHANGELOG}")
-          echo ::set-output name=SKIP_RELEASE::${SKIP_RELEASE}
-          echo ::set-output name=IS_CANDIDATE::${IS_CANDIDATE}
-          echo ::set-output name=RELEASE_VERSION::${RELEASE_VERSION}
+          echo CHANGELOG=$(echo -e "${CHANGELOG}") >> $GITHUB_OUTPUT
+          echo SKIP_RELEASE="${SKIP_RELEASE}" >> $GITHUB_OUTPUT
+          echo IS_CANDIDATE="${IS_CANDIDATE}" >> $GITHUB_OUTPUT
+          echo RELEASE_VERSION="${RELEASE_VERSION}" >> $GITHUB_OUTPUT
       - name: Release build
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.release_info.outputs.RELEASE_VERSION }}


### PR DESCRIPTION
to avoid warning messages like

Run echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/} Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/