### PR TITLE
fix(saml): revert esapi library change

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -239,9 +239,5 @@ dependencies {
       because "1.9.15 is resolved transitively through Groovy, removes CVE-2021-36374, CVE-2021-36373, CVE-2020-11979, CVE-2020-15250"
     }
 
-    api('org.owasp.esapi:esapi:2.3.0.0') {
-      because '2.1.0.1 is resolved transitively through spring-security-saml-dsl-core, removes CVE-2022-23457'
-    }
-
   }
 }


### PR DESCRIPTION
See: https://github.com/ESAPI/esapi-java-legacy/issues/567
and
https://github.com/spinnaker/kork/pull/1020#issuecomment-1495005465

ESAPI on newer releases removed a class that opensaml referenced in a hard coded manner.  We need to bump opensaml to a later release & do a LOT more validation.