### PR TITLE
refactor/test(retrofit): store parsed error body as Map for SpinnakerHttpException

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.kork.retrofit.exceptions;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.Objects;
+import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 import retrofit2.Converter;
 import retrofit2.Response;
@@ -83,7 +84,20 @@ public class RetrofitException extends RuntimeException {
     try {
       return converter.convert(response.errorBody());
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      String jsonErrorMessage =
+          "{\"message\":\"" + response.code() + " " + "Failed to parse response\"}";
+      ResponseBody responseBody = getResponseBody(jsonErrorMessage);
+      try {
+        return converter.convert(responseBody);
+      } catch (IOException ex) {
+        // control is never expected to come to this block.
+        throw new RuntimeException(ex);
+      }
     }
+  }
+
+  private ResponseBody getResponseBody(String jsonErrorMessage) {
+    return ResponseBody.create(
+        MediaType.parse("application/json" + "; charset=utf-8"), jsonErrorMessage);
   }
 }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -16,13 +16,8 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
-import java.util.Optional;
-import lombok.Getter;
 import retrofit.RetrofitError;
 
 /** An exception that exposes the message of a {@link RetrofitError}, or a custom message. */
@@ -30,30 +25,16 @@ import retrofit.RetrofitError;
 public class SpinnakerServerException extends SpinnakerException {
 
   /**
-   * A message derived from a RetrofitError's response body, or null if a custom message has been
-   * provided.
-   */
-  private final String rawMessage;
-
-  /**
-   * Parses the message from the {@link RetrofitErrorResponseBody} of a {@link RetrofitError}.
+   * Parses the message from the hashMap of a {@link RetrofitError}.
    *
    * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
    */
   public SpinnakerServerException(RetrofitError e) {
-    super(e.getCause());
-    RetrofitErrorResponseBody body =
-        (RetrofitErrorResponseBody) e.getBodyAs(RetrofitErrorResponseBody.class);
-    this.rawMessage =
-        Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse(e.getMessage());
+    super(e.getMessage(), e.getCause());
   }
 
   public SpinnakerServerException(RetrofitException e) {
-    super(e.getCause());
-    RetrofitErrorResponseBody body =
-        (RetrofitErrorResponseBody) e.getErrorBodyAs(RetrofitErrorResponseBody.class);
-    this.rawMessage =
-        Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse(e.getMessage());
+    super(e.getMessage(), e.getCause());
   }
 
   /**
@@ -67,35 +48,6 @@ public class SpinnakerServerException extends SpinnakerException {
    */
   public SpinnakerServerException(String message, Throwable cause) {
     super(message, cause);
-    rawMessage = null;
-  }
-
-  @Override
-  public String getMessage() {
-    if (rawMessage == null) {
-      return super.getMessage();
-    }
-    return rawMessage;
-  }
-
-  final String getRawMessage() {
-    return rawMessage;
-  }
-
-  @Getter
-  // Use JsonIgnoreProperties because some responses contain properties that
-  // cannot be mapped to the RetrofitErrorResponseBody class.  If the default
-  // JacksonConverter (with no extra configurations) is used to deserialize the
-  // response body and properties other than "message" exist in the JSON
-  // response, there will be an UnrecognizedPropertyException.
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  private static final class RetrofitErrorResponseBody {
-    private final String message;
-
-    @JsonCreator
-    RetrofitErrorResponseBody(@JsonProperty("message") String message) {
-      this.message = message;
-    }
   }
 
   @Override


### PR DESCRIPTION
refactor/test(retrofit): store parsed error body as Map for SpinnakerHttpException changes include:
* Remove RetrofitErrorResponseBody and call e.getBodyAs / e.getErrorBodyAs with HashMap.class 
* Move rawMessage and response body map to SpinnakerHttpException as network / unexpected do not have a json response body
* Check that SpinnakerHttpException with invalid json error body returns a valid error message instead of RuntimeException 