### PR TITLE
refactor(retrofit): change method name in RetrofitException class from : getErrorBodyAs() to: getBodyAs()

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
@@ -74,7 +74,7 @@ public class RetrofitException extends RuntimeException {
    * @throws RuntimeException wrapping the underlying IOException if unable to convert the body to
    *     the specified {@code type}.
    */
-  public <T> T getErrorBodyAs(Class<T> type) {
+  public <T> T getBodyAs(Class<T> type) {
     if (response == null) {
       return null;
     }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -50,8 +50,7 @@ public class SpinnakerServerException extends SpinnakerException {
 
   public SpinnakerServerException(RetrofitException e) {
     super(e.getCause());
-    RetrofitErrorResponseBody body =
-        (RetrofitErrorResponseBody) e.getErrorBodyAs(RetrofitErrorResponseBody.class);
+    RetrofitErrorResponseBody body = e.getBodyAs(RetrofitErrorResponseBody.class);
     this.rawMessage =
         Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse(e.getMessage());
   }

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
@@ -35,6 +35,8 @@ public class RetrofitExceptionTest {
 
   private final String validJsonResponseBodyString = "{\"name\":\"test\"}";
 
+  private final String invalidJsonResponseBodyString = "{\"name\":\"test\""; // missing "}" at end.
+
   @BeforeAll
   public static void setupOnce() {
     retrofit2Service =
@@ -63,6 +65,23 @@ public class RetrofitExceptionTest {
   public void testUnexpectedErrorHasNoResponseErrorBody() {
     Throwable cause = new Throwable("custom message");
     RetrofitException retrofitException = RetrofitException.unexpectedError(cause);
-    assertNull(retrofitException.getErrorBodyAs(HashMap.class));
+    assertNull(retrofitException.getBodyAs(HashMap.class));
+  }
+
+  @Test
+  public void testSpinnakerHttpExceptionExpectsValidJsonErrorBody() {
+    ResponseBody responseBody =
+        ResponseBody.create(
+            MediaType.parse("application/json" + "; charset=utf-8"), invalidJsonResponseBodyString);
+    Response response = Response.error(HttpStatus.NOT_FOUND.value(), responseBody);
+
+    RetrofitException retrofitException = RetrofitException.httpError(response, retrofit2Service);
+    /*
+    TODO :
+     handling of below RuntimeException:
+    assertThrows(RuntimeException.class, () -> retrofitException.getBodyAs(HashMap.class));
+    assertThrows(RuntimeException.class, () -> new SpinnakerHttpException(RetrofitException));
+    */
+    assertThrows(RuntimeException.class, () -> retrofitException.getBodyAs(HashMap.class));
   }
 }


### PR DESCRIPTION
refactor/test(retrofit): change method name in RetrofitException class from : getErrorBodyAs() to: getBodyAs()

Added a test to verify that if response does not contain a valid json errorBody, RetrofitException::getBodyAs() throws a RuntimeException