### PR TITLE
feat(retrofit): add utility methods for improved exception handler (#82)

### DIFF
--- a/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/SpinnakerException.java
+++ b/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/exceptions/SpinnakerException.java
@@ -77,4 +77,29 @@ public class SpinnakerException extends RuntimeException implements HasAdditiona
       String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);
   }
+
+  /**
+   * Creates a new instance of the exception, but with a new message.
+   *
+   * <p>This method in and of itself is not really useful (using something like new
+   * SpinnakerException(message, e) would work). However, it becomes useful when all other child
+   * classes of SpinnakerException override it.
+   *
+   * <p>This allows a caller to use a generic catch statement to update the message, all in one
+   * line, i.e
+   *
+   * <pre>
+   *   catch (SpinnakerException e) {
+   *    // if the child class has a newInstance override, the return type will stay
+   *    // the type of the child class
+   *    return e.newInstance("new message");
+   *   }
+   * </pre>
+   *
+   * @param message
+   * @return
+   */
+  public SpinnakerException newInstance(String message) {
+    return new SpinnakerException(message, this);
+  }
 }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -121,4 +121,9 @@ public class SpinnakerHttpException extends SpinnakerServerException {
           response.getStatus(), response.getUrl(), getRawMessage());
     }
   }
+
+  @Override
+  public SpinnakerHttpException newInstance(String message) {
+    return new SpinnakerHttpException(message, this);
+  }
 }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
@@ -29,4 +29,13 @@ public final class SpinnakerNetworkException extends SpinnakerServerException {
   public SpinnakerNetworkException(RetrofitException e) {
     super(e);
   }
+
+  public SpinnakerNetworkException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  @Override
+  public SpinnakerNetworkException newInstance(String message) {
+    return new SpinnakerNetworkException(message, this);
+  }
 }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -97,4 +97,9 @@ public class SpinnakerServerException extends SpinnakerException {
       this.message = message;
     }
   }
+
+  @Override
+  public SpinnakerServerException newInstance(String message) {
+    return new SpinnakerServerException(message, this);
+  }
 }

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -173,6 +174,26 @@ public class SpinnakerRetrofitErrorHandlerTest {
     SpinnakerRetrofitErrorHandler handler = SpinnakerRetrofitErrorHandler.getInstance();
     Throwable throwable = handler.handleError(retrofitError);
     Assert.assertEquals(message, throwable.getMessage());
+  }
+
+  @Test
+  public void testChainSpinnakerException_SpinnakerNetworkException() {
+    SpinnakerRetrofitErrorHandler handler = SpinnakerRetrofitErrorHandler.getInstance();
+
+    String originalMessage = "original message";
+    String newMessage = "new message";
+
+    IOException originalException = new IOException(originalMessage);
+    RetrofitError retrofitError = RetrofitError.networkError("http://localhost", originalException);
+
+    Throwable newException =
+        handler.handleError(
+            retrofitError,
+            (exception) -> String.format("%s: %s", newMessage, exception.getMessage()));
+
+    assertTrue(newException instanceof SpinnakerNetworkException);
+    assertEquals("new message: original message", newException.getMessage());
+    assertEquals(originalMessage, newException.getCause().getMessage());
   }
 
   interface RetrofitService {

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+public class SpinnakerServerExceptionTest {
+  private static final String CUSTOM_MESSAGE = "custom message";
+
+  @Test
+  public void testSpinnakerHttpException_NewInstance() {
+    Response response = new Response("http://localhost", 200, "reason", List.of(), null);
+    try {
+      RetrofitError error = RetrofitError.httpError("http://localhost", response, null, null);
+      throw new SpinnakerHttpException(error);
+    } catch (SpinnakerException e) {
+      SpinnakerException newException = e.newInstance(CUSTOM_MESSAGE);
+
+      assertTrue(newException instanceof SpinnakerHttpException);
+      assertEquals(CUSTOM_MESSAGE, newException.getMessage());
+      assertEquals(e, newException.getCause());
+      assertEquals(response.getStatus(), ((SpinnakerHttpException) newException).getResponseCode());
+    }
+  }
+
+  @Test
+  public void testSpinnakerNetworkException_NewInstance() {
+    IOException initialException = new IOException("message");
+    try {
+      RetrofitError error = RetrofitError.networkError("http://localhost", initialException);
+      throw new SpinnakerNetworkException(error);
+    } catch (SpinnakerException e) {
+      SpinnakerException newException = e.newInstance(CUSTOM_MESSAGE);
+
+      assertTrue(newException instanceof SpinnakerNetworkException);
+      assertEquals(CUSTOM_MESSAGE, newException.getMessage());
+      assertEquals(e, newException.getCause());
+    }
+  }
+
+  @Test
+  public void testSpinnakerServerException_NewInstance() {
+    Throwable cause = new Throwable("message");
+    try {
+      RetrofitError error = RetrofitError.unexpectedError("http://localhost", cause);
+      throw new SpinnakerServerException(error);
+    } catch (SpinnakerException e) {
+      SpinnakerException newException = e.newInstance(CUSTOM_MESSAGE);
+
+      assertTrue(newException instanceof SpinnakerServerException);
+      assertEquals(CUSTOM_MESSAGE, newException.getMessage());
+      assertEquals(e, newException.getCause());
+    }
+  }
+}


### PR DESCRIPTION
Adding utility methods on the SpinnakerRetrofitErrorHandler, as well as the SpinnakerException and all exceptions that inherit from SpinnakerException. These methods make it easier to add custom messages when dealing with SpinnakerExceptions