### PR TITLE
fix(artifacts): Fix test duplication in artifact store

### DIFF
--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/EmbeddedArtifactSerializerTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/EmbeddedArtifactSerializerTest.java
@@ -68,8 +68,8 @@ class EmbeddedArtifactSerializerTest {
             "stored",
             "{\"type\":\"remote/base64\",\"customKind\":false,\"name\":null,\"version\":null,\"location\":null,\"reference\":\"link\",\"metadata\":{},\"artifactAccount\":null,\"provenance\":null,\"uuid\":null}",
             Artifact.builder()
-                .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
-                .reference(Base64.encodeBase64String("foo".getBytes()))
+                .type(ArtifactTypes.REMOTE_BASE64.getMimeType())
+                .reference("link")
                 .build(),
             Artifact.builder()
                 .type(ArtifactTypes.REMOTE_BASE64.getMimeType())


### PR DESCRIPTION
When I was refactoring the EmbeddedArtifactSerializerTest it looks like I copy pasta'd the same test vector twice. This commit addresses that and fixes it