### PR TITLE
fix(expressions): Restore delegation to default SpEL type converter

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ArtifactUriToReferenceConverter.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ArtifactUriToReferenceConverter.java
@@ -37,19 +37,19 @@ public class ArtifactUriToReferenceConverter implements TypeConverter {
 
   @Override
   public boolean canConvert(TypeDescriptor sourceType, @NotNull TypeDescriptor targetType) {
-    if (sourceType == null) {
-      return false;
-    }
+    return isArtifactUriType(sourceType, targetType) || defaultTypeConverter.canConvert(sourceType, targetType);
+  }
 
-    return sourceType.getObjectType() == String.class && targetType.getObjectType() == String.class;
+  private boolean isArtifactUriType(TypeDescriptor sourceType, @NotNull TypeDescriptor targetType) {
+    return sourceType != null &&
+      sourceType.getObjectType() == String.class &&
+      targetType.getObjectType() == String.class;
   }
 
   @Override
   public Object convertValue(
       Object value, TypeDescriptor sourceType, @NotNull TypeDescriptor targetType) {
-    // For some obscene reason(s), SpEL does not use this in the
-    // FunctionReference call when calling a method. So we call it internally
-    if (!canConvert(sourceType, targetType)) {
+    if (!isArtifactUriType(sourceType, targetType)) {
       return defaultTypeConverter.convertValue(value, sourceType, targetType);
     }
 

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ArtifactUriToReferenceConverter.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ArtifactUriToReferenceConverter.java
@@ -37,13 +37,14 @@ public class ArtifactUriToReferenceConverter implements TypeConverter {
 
   @Override
   public boolean canConvert(TypeDescriptor sourceType, @NotNull TypeDescriptor targetType) {
-    return isArtifactUriType(sourceType, targetType) || defaultTypeConverter.canConvert(sourceType, targetType);
+    return isArtifactUriType(sourceType, targetType)
+        || defaultTypeConverter.canConvert(sourceType, targetType);
   }
 
   private boolean isArtifactUriType(TypeDescriptor sourceType, @NotNull TypeDescriptor targetType) {
-    return sourceType != null &&
-      sourceType.getObjectType() == String.class &&
-      targetType.getObjectType() == String.class;
+    return sourceType != null
+        && sourceType.getObjectType() == String.class
+        && targetType.getObjectType() == String.class;
   }
 
   @Override

--- a/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupportTest.java
+++ b/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupportTest.java
@@ -131,6 +131,26 @@ public class ExpressionsSupportTest {
     assertThat(evaluated).isEqualTo(expectedValue);
   }
 
+  @Test
+  public void delegatesTypeConversion() {
+    // If a thing is not an artifact URI, it should delegate to StandardTypeConverter
+    ExpressionProperties expressionProperties = new ExpressionProperties();
+
+    // StandardTypeConverter does things like convert ints to longs
+    String testInput = ("${new java.util.UUID(0,0).toString()}");
+    Map<String, Object> testContext = Map.of();
+
+    String evaluated =
+        new ExpressionTransform(parserContext, parser, Function.identity())
+            .transformString(
+                testInput,
+                new ExpressionsSupport(null, expressionProperties)
+                    .buildEvaluationContext(testContext, true),
+                new ExpressionEvaluationSummary());
+
+    assertThat(evaluated).isEqualTo("00000000-0000-0000-0000-000000000000");
+  }
+
   public class MockArtifactStore extends ArtifactStore {
     public Map<String, String> cache = new HashMap<>();
 


### PR DESCRIPTION
The type interceptor for detecting remote artifact URIs was not properly delegating `canConvert`, which resulted in only String -> String being auto-converted in SpEL.

This breaks many expressions, as SpEL's default `StandardTypeConverter` handles common cases like int -> long.