### PR TITLE
chore(preview): remove preview feature of version ordering (VERSION_ORDERING_V2) for gradle dependencies

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -23,8 +23,6 @@ if (spinnakerGradleVersion.endsWith('-SNAPSHOT')) {
   }
 }
 
-enableFeaturePreview("VERSION_ORDERING_V2")
-
 include(
   "spinnaker-dependencies",
   "kork-actuator",


### PR DESCRIPTION
With gradle 6.x, used [feature preview API](https://docs.gradle.org/7.6.1/userguide/feature_lifecycle.html#feature_preview) to take advantage of [improvised dependency version ordering](https://docs.gradle.org/6.5/release-notes.html#improved-dependency-version-ordering). This feature is made public for gradle 7.x. So, removing it from settings.gradle as we moved to gradle 7.6.1.