### PR TITLE
chore(dependency): unpin json-smart

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -198,7 +198,6 @@ dependencies {
     api("javax.xml.bind:jaxb-api:2.3.1")
     api("mysql:mysql-connector-java:8.0.20")
     api("net.logstash.logback:logstash-logback-encoder:4.11")
-    api("net.minidev:json-smart:2.4.1") // TODO: remove this with upgrade of spring-boot version to 2.5.0 or above
     api("org.apache.commons:commons-exec:1.3")
     // TODO(jvz): beginning in BC 1.71, this should use the -jdk18on artifacts
     api("org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}")


### PR DESCRIPTION
Consumed the modified kork to build and test all spinnaker components, all build successfully and test passed. Below is the difference in version of json-smart before and after the logback upgrade (in gate):
```
$ ./gradlew gate-web:dI --dependency json-smart --configuration testCompileClasspath

> Task :gate-web:dependencyInsight
net.minidev:json-smart:2.4.1
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced
      - Was requested: didn't match versions 2.5.0, 2.4.11, 2.4.10, 2.4.9, 2.4.8, 2.4.7, 2.4.6, 2.4.5, 2.4.4, 2.4.2, 2.4.1, 2.3.1

net.minidev:json-smart:2.4.1
\--- io.spinnaker.kork:kork-bom:7.182.1
     \--- testCompileClasspath

net.minidev:json-smart:2.3 -> 2.4.1
\--- com.jayway.jsonpath:json-path:2.5.0
     +--- io.spinnaker.kork:kork-bom:7.182.1
     |    \--- testCompileClasspath
     \--- org.springframework.boot:spring-boot-starter-test:2.5.14
          +--- testCompileClasspath (requested org.springframework.boot:spring-boot-starter-test)
          \--- io.spinnaker.kork:kork-bom:7.182.1 (*)

net.minidev:json-smart:[1.3.1,2.3] -> 2.4.1
\--- com.nimbusds:nimbus-jose-jwt:7.9
     +--- io.spinnaker.kork:kork-bom:7.182.1
     |    \--- testCompileClasspath
     \--- org.springframework.security:spring-security-oauth2-jose:5.5.8 (requested com.nimbusds:nimbus-jose-jwt:9.10.1)
          +--- testCompileClasspath (requested org.springframework.security:spring-security-oauth2-jose)
          \--- io.spinnaker.kork:kork-bom:7.182.1 (*)

```
===================After===============================
```
$ ./gradlew gate-web:dI --dependency json-smart --configuration testCompileClasspath

> Task :gate-web:dependencyInsight
io.spinnaker.kork:kork-annotations:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-annotations:json-smart-SNAPSHOT
+--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
|    \--- testCompileClasspath
+--- io.spinnaker.kork:kork-core:json-smart-SNAPSHOT
|    +--- testCompileClasspath (requested io.spinnaker.kork:kork-core)
|    +--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
|    \--- io.spinnaker.kork:kork-web:json-smart-SNAPSHOT
|         +--- testCompileClasspath (requested io.spinnaker.kork:kork-web)
|         \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
+--- io.spinnaker.kork:kork-crypto:json-smart-SNAPSHOT
|    +--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
|    \--- io.spinnaker.kork:kork-web:json-smart-SNAPSHOT (*)
\--- io.spinnaker.kork:kork-plugins-api:json-smart-SNAPSHOT
     +--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
     +--- project :gate-api (requested io.spinnaker.kork:kork-plugins-api)
     |    \--- testCompileClasspath
     \--- io.spinnaker.kork:kork-api:json-smart-SNAPSHOT
          +--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
          +--- io.spinnaker.fiat:fiat-api:1.41.0 (requested io.spinnaker.kork:kork-api:7.175.0)
          |    \--- testCompileClasspath
          +--- io.spinnaker.kork:kork-core:json-smart-SNAPSHOT (*)
          \--- io.spinnaker.kork:kork-plugins:json-smart-SNAPSHOT
               +--- testCompileClasspath (requested io.spinnaker.kork:kork-plugins)
               \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)

io.spinnaker.kork:kork-annotations -> json-smart-SNAPSHOT
\--- project :gate-api
     \--- testCompileClasspath

io.spinnaker.kork:kork-api:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-api:json-smart-SNAPSHOT
+--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
|    \--- testCompileClasspath
+--- io.spinnaker.kork:kork-core:json-smart-SNAPSHOT
|    +--- testCompileClasspath (requested io.spinnaker.kork:kork-core)
|    +--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
|    \--- io.spinnaker.kork:kork-web:json-smart-SNAPSHOT
|         +--- testCompileClasspath (requested io.spinnaker.kork:kork-web)
|         \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
\--- io.spinnaker.kork:kork-plugins:json-smart-SNAPSHOT
     +--- testCompileClasspath (requested io.spinnaker.kork:kork-plugins)
     \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)

io.spinnaker.kork:kork-api:7.175.0 -> json-smart-SNAPSHOT
\--- io.spinnaker.fiat:fiat-api:1.41.0
     \--- testCompileClasspath

io.spinnaker.kork:kork-artifacts:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-artifacts:json-smart-SNAPSHOT
\--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
     \--- testCompileClasspath

io.spinnaker.kork:kork-artifacts -> json-smart-SNAPSHOT
\--- testCompileClasspath

io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (forced)
  Variant enforced-platform-compile:
    | Attribute Name                 | Provided          | Requested         |
    |--------------------------------|-------------------|-------------------|
    | org.gradle.status              | integration       |                   |
    | org.gradle.category            | enforced-platform | enforced-platform |
    | org.gradle.usage               | java-api          | java-api          |
    | org.gradle.dependency.bundling |                   | external          |
    | org.gradle.jvm.environment     |                   | standard-jvm      |
    | org.gradle.jvm.version         |                   | 11                |
    | org.gradle.libraryelements     |                   | classes+resources |

io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
\--- testCompileClasspath

io.spinnaker.kork:kork-config:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-config:json-smart-SNAPSHOT
\--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
     \--- testCompileClasspath

io.spinnaker.kork:kork-config -> json-smart-SNAPSHOT
\--- testCompileClasspath

io.spinnaker.kork:kork-core:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-core:json-smart-SNAPSHOT
+--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
|    \--- testCompileClasspath
\--- io.spinnaker.kork:kork-web:json-smart-SNAPSHOT
     +--- testCompileClasspath (requested io.spinnaker.kork:kork-web)
     \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)

io.spinnaker.kork:kork-core -> json-smart-SNAPSHOT
\--- testCompileClasspath

io.spinnaker.kork:kork-crypto:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-crypto:json-smart-SNAPSHOT
+--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
|    \--- testCompileClasspath
\--- io.spinnaker.kork:kork-web:json-smart-SNAPSHOT
     +--- testCompileClasspath (requested io.spinnaker.kork:kork-web)
     \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)

io.spinnaker.kork:kork-exceptions:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-exceptions:json-smart-SNAPSHOT
+--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
|    \--- testCompileClasspath
+--- io.spinnaker.kork:kork-core:json-smart-SNAPSHOT
|    +--- testCompileClasspath (requested io.spinnaker.kork:kork-core)
|    +--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
|    \--- io.spinnaker.kork:kork-web:json-smart-SNAPSHOT
|         +--- testCompileClasspath (requested io.spinnaker.kork:kork-web)
|         \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
\--- io.spinnaker.kork:kork-web:json-smart-SNAPSHOT (*)

io.spinnaker.kork:kork-jedis-test:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-jedis-test:json-smart-SNAPSHOT
\--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
     \--- testCompileClasspath

io.spinnaker.kork:kork-jedis-test -> json-smart-SNAPSHOT
\--- testCompileClasspath

io.spinnaker.kork:kork-plugins:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-plugins:json-smart-SNAPSHOT
\--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
     \--- testCompileClasspath

io.spinnaker.kork:kork-plugins -> json-smart-SNAPSHOT
\--- testCompileClasspath

io.spinnaker.kork:kork-plugins-api:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-plugins-api:json-smart-SNAPSHOT
+--- io.spinnaker.kork:kork-api:json-smart-SNAPSHOT
|    +--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
|    |    \--- testCompileClasspath
|    +--- io.spinnaker.fiat:fiat-api:1.41.0 (requested io.spinnaker.kork:kork-api:7.175.0)
|    |    \--- testCompileClasspath
|    +--- io.spinnaker.kork:kork-core:json-smart-SNAPSHOT
|    |    +--- testCompileClasspath (requested io.spinnaker.kork:kork-core)
|    |    +--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
|    |    \--- io.spinnaker.kork:kork-web:json-smart-SNAPSHOT
|    |         +--- testCompileClasspath (requested io.spinnaker.kork:kork-web)
|    |         \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
|    \--- io.spinnaker.kork:kork-plugins:json-smart-SNAPSHOT
|         +--- testCompileClasspath (requested io.spinnaker.kork:kork-plugins)
|         \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
\--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)

io.spinnaker.kork:kork-plugins-api -> json-smart-SNAPSHOT
\--- project :gate-api
     \--- testCompileClasspath

io.spinnaker.kork:kork-security:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-security:json-smart-SNAPSHOT
+--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
|    \--- testCompileClasspath
\--- io.spinnaker.kork:kork-web:json-smart-SNAPSHOT
     +--- testCompileClasspath (requested io.spinnaker.kork:kork-web)
     \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)

io.spinnaker.kork:kork-test:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-test:json-smart-SNAPSHOT
\--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
     \--- testCompileClasspath

io.spinnaker.kork:kork-test -> json-smart-SNAPSHOT
\--- testCompileClasspath

io.spinnaker.kork:kork-web:json-smart-SNAPSHOT
  Variant compile:
    | Attribute Name                 | Provided    | Requested         |
    |--------------------------------|-------------|-------------------|
    | org.gradle.status              | integration |                   |
    | org.gradle.category            | library     | library           |
    | org.gradle.libraryelements     | jar         | classes+resources |
    | org.gradle.usage               | java-api    | java-api          |
    | org.gradle.dependency.bundling |             | external          |
    | org.gradle.jvm.environment     |             | standard-jvm      |
    | org.gradle.jvm.version         |             | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-web:json-smart-SNAPSHOT
\--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
     \--- testCompileClasspath

io.spinnaker.kork:kork-web -> json-smart-SNAPSHOT
\--- testCompileClasspath

net.minidev:json-smart:2.4.8
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced
      - Was requested: didn't match versions 2.5.0, 2.4.11, 2.4.10, 2.4.9, 2.4.8, 2.4.7, 2.4.6, 2.4.5, 2.4.4, 2.4.2, 2.4.1, 2.3.1

net.minidev:json-smart:2.4.8
\--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
     \--- testCompileClasspath

net.minidev:json-smart:2.3 -> 2.4.8
\--- com.jayway.jsonpath:json-path:2.5.0
     +--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
     |    \--- testCompileClasspath
     \--- org.springframework.boot:spring-boot-starter-test:2.5.14
          +--- testCompileClasspath (requested org.springframework.boot:spring-boot-starter-test)
          \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)

net.minidev:json-smart:[1.3.1,2.3] -> 2.4.8
\--- com.nimbusds:nimbus-jose-jwt:7.9
     +--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT
     |    \--- testCompileClasspath
     \--- org.springframework.security:spring-security-oauth2-jose:5.5.8 (requested com.nimbusds:nimbus-jose-jwt:9.10.1)
          +--- testCompileClasspath (requested org.springframework.security:spring-security-oauth2-jose)
          \--- io.spinnaker.kork:kork-bom:json-smart-SNAPSHOT (*)
```