### PR TITLE
chore(dependencies): remove unnecessary dependency on log4j-core

### DIFF
--- a/kork-artifacts/kork-artifacts.gradle
+++ b/kork-artifacts/kork-artifacts.gradle
@@ -14,7 +14,6 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-autoconfigure"
   implementation "org.springframework.security:spring-security-core"
   implementation 'org.apache.logging.log4j:log4j-api'
-  implementation 'org.apache.logging.log4j:log4j-core'
   api "com.hubspot.jinjava:jinjava"
 
   testImplementation "org.assertj:assertj-core"

--- a/kork-core/kork-core.gradle
+++ b/kork-core/kork-core.gradle
@@ -18,6 +18,7 @@ dependencies {
   api "io.github.resilience4j:resilience4j-retry"
   api "io.github.resilience4j:resilience4j-spring-boot2"
 
+  implementation "org.apache.logging.log4j:log4j-api"
   implementation "com.fasterxml.jackson.core:jackson-annotations"
   implementation "com.fasterxml.jackson.core:jackson-databind"
   implementation "com.netflix.spectator:spectator-ext-gc"

--- a/kork-credentials/kork-credentials.gradle
+++ b/kork-credentials/kork-credentials.gradle
@@ -21,6 +21,7 @@ dependencies {
   api project(":kork-credentials-api")
   api project(":kork-annotations")
   implementation(platform(project(":spinnaker-dependencies")))
+  implementation 'org.apache.logging.log4j:log4j-api'
   implementation "org.springframework.boot:spring-boot"
   implementation 'org.springframework.boot:spring-boot-starter-json'
   implementation 'javax.annotation:javax.annotation-api'

--- a/kork-secrets/kork-secrets.gradle
+++ b/kork-secrets/kork-secrets.gradle
@@ -14,6 +14,7 @@ dependencies {
   implementation "org.yaml:snakeyaml"
   implementation "com.google.guava:guava"
   implementation "org.apache.commons:commons-lang3"
+  implementation "org.apache.logging.log4j:log4j-api"
 
   testImplementation "com.hubspot.jinjava:jinjava"
   testImplementation "org.spockframework:spock-core"

--- a/kork-security/kork-security.gradle
+++ b/kork-security/kork-security.gradle
@@ -11,6 +11,7 @@ dependencies {
   api "com.fasterxml.jackson.core:jackson-annotations"
 
   implementation "com.google.guava:guava"
+  implementation "org.apache.logging.log4j:log4j-api"
   implementation "org.slf4j:slf4j-api"
 
   testImplementation "org.spockframework:spock-core"

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -57,8 +57,8 @@ dependencies {
    */
    // Log4shell safeguard.  Per analysis, log4j-core is not included in dependencies, but this would prevent transitive inclusion of it by extension
    // platforms.   Doing 2.16.0 which completely removes message lookups AND sets jndi to disabled by default
-   // 2.16.0 is subject to CVE-2021-45105.  2.17.0 is subject to CVE-2021-44832, so use 2.17.1.
-  api(platform("org.apache.logging.log4j:log4j-bom:2.17.1"))
+   // 2.16.0 is subject to CVE-2021-45105.  2.17.0 is subject to CVE-2021-44832, so use >= 2.17.1.
+  api(platform("org.apache.logging.log4j:log4j-bom:2.20.0"))
 
   //Upgrade of spring boot 2.5.x brings groovy 3.x as transitive dependency.
   //To avoid transitive upgrade of groovy, pinning it with enforcedPlatform() closure.

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -57,8 +57,8 @@ dependencies {
    */
    // Log4shell safeguard.  Per analysis, log4j-core is not included in dependencies, but this would prevent transitive inclusion of it by extension
    // platforms.   Doing 2.16.0 which completely removes message lookups AND sets jndi to disabled by default
-
-  api(platform("org.apache.logging.log4j:log4j-bom:2.16.0"))
+   // 2.16.0 is subject to CVE-2021-45105.  2.17.0 is subject to CVE-2021-44832, so use 2.17.1.
+  api(platform("org.apache.logging.log4j:log4j-bom:2.17.1"))
 
   //Upgrade of spring boot 2.5.x brings groovy 3.x as transitive dependency.
   //To avoid transitive upgrade of groovy, pinning it with enforcedPlatform() closure.


### PR DESCRIPTION
and make dependencies on log4j-api explicit.

https://github.com/spinnaker/kork/pull/1069 introduced the dependency on org.apache.logging.log4j.log4j-core in kork-artifacts, but it's not necessary.  At least, after removing it, and verifying the dependency is gone from
```
$ ./gradle kork-artifacts:dependencies
```
the code still builds fine.  As well
```
$ git grep "import org.apache.logging.log4j"
kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretTypeProvider.java:import org.apache.logging.log4j.LogManager; kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequestDecorator.java:import org.apache.logging.log4j.ThreadContext;
```
turns up classes present in log4j-api, but nothing in log4j-core.

As well uses of the `@Log4j2` annotation depend on log4j-api (see https://projectlombok.org/api/lombok/extern/log4j/Log4j2)
```
$ git grep @Log4j2
kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreConfiguration.java:@Log4j2 kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStore.java:@Log4j2 kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/JsonTypeNameParser.java:@Log4j2 kork-credentials/src/main/java/com/netflix/spinnaker/credentials/jackson/SensitiveSerializer.java:@Log4j2 kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/EncryptedSecret.java:@Log4j2
```
This all makes the comment in [spinnaker-dependencies.gradle](https://github.com/spinnaker/kork/blob/ed082ade1ec460a0310b78d71e84906862ff269c/spinnaker-dependencies/spinnaker-dependencies.gradle#L58) true again:

> Per analysis, log4j-core is not included in dependencies

While we're at it, get log4j-bom up to date.