### PR TITLE
fix(tests): apply groovy plugin for groovy based kork-moniker tests

### DIFF
--- a/kork-moniker/kork-moniker.gradle
+++ b/kork-moniker/kork-moniker.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+apply plugin:"groovy"
 
 dependencies {
   api(platform(project(":spinnaker-dependencies")))


### PR DESCRIPTION
While running test task with kork-moniker, groovy based tests are not detected and executed. To fix this, applying the groovy plugin in kork-moniker.gradle for detection and execution of groovy based tests. After fix, overall test executions increased from 539 to 584.