### PR TITLE
refactor(tests): convert junit4 based testcases to junit5 in kork

### DIFF
--- a/kork-aws/kork-aws.gradle
+++ b/kork-aws/kork-aws.gradle
@@ -42,5 +42,4 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-engine"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.junit.platform:junit-platform-runner"
 }

--- a/kork-aws/src/test/java/com/netflix/spinnaker/kork/aws/ARNTest.java
+++ b/kork-aws/src/test/java/com/netflix/spinnaker/kork/aws/ARNTest.java
@@ -21,10 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class ARNTest {
 
   @ParameterizedTest

--- a/kork-core/kork-core.gradle
+++ b/kork-core/kork-core.gradle
@@ -30,4 +30,5 @@ dependencies {
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
   testRuntimeOnly "org.slf4j:slf4j-simple"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/kork-core/src/test/java/com/netflix/spinnaker/kork/jackson/ObjectMapperSubtypeConfigurerTest.java
+++ b/kork-core/src/test/java/com/netflix/spinnaker/kork/jackson/ObjectMapperSubtypeConfigurerTest.java
@@ -15,7 +15,8 @@
  */
 package com.netflix.spinnaker.kork.jackson;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
@@ -27,14 +28,14 @@ import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer.ClassSub
 import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer.StringSubtypeLocator;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ObjectMapperSubtypeConfigurerTest {
 
   ObjectMapper mapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mapper = new ObjectMapper();
   }
@@ -58,11 +59,14 @@ public class ObjectMapperSubtypeConfigurerTest {
     assertEquals("{\"kind\":\"child\"}", mapper.writeValueAsString(new ChildType()));
   }
 
-  @Test(expected = InvalidSubtypeConfigurationException.class)
+  @Test
   public void shouldThrowWhenSubtypeNameIsUndefined() {
-    new ObjectMapperSubtypeConfigurer(true)
-        .registerSubtype(
-            mapper, new ClassSubtypeLocator(UndefinedRootType.class, searchPackages()));
+    assertThrows(
+        InvalidSubtypeConfigurationException.class,
+        () ->
+            new ObjectMapperSubtypeConfigurer(true)
+                .registerSubtype(
+                    mapper, new ClassSubtypeLocator(UndefinedRootType.class, searchPackages())));
   }
 
   List<String> searchPackages() {

--- a/kork-jedis/kork-jedis.gradle
+++ b/kork-jedis/kork-jedis.gradle
@@ -17,7 +17,8 @@ dependencies {
   testImplementation project(":kork-jedis-test")
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.spockframework:spock-core"
-  testImplementation "junit:junit"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/kork-jedis/src/test/java/com/netflix/spinnaker/kork/jedis/RedisClientConnectionPropertiesTest.java
+++ b/kork-jedis/src/test/java/com/netflix/spinnaker/kork/jedis/RedisClientConnectionPropertiesTest.java
@@ -17,13 +17,13 @@
 
 package com.netflix.spinnaker.kork.jedis;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import redis.clients.jedis.Protocol;
 
 public class RedisClientConnectionPropertiesTest {

--- a/kork-jedis/src/test/java/com/netflix/spinnaker/kork/jedis/telemetry/InstrumentedJedisPoolTest.java
+++ b/kork-jedis/src/test/java/com/netflix/spinnaker/kork/jedis/telemetry/InstrumentedJedisPoolTest.java
@@ -16,11 +16,11 @@
 
 package com.netflix.spinnaker.kork.jedis.telemetry;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import com.netflix.spectator.api.Registry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import redis.clients.jedis.JedisPool;
 
 public class InstrumentedJedisPoolTest {

--- a/kork-moniker/kork-moniker.gradle
+++ b/kork-moniker/kork-moniker.gradle
@@ -24,6 +24,5 @@ dependencies {
 
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/kork-plugins-tck/kork-plugins-tck.gradle
+++ b/kork-plugins-tck/kork-plugins-tck.gradle
@@ -19,7 +19,6 @@ dependencies {
 
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/Retrofit2SyncCallTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/Retrofit2SyncCallTest.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -173,7 +172,7 @@ public class SpinnakerRetrofitErrorHandlerTest {
     RetrofitError retrofitError = RetrofitError.networkError("http://localhost", e);
     SpinnakerRetrofitErrorHandler handler = SpinnakerRetrofitErrorHandler.getInstance();
     Throwable throwable = handler.handleError(retrofitError);
-    Assert.assertEquals(message, throwable.getMessage());
+    assertEquals(message, throwable.getMessage());
   }
 
   @Test

--- a/kork-secrets-aws/src/test/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerSecretEngineIntegrationTest.java
+++ b/kork-secrets-aws/src/test/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerSecretEngineIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.kork.secrets.engines;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;

--- a/kork-secrets-aws/src/test/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerSecretEngineTest.java
+++ b/kork-secrets-aws/src/test/java/com/netflix/spinnaker/kork/secrets/engines/SecretsManagerSecretEngineTest.java
@@ -15,8 +15,9 @@
  */
 package com.netflix.spinnaker.kork.secrets.engines;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -40,10 +41,8 @@ import com.netflix.spinnaker.kork.secrets.user.UserSecretSerdeFactory;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Spy;
 
@@ -63,9 +62,7 @@ public class SecretsManagerSecretEngineTest {
   private GetSecretValueResult secretStringFileValue =
       new GetSecretValueResult().withSecretString("BEGIN RSA PRIVATE KEY");
 
-  @Rule public ExpectedException exceptionRule = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setup() {
     ObjectMapper mapper = new ObjectMapper();
     List<ObjectMapper> mappers = List.of(mapper);
@@ -96,9 +93,9 @@ public class SecretsManagerSecretEngineTest {
   public void decryptFileWithKey() {
     EncryptedSecret kvSecret =
         EncryptedSecret.parse("encryptedFile:secrets-manager!r:us-west-2!s:private-key!k:password");
-    exceptionRule.expect(InvalidSecretFormatException.class);
     doReturn(kvSecretValue).when(secretsManagerSecretEngine).getSecretValue(any());
-    secretsManagerSecretEngine.validate(kvSecret);
+    assertThrows(
+        InvalidSecretFormatException.class, () -> secretsManagerSecretEngine.validate(kvSecret));
   }
 
   @Test
@@ -124,8 +121,7 @@ public class SecretsManagerSecretEngineTest {
     EncryptedSecret kvSecret =
         EncryptedSecret.parse("encrypted:secrets-manager!r:us-west-2!s:test-secret!k:password");
     doReturn(binarySecretValue).when(secretsManagerSecretEngine).getSecretValue(any());
-    exceptionRule.expect(SecretException.class);
-    secretsManagerSecretEngine.decrypt(kvSecret);
+    assertThrows(SecretException.class, () -> secretsManagerSecretEngine.decrypt(kvSecret));
   }
 
   @Test

--- a/kork-secrets-gcp/kork-secrets-gcp.gradle
+++ b/kork-secrets-gcp/kork-secrets-gcp.gradle
@@ -29,6 +29,7 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-databind"
   implementation "com.google.cloud:google-cloud-secretmanager"
 
-  testImplementation "junit:junit"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.mockito:mockito-core"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/kork-secrets-gcp/src/test/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngineTest.java
+++ b/kork-secrets-gcp/src/test/java/com/netflix/spinnaker/kork/secrets/engines/GoogleSecretsManagerSecretEngineTest.java
@@ -15,7 +15,8 @@
  */
 package com.netflix.spinnaker.kork.secrets.engines;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -25,10 +26,8 @@ import com.google.protobuf.ByteString;
 import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
 import com.netflix.spinnaker.kork.secrets.SecretException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Spy;
 
 public class GoogleSecretsManagerSecretEngineTest {
@@ -36,8 +35,6 @@ public class GoogleSecretsManagerSecretEngineTest {
   @Spy
   private GoogleSecretsManagerSecretEngine googleSecretsManagerSecretEngine =
       new GoogleSecretsManagerSecretEngine();
-
-  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   private final SecretPayload minioAccessKeyId =
       SecretPayload.newBuilder()
@@ -60,7 +57,7 @@ public class GoogleSecretsManagerSecretEngineTest {
   private final SecretPayload plaintextSecretValue =
       SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("my-k8s-v2-account-name")).build();
 
-  @Before
+  @BeforeEach
   public void setup() {
     initMocks(this);
   }
@@ -93,11 +90,12 @@ public class GoogleSecretsManagerSecretEngineTest {
     EncryptedSecret kvSecret =
         EncryptedSecret.parse(
             "encryptedFile:google-secrets-manager!p:824069899151!s:spinnaker-store!k:minioAccessKeyId");
-    exceptionRule.expect(InvalidSecretFormatException.class);
     doReturn(kvSecretValue)
         .when(googleSecretsManagerSecretEngine)
         .getSecretPayload(any(), any(), any());
-    googleSecretsManagerSecretEngine.validate(kvSecret);
+    assertThrows(
+        InvalidSecretFormatException.class,
+        () -> googleSecretsManagerSecretEngine.validate(kvSecret));
   }
 
   @Test
@@ -132,8 +130,7 @@ public class GoogleSecretsManagerSecretEngineTest {
     doReturn(binarySecretValue)
         .when(googleSecretsManagerSecretEngine)
         .getSecretPayload(any(), any(), any());
-    exceptionRule.expect(SecretException.class);
-    googleSecretsManagerSecretEngine.decrypt(kvSecret);
+    assertThrows(SecretException.class, () -> googleSecretsManagerSecretEngine.decrypt(kvSecret));
   }
 
   @Test
@@ -144,7 +141,6 @@ public class GoogleSecretsManagerSecretEngineTest {
     doReturn(binarySecretValue)
         .when(googleSecretsManagerSecretEngine)
         .getSecretPayload(any(), any(), any());
-    exceptionRule.expect(SecretException.class);
-    googleSecretsManagerSecretEngine.decrypt(kvSecret);
+    assertThrows(SecretException.class, () -> googleSecretsManagerSecretEngine.decrypt(kvSecret));
   }
 }

--- a/kork-secrets/kork-secrets.gradle
+++ b/kork-secrets/kork-secrets.gradle
@@ -17,10 +17,13 @@ dependencies {
 
   testImplementation "com.hubspot.jinjava:jinjava"
   testImplementation "org.spockframework:spock-core"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 
   testImplementation("org.springframework:spring-test")
   testImplementation("org.springframework.boot:spring-boot-test")
   testImplementation("org.mockito:mockito-core")
+  testImplementation("org.mockito:mockito-junit-jupiter")
 }

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/EncryptedSecretTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/EncryptedSecretTest.java
@@ -16,16 +16,14 @@
 
 package com.netflix.spinnaker.kork.secrets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class EncryptedSecretTest {
-
-  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
   public void isEncryptedSecretShouldReturnFalse() {
@@ -95,20 +93,25 @@ public class EncryptedSecretTest {
 
   @Test
   public void updateThrowsInvalidSecretFormatException() {
-    exceptionRule.expect(InvalidSecretFormatException.class);
-    exceptionRule.expectMessage(
-        "Invalid encrypted secret format, must have at least one parameter");
-    EncryptedSecret encryptedSecret = new EncryptedSecret();
-    encryptedSecret.update("encrypted:s3");
+    Exception exception =
+        assertThrows(
+            InvalidSecretFormatException.class, () -> new EncryptedSecret().update("encrypted:s3"));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Invalid encrypted secret format, must have at least one parameter"));
   }
 
   @Test
   public void updateThrowsInvalidSecretFormatExceptionNoKeyValuePairs() {
-    exceptionRule.expect(InvalidSecretFormatException.class);
-    exceptionRule.expectMessage(
-        "Invalid encrypted secret format, keys and values must be delimited by ':'");
-    EncryptedSecret encryptedSecret = new EncryptedSecret();
-    encryptedSecret.update("encrypted:s3!foobar");
+    Exception exception =
+        assertThrows(
+            InvalidSecretFormatException.class,
+            () -> new EncryptedSecret().update("encrypted:s3!foobar"));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Invalid encrypted secret format, keys and values must be delimited by ':'"));
   }
 
   @Test

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/SecretAwarePropertySourceTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/SecretAwarePropertySourceTest.java
@@ -1,25 +1,21 @@
 package com.netflix.spinnaker.kork.secrets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.MapPropertySource;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SecretAwarePropertySourceTest {
 
   private SecretAwarePropertySource<Map<String, Object>> secretAwarePropertySource;
@@ -28,7 +24,7 @@ public class SecretAwarePropertySourceTest {
   private final Map<String, Object> testValues = new HashMap<>();
   private final MapPropertySource propertySource = new MapPropertySource("testSource", testValues);
 
-  @Before
+  @BeforeEach
   public void setup() {
     testValues.put("testSecretFile", "encrypted:noop!k:testValue");
     testValues.put("testSecretPath", "encrypted:noop!k:testValue");
@@ -41,8 +37,8 @@ public class SecretAwarePropertySourceTest {
     secretAwarePropertySource =
         new SecretAwarePropertySource<>(propertySource, secretPropertyProcessor);
 
-    when(secretManager.decryptAsFile(any())).thenReturn(Paths.get("decryptedFile"));
-    when(secretManager.decrypt(any())).thenReturn("decryptedString");
+    lenient().when(secretManager.decryptAsFile(any())).thenReturn(Paths.get("decryptedFile"));
+    lenient().when(secretManager.decrypt(any())).thenReturn("decryptedString");
   }
 
   @Test

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/SecretSessionTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/SecretSessionTest.java
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.kork.secrets;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
@@ -14,8 +14,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -27,7 +27,7 @@ public class SecretSessionTest {
   private SecretManager secretManager;
   private SecretSession secretSession;
 
-  @Before
+  @BeforeEach
   public void setup() {
     MockitoAnnotations.initMocks(this);
 

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/engines/AbstractStorageEngineTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/engines/AbstractStorageEngineTest.java
@@ -16,20 +16,20 @@
 
 package com.netflix.spinnaker.kork.secrets.engines;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Arrays;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AbstractStorageEngineTest {
   AbstractStorageSecretEngine engine;
 
-  @Before
+  @BeforeEach
   public void init() {
     engine =
         new AbstractStorageSecretEngine() {

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManagerTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManagerTest.java
@@ -16,20 +16,20 @@
 
 package com.netflix.spinnaker.kork.secrets.user;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import com.netflix.spinnaker.kork.secrets.SecretConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @SpringBootTest(classes = SecretConfiguration.class)
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 public class UserSecretManagerTest {
 
   @Autowired UserSecretManager userSecretManager;

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretReferenceTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretReferenceTest.java
@@ -1,10 +1,10 @@
 package com.netflix.spinnaker.kork.secrets.user;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UserSecretReferenceTest {
 

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretSerdeTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretSerdeTest.java
@@ -22,13 +22,13 @@ import static org.hamcrest.Matchers.equalTo;
 import com.netflix.spinnaker.kork.secrets.SecretConfiguration;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = SecretConfiguration.class)
 public class UserSecretSerdeTest {
 

--- a/kork-sql-test/kork-sql-test.gradle
+++ b/kork-sql-test/kork-sql-test.gradle
@@ -8,7 +8,6 @@ dependencies {
   api("org.testcontainers:postgresql")
 
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.platform:junit-platform-runner"
 
   runtimeOnly "com.h2database:h2"
 

--- a/kork-sql-test/src/test/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtilTest.java
+++ b/kork-sql-test/src/test/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtilTest.java
@@ -15,19 +15,16 @@
  */
 package com.netflix.spinnaker.kork.sql.test;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.testcontainers.DockerClientFactory;
 
 /**
  * Verify that SqlTestUtil can bring up database containers. Beyond testing the code, it also helps
  * to verify that appropriate docker images are available in CI environments.
  */
-@RunWith(JUnitPlatform.class)
 public class SqlTestUtilTest {
 
   @BeforeAll

--- a/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt
+++ b/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt
@@ -21,8 +21,8 @@ import com.netflix.spinnaker.kork.sql.health.SqlHealthIndicator
 import org.jooq.DSLContext
 import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.table
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.getBeansOfType
 import org.springframework.boot.actuate.health.HealthIndicator
@@ -30,13 +30,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import strikt.api.expectThat
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @SpringBootTest(
   classes = [StartupTestApp::class],
   properties = [

--- a/kork-stackdriver/kork-stackdriver.gradle
+++ b/kork-stackdriver/kork-stackdriver.gradle
@@ -34,5 +34,6 @@ dependencies {
   compileOnly "org.springframework.boot:spring-boot-autoconfigure"
 
   testImplementation "org.mockito:mockito-core"
-  testImplementation "junit:junit"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MetricDescriptorCacheTest.java
+++ b/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MetricDescriptorCacheTest.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spectator.stackdriver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
@@ -36,18 +38,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-@RunWith(JUnit4.class)
 public class MetricDescriptorCacheTest {
   static class ReturnExecuteDescriptorArg implements Answer {
     private Monitoring.Projects.MetricDescriptors.Create mockCreateMethod;
@@ -142,7 +140,7 @@ public class MetricDescriptorCacheTest {
     return result;
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     MockitoAnnotations.initMocks(this);
     when(monitoringApi.projects()).thenReturn(projectsApi);
@@ -165,7 +163,7 @@ public class MetricDescriptorCacheTest {
 
   @Test
   public void descriptorTypeAreCompliant() {
-    Assert.assertEquals(
+    assertEquals(
         "custom.googleapis.com/TESTNAMESPACE/" + applicationName + "/idA",
         cache.idToDescriptorType(idA));
   }
@@ -196,7 +194,7 @@ public class MetricDescriptorCacheTest {
     when(mockGetMethod.execute()).thenReturn(origDescriptor);
     when(mockCreateMethod.execute()).thenReturn(updatedDescriptor);
 
-    Assert.assertEquals(updatedDescriptor, cache.addLabel(type, label));
+    assertEquals(updatedDescriptor, cache.addLabel(type, label));
     verify(mockGetMethod, times(1)).execute();
     verify(mockDeleteMethod, times(1)).execute();
     verify(mockCreateMethod, times(1)).execute();
@@ -229,7 +227,7 @@ public class MetricDescriptorCacheTest {
     when(mockDeleteMethod.execute()).thenThrow(new IOException("Not Found"));
     when(mockCreateMethod.execute()).thenReturn(updatedDescriptor);
 
-    Assert.assertEquals(updatedDescriptor, cache.addLabel(type, label));
+    assertEquals(updatedDescriptor, cache.addLabel(type, label));
     verify(mockGetMethod, times(1)).execute();
     verify(mockDeleteMethod, times(1)).execute();
     verify(mockCreateMethod, times(1)).execute();
@@ -261,7 +259,7 @@ public class MetricDescriptorCacheTest {
     when(mockGetMethod.execute()).thenReturn(origDescriptor);
     when(mockCreateMethod.execute()).thenThrow(new IOException("Not Found"));
 
-    Assert.assertNull(cache.addLabel(type, label));
+    assertNull(cache.addLabel(type, label));
 
     verify(mockGetMethod, times(1)).execute();
     verify(mockDeleteMethod, times(1)).execute();
@@ -288,7 +286,7 @@ public class MetricDescriptorCacheTest {
     when(descriptorsApi.create(any(), any())).thenReturn(mockCreateMethod);
 
     when(mockGetMethod.execute()).thenReturn(origDescriptor);
-    Assert.assertEquals(origDescriptor, cache.addLabel(type, label));
+    assertEquals(origDescriptor, cache.addLabel(type, label));
 
     verify(mockGetMethod, times(1)).execute();
     verify(mockDeleteMethod, times(0)).execute();

--- a/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MonitoredResourceBuilderTest.java
+++ b/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/MonitoredResourceBuilderTest.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spectator.stackdriver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -25,18 +26,14 @@ import com.google.api.services.monitoring.v3.model.MonitoredResource;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class MonitoredResourceBuilderTest {
 
   MonitoredResourceBuilder builder;
 
-  @Before
+  @BeforeEach
   public void setup() {
     builder = spy(new MonitoredResourceBuilder());
   }
@@ -59,8 +56,8 @@ public class MonitoredResourceBuilderTest {
     labels.put("zone", zone);
 
     MonitoredResource resource = builder.build();
-    Assert.assertEquals("gce_instance", resource.getType());
-    Assert.assertEquals(labels, resource.getLabels());
+    assertEquals("gce_instance", resource.getType());
+    assertEquals(labels, resource.getLabels());
   }
 
   @Test
@@ -72,9 +69,9 @@ public class MonitoredResourceBuilderTest {
             + " \"region\" : \"us-east-1\"\n"
             + "}";
 
-    Assert.assertEquals("the-instance", builder.matchAttribute(text, "instanceId"));
-    Assert.assertEquals("us-east-1", builder.matchAttribute(text, "region"));
-    Assert.assertEquals("", builder.matchAttribute(text, "notFound"));
+    assertEquals("the-instance", builder.matchAttribute(text, "instanceId"));
+    assertEquals("us-east-1", builder.matchAttribute(text, "region"));
+    assertEquals("", builder.matchAttribute(text, "notFound"));
   }
 
   @Test
@@ -115,8 +112,8 @@ public class MonitoredResourceBuilderTest {
     labels.put("project_id", project);
 
     MonitoredResource resource = builder.build();
-    Assert.assertEquals("aws_ec2_instance", resource.getType());
-    Assert.assertEquals(labels, resource.getLabels());
+    assertEquals("aws_ec2_instance", resource.getType());
+    assertEquals(labels, resource.getLabels());
   }
 
   @Test
@@ -131,7 +128,7 @@ public class MonitoredResourceBuilderTest {
     labels.put("project_id", project);
 
     MonitoredResource resource = builder.build();
-    Assert.assertEquals("global", resource.getType());
-    Assert.assertEquals(labels, resource.getLabels());
+    assertEquals("global", resource.getType());
+    assertEquals(labels, resource.getLabels());
   }
 }

--- a/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/StackdriverWriterTest.java
+++ b/kork-stackdriver/src/test/java/com/netflix/spectator/stackdriver/StackdriverWriterTest.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spectator.stackdriver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doReturn;
@@ -45,18 +47,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-@RunWith(JUnit4.class)
 public class StackdriverWriterTest {
   static class TestableStackdriverWriter extends StackdriverWriter {
     public TestableStackdriverWriter(ConfigParams params) {
@@ -160,7 +158,7 @@ public class StackdriverWriterTest {
     return result;
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     MockitoAnnotations.initMocks(this);
     when(monitoringApi.projects()).thenReturn(projectsApi);
@@ -201,7 +199,7 @@ public class StackdriverWriterTest {
             .setApplicationName(applicationName)
             .setMeasurementFilter(allowAll)
             .build();
-    Assert.assertTrue(!config.getInstanceId().isEmpty());
+    assertTrue(!config.getInstanceId().isEmpty());
   }
 
   TimeSeries makeTimeSeries(MetricDescriptor descriptor, Id id, double value, String time) {
@@ -280,10 +278,10 @@ public class StackdriverWriterTest {
     descriptorRegistrySpy.addExtraTimeSeriesLabel(
         MetricDescriptorCache.INSTANCE_LABEL, INSTANCE_ID);
 
-    Assert.assertEquals(
+    assertEquals(
         makeTimeSeries(descriptorA, idAXY, 1, timeA),
         writer.measurementToTimeSeries(descriptorA.getType(), testRegistry, timerA, measureAXY));
-    Assert.assertEquals(
+    assertEquals(
         makeTimeSeries(descriptorB, idBXY, 20.1, timeB),
         writer.measurementToTimeSeries(descriptorB.getType(), testRegistry, timerB, measureBXY));
   }
@@ -311,7 +309,7 @@ public class StackdriverWriterTest {
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
     verify(timeseriesApi, times(1)).create(eq("projects/test-project"), captor.capture());
     // A, B, timer count and totalTime.
-    Assert.assertEquals(4, captor.getValue().getTimeSeries().size());
+    assertEquals(4, captor.getValue().getTimeSeries().size());
   }
 
   @Test
@@ -372,8 +370,8 @@ public class StackdriverWriterTest {
     spy.writeRegistry(registry);
 
     verify(mockCreateMethod, times(2)).execute();
-    Assert.assertEquals(1, match200.found);
-    Assert.assertEquals(1, match1.found);
+    assertEquals(1, match200.found);
+    assertEquals(1, match1.found);
   }
 
   @Test
@@ -385,6 +383,6 @@ public class StackdriverWriterTest {
     // If we get the expected result then we matched the expected descriptors,
     // which means the transforms occurred as expected.
     List<TimeSeries> tsList = writer.registryToTimeSeries(testRegistry);
-    Assert.assertEquals(2, tsList.size());
+    assertEquals(2, tsList.size());
   }
 }

--- a/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptorMicrometerTest.java
+++ b/kork-web/src/test/groovy/com/netflix/spinnaker/kork/web/interceptors/MetricsInterceptorMicrometerTest.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.method.HandlerMethod;


### PR DESCRIPTION
The following modules of kork are using junit4 constructs or/and platform to run tests, converting them to junit5 based constructs or/and platform. This refactor makes junit5 as a uniform test framework for kork.

kork-core, kork-jedis, kork-secrets, kork-secrets-gcp, kork-sql, kork-sql-test, kork-stackdriver, kork-web, kork-secrets-aws, kork-retrofit

Clean up junit4 constructs  from kork-aws, kork-moniker, kork-plugin-tck.

Recently, 1 test case has been withdrawn in this [PR](https://github.com/spinnaker/kork/pull/1068).

Before refactoring, 583 test cases executed.
After refactoring, 584 test cases executed.

