### PR TITLE
refactor(retrofit): Move rawMessage and response body map to SpinnakerHttpException

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -16,13 +16,8 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
-import java.util.Optional;
-import lombok.Getter;
 import retrofit.RetrofitError;
 
 /** An exception that exposes the message of a {@link RetrofitError}, or a custom message. */
@@ -30,30 +25,16 @@ import retrofit.RetrofitError;
 public class SpinnakerServerException extends SpinnakerException {
 
   /**
-   * A message derived from a RetrofitError's response body, or null if a custom message has been
-   * provided.
-   */
-  private final String rawMessage;
-
-  /**
-   * Parses the message from the {@link RetrofitErrorResponseBody} of a {@link RetrofitError}.
+   * Parses the message from the {@link RetrofitError}.
    *
    * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
    */
   public SpinnakerServerException(RetrofitError e) {
-    super(e.getCause());
-    RetrofitErrorResponseBody body =
-        (RetrofitErrorResponseBody) e.getBodyAs(RetrofitErrorResponseBody.class);
-    this.rawMessage =
-        Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse(e.getMessage());
+    super(e.getMessage(), e.getCause());
   }
 
   public SpinnakerServerException(RetrofitException e) {
-    super(e.getCause());
-    RetrofitErrorResponseBody body =
-        (RetrofitErrorResponseBody) e.getErrorBodyAs(RetrofitErrorResponseBody.class);
-    this.rawMessage =
-        Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse(e.getMessage());
+    super(e.getMessage(), e.getCause());
   }
 
   /**
@@ -67,35 +48,6 @@ public class SpinnakerServerException extends SpinnakerException {
    */
   public SpinnakerServerException(String message, Throwable cause) {
     super(message, cause);
-    rawMessage = null;
-  }
-
-  @Override
-  public String getMessage() {
-    if (rawMessage == null) {
-      return super.getMessage();
-    }
-    return rawMessage;
-  }
-
-  final String getRawMessage() {
-    return rawMessage;
-  }
-
-  @Getter
-  // Use JsonIgnoreProperties because some responses contain properties that
-  // cannot be mapped to the RetrofitErrorResponseBody class.  If the default
-  // JacksonConverter (with no extra configurations) is used to deserialize the
-  // response body and properties other than "message" exist in the JSON
-  // response, there will be an UnrecognizedPropertyException.
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  private static final class RetrofitErrorResponseBody {
-    private final String message;
-
-    @JsonCreator
-    RetrofitErrorResponseBody(@JsonProperty("message") String message) {
-      this.message = message;
-    }
   }
 
   @Override


### PR DESCRIPTION
refactor(retrofit): Move rawMessage and response body map to SpinnakerHttpException as network / unexpected do not have a json response body

The ErrorHandlingExecutorCallAdapterFactory::execute() does not return/add a retrofit2 Response body if either of:
* network error like IOException(SpinnakerNetworkException) during server communication occurs or
* unexpected error like RuntimeException(SpinnakerServerException) while creating/decoding the request/response is thrown