### PR TITLE
refactor(retrofit): remove retrofit-related constructors from SpinnakerServerException

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/ErrorHandlingExecutorCallAdapterFactory.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/ErrorHandlingExecutorCallAdapterFactory.java
@@ -153,9 +153,9 @@ public class ErrorHandlingExecutorCallAdapterFactory extends CallAdapter.Factory
           return syncResp;
         }
       } catch (IOException e) {
-        throw new SpinnakerNetworkException(RetrofitException.networkError(e));
+        throw new SpinnakerNetworkException(e);
       } catch (Exception e) {
-        throw new SpinnakerServerException(RetrofitException.unexpectedError(e));
+        throw new SpinnakerServerException(e);
       }
       throw createSpinnakerHttpException(syncResp);
     }
@@ -260,11 +260,11 @@ public class ErrorHandlingExecutorCallAdapterFactory extends CallAdapter.Factory
 
       SpinnakerServerException exception;
       if (t instanceof IOException) {
-        exception = new SpinnakerNetworkException(RetrofitException.networkError((IOException) t));
+        exception = new SpinnakerNetworkException(t);
       } else if (t instanceof SpinnakerHttpException) {
         exception = (SpinnakerHttpException) t;
       } else {
-        exception = new SpinnakerServerException(RetrofitException.unexpectedError(t));
+        exception = new SpinnakerServerException(t);
       }
       final SpinnakerServerException finalException = exception;
       callbackExecutor.execute(

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2SyncCall.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2SyncCall.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.kork.retrofit;
 
-import com.netflix.spinnaker.kork.retrofit.exceptions.RetrofitException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerNetworkException;
 import java.io.IOException;
 import retrofit2.Call;
@@ -34,7 +33,7 @@ public class Retrofit2SyncCall<T> {
     try {
       return call.execute().body();
     } catch (IOException e) {
-      throw new SpinnakerNetworkException(RetrofitException.networkError(e));
+      throw new SpinnakerNetworkException(e);
     }
   }
 }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitException.java
@@ -33,15 +33,7 @@ import retrofit2.Retrofit;
 public class RetrofitException extends RuntimeException {
   public static RetrofitException httpError(Response response, Retrofit retrofit) {
     String message = response.code() + " " + response.message();
-    return new RetrofitException(message, response, null, retrofit);
-  }
-
-  public static RetrofitException networkError(IOException exception) {
-    return new RetrofitException(exception.getMessage(), null, exception, null);
-  }
-
-  public static RetrofitException unexpectedError(Throwable exception) {
-    return new RetrofitException(exception.getMessage(), null, exception, null);
+    return new RetrofitException(message, response, retrofit);
   }
 
   /** Response from server, which contains causes for the failure */
@@ -53,8 +45,9 @@ public class RetrofitException extends RuntimeException {
    */
   private final Retrofit retrofit;
 
-  RetrofitException(String message, Response response, Throwable exception, Retrofit retrofit) {
-    super(message, exception);
+  RetrofitException(String message, Response response, Retrofit retrofit) {
+    super(message);
+
     this.response = response;
     if (response != null) {
       // Fail fast instead of checking for null in e.g. getErrorBodyAs.

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
@@ -22,12 +22,8 @@ import retrofit.RetrofitError;
 /** Wraps an exception of kind {@link RetrofitError.Kind} NETWORK. */
 @NonnullByDefault
 public final class SpinnakerNetworkException extends SpinnakerServerException {
-  public SpinnakerNetworkException(RetrofitError e) {
-    super(e);
-  }
-
-  public SpinnakerNetworkException(RetrofitException e) {
-    super(e);
+  public SpinnakerNetworkException(Throwable cause) {
+    super(cause);
   }
 
   public SpinnakerNetworkException(String message, Throwable cause) {

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandler.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandler.java
@@ -59,9 +59,9 @@ public final class SpinnakerRetrofitErrorHandler implements ErrorHandler {
         }
         return retval;
       case NETWORK:
-        return new SpinnakerNetworkException(e);
+        return new SpinnakerNetworkException(e.getMessage(), e.getCause());
       default:
-        return new SpinnakerServerException(e);
+        return new SpinnakerServerException(e.getMessage(), e.getCause());
     }
   }
 

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -18,36 +18,17 @@ package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
-import retrofit.RetrofitError;
 
-/** An exception that exposes the message of a {@link RetrofitError}, or a custom message. */
+/** Represents an error while attempting to execute a retrofit http client request. */
 @NonnullByDefault
 public class SpinnakerServerException extends SpinnakerException {
 
-  /**
-   * Parses the message from the {@link RetrofitError}.
-   *
-   * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
-   */
-  public SpinnakerServerException(RetrofitError e) {
-    super(e.getMessage(), e.getCause());
-  }
-
-  public SpinnakerServerException(RetrofitException e) {
-    super(e.getMessage(), e.getCause());
-  }
-
-  /**
-   * Construct a SpinnakerServerException with a specified message, instead of deriving one from a
-   * response body.
-   *
-   * @param message the message
-   * @param cause the cause. Note that this is required (i.e. can't be null) since in the absence of
-   *     a cause or a RetrofitError that provides the cause, SpinnakerServerException is likely not
-   *     the appropriate exception class to use.
-   */
   public SpinnakerServerException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  public SpinnakerServerException(Throwable cause) {
+    super(cause);
   }
 
   @Override

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/RetrofitExceptionTest.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.kork.retrofit.exceptions;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.HashMap;
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 import org.junit.jupiter.api.BeforeAll;
@@ -57,12 +56,5 @@ public class RetrofitExceptionTest {
 
     assertThrows(
         NullPointerException.class, () -> RetrofitException.httpError(response, retrofit2Service));
-  }
-
-  @Test
-  public void testUnexpectedErrorHasNoResponseErrorBody() {
-    Throwable cause = new Throwable("custom message");
-    RetrofitException retrofitException = RetrofitException.unexpectedError(cause);
-    assertNull(retrofitException.getErrorBodyAs(HashMap.class));
   }
 }


### PR DESCRIPTION
since it isn't using any retrofit-specific information from them.  This also removes the
potential to pass an http exception (e.g. a return value from RetrofitError.httpError) to
a SpinnakerServerException constructor, instead of SpinnakerHttpException.