### PR TITLE
fix(web): com.squareup.okhttp3:logging-interceptor is an api dependency

### DIFF
--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -21,10 +21,10 @@ dependencies {
   api "com.netflix.spectator:spectator-api"
   api "com.fasterxml.jackson.core:jackson-annotations"
   api "com.squareup.okhttp:okhttp"
+  api "com.squareup.okhttp3:logging-interceptor"
   api "com.squareup.okhttp3:okhttp"
   api "com.squareup.retrofit:retrofit"
 
-  implementation "com.squareup.okhttp3:logging-interceptor"
   implementation "com.google.guava:guava"
   implementation "javax.inject:javax.inject:1"
   implementation("com.netflix.spectator:spectator-web-spring") {


### PR DESCRIPTION
now that https://github.com/spinnaker/kork/pull/1004 introduced a HttpLoggingInterceptor.Level bean in kork-web's RetrofitConfiguration class.

This fixes failures like https://github.com/spinnaker/orca/actions/runs/4598191534/jobs/8121901031?pr=4442 and https://github.com/spinnaker/gate/actions/runs/4598187183/jobs/8121890373?pr=1647