### PR TITLE
chore(dependency): unpin junit-bom

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -72,7 +72,6 @@ dependencies {
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
-  api(platform("org.junit:junit-bom:5.6.3"))
   api(platform("com.fasterxml.jackson:jackson-bom:2.12.7.20221012"))
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))


### PR DESCRIPTION
Consumed the modified kork to build and test all spinnaker components, all build successfully and test passed. Below is the difference in version of junit-bom before and after the junit-bom unpin (in gate):
```
$ ./gradlew gate-web:dI --dependency org.junit.jupiter --configuration testCompileClasspath

> Task :gate-web:dependencyInsight
org.junit.jupiter:junit-jupiter:5.6.3
  Variant apiElements:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.dependency.bundling | external | external          |
    | org.gradle.jvm.version         | 8        | 11                |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
   Selection reasons:
      - By constraint
      - Forced

org.junit.jupiter:junit-jupiter:5.6.3
+--- io.spinnaker.kork:kork-bom:7.182.1
|    \--- testCompileClasspath
\--- org.junit:junit-bom:5.6.3
     +--- org.junit.jupiter:junit-jupiter-params:5.6.3
     |    +--- io.spinnaker.kork:kork-bom:7.182.1 (*)
     |    +--- org.junit:junit-bom:5.6.3 (*)
     |    \--- org.junit.jupiter:junit-jupiter:5.6.3 (*)
     +--- org.junit.jupiter:junit-jupiter-api:5.6.3
     |    +--- io.spinnaker.kork:kork-bom:7.182.1 (*)
     |    +--- org.junit.jupiter:junit-jupiter-params:5.6.3 (*)
     |    +--- org.junit:junit-bom:5.6.3 (*)
     |    \--- org.junit.jupiter:junit-jupiter:5.6.3 (*)
     +--- org.junit.platform:junit-platform-commons:1.6.3
     |    +--- io.spinnaker.kork:kork-bom:7.182.1 (*)
     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.3 (*)
     |    \--- org.junit:junit-bom:5.6.3 (*)
     \--- org.junit.jupiter:junit-jupiter:5.6.3 (*)

org.junit.jupiter:junit-jupiter:5.7.2 -> 5.6.3
\--- org.springframework.boot:spring-boot-starter-test:2.5.14
     +--- testCompileClasspath (requested org.springframework.boot:spring-boot-starter-test)
     \--- io.spinnaker.kork:kork-bom:7.182.1
          \--- testCompileClasspath

org.junit.jupiter:junit-jupiter-api:5.6.3
  Variant apiElements:
    | Attribute Name                      | Provided | Requested         |
    |-------------------------------------|----------|-------------------|
    | org.gradle.status                   | release  |                   |
    | org.jetbrains.kotlin.localToProject | public   |                   |
    | org.jetbrains.kotlin.platform.type  | jvm      |                   |
    | org.gradle.category                 | library  | library           |
    | org.gradle.dependency.bundling      | external | external          |
    | org.gradle.jvm.version              | 8        | 11                |
    | org.gradle.libraryelements          | jar      | classes+resources |
    | org.gradle.usage                    | java-api | java-api          |
    | org.gradle.jvm.environment          |          | standard-jvm      |
   Selection reasons:
      - By constraint
      - Forced

org.junit.jupiter:junit-jupiter-api:5.6.3
+--- io.spinnaker.kork:kork-bom:7.182.1
|    \--- testCompileClasspath
+--- org.junit:junit-bom:5.6.3
|    +--- org.junit.jupiter:junit-jupiter-params:5.6.3
|    |    +--- io.spinnaker.kork:kork-bom:7.182.1 (*)
|    |    +--- org.junit:junit-bom:5.6.3 (*)
|    |    \--- org.junit.jupiter:junit-jupiter:5.6.3
|    |         +--- io.spinnaker.kork:kork-bom:7.182.1 (*)
|    |         +--- org.springframework.boot:spring-boot-starter-test:2.5.14 (requested org.junit.jupiter:junit-jupiter:5.7.2)
|    |         |    +--- testCompileClasspath (requested org.springframework.boot:spring-boot-starter-test)
|    |         |    \--- io.spinnaker.kork:kork-bom:7.182.1 (*)
|    |         \--- org.junit:junit-bom:5.6.3 (*)
|    +--- org.junit.jupiter:junit-jupiter-api:5.6.3 (*)
|    +--- org.junit.platform:junit-platform-commons:1.6.3
|    |    +--- io.spinnaker.kork:kork-bom:7.182.1 (*)
|    |    +--- org.junit.jupiter:junit-jupiter-api:5.6.3 (*)
|    |    \--- org.junit:junit-bom:5.6.3 (*)
|    \--- org.junit.jupiter:junit-jupiter:5.6.3 (*)
+--- org.junit.jupiter:junit-jupiter:5.6.3 (*)
\--- org.junit.jupiter:junit-jupiter-params:5.6.3 (*)

org.junit.jupiter:junit-jupiter-params:5.6.3
  Variant apiElements:
    | Attribute Name                      | Provided | Requested         |
    |-------------------------------------|----------|-------------------|
    | org.gradle.status                   | release  |                   |
    | org.jetbrains.kotlin.localToProject | public   |                   |
    | org.jetbrains.kotlin.platform.type  | jvm      |                   |
    | org.gradle.category                 | library  | library           |
    | org.gradle.dependency.bundling      | external | external          |
    | org.gradle.jvm.version              | 8        | 11                |
    | org.gradle.libraryelements          | jar      | classes+resources |
    | org.gradle.usage                    | java-api | java-api          |
    | org.gradle.jvm.environment          |          | standard-jvm      |
   Selection reasons:
      - By constraint
      - Forced

org.junit.jupiter:junit-jupiter-params:5.6.3
+--- io.spinnaker.kork:kork-bom:7.182.1
|    \--- testCompileClasspath
+--- org.junit:junit-bom:5.6.3
|    +--- org.junit.jupiter:junit-jupiter-params:5.6.3 (*)
|    +--- org.junit.jupiter:junit-jupiter-api:5.6.3
|    |    +--- io.spinnaker.kork:kork-bom:7.182.1 (*)
|    |    +--- org.junit.jupiter:junit-jupiter-params:5.6.3 (*)
|    |    +--- org.junit:junit-bom:5.6.3 (*)
|    |    \--- org.junit.jupiter:junit-jupiter:5.6.3
|    |         +--- io.spinnaker.kork:kork-bom:7.182.1 (*)
|    |         +--- org.springframework.boot:spring-boot-starter-test:2.5.14 (requested org.junit.jupiter:junit-jupiter:5.7.2)
|    |         |    +--- testCompileClasspath (requested org.springframework.boot:spring-boot-starter-test)
|    |         |    \--- io.spinnaker.kork:kork-bom:7.182.1 (*)
|    |         \--- org.junit:junit-bom:5.6.3 (*)
|    +--- org.junit.platform:junit-platform-commons:1.6.3
|    |    +--- io.spinnaker.kork:kork-bom:7.182.1 (*)
|    |    +--- org.junit.jupiter:junit-jupiter-api:5.6.3 (*)
|    |    \--- org.junit:junit-bom:5.6.3 (*)
|    \--- org.junit.jupiter:junit-jupiter:5.6.3 (*)
\--- org.junit.jupiter:junit-jupiter:5.6.3 (*)
```
=========================After==============================
```
$ ./gradlew gate-web:dI --dependency org.junit.jupiter --configuration testCompileClasspath

> Task :gate-web:dependencyInsight
org.junit.jupiter:junit-jupiter:5.7.2
  Variant apiElements:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.dependency.bundling | external | external          |
    | org.gradle.jvm.version         | 8        | 11                |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
   Selection reasons:
      - By constraint
      - Forced

org.junit.jupiter:junit-jupiter:5.7.2
+--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT
|    \--- testCompileClasspath
+--- org.junit:junit-bom:5.7.2
|    +--- org.junit.jupiter:junit-jupiter-params:5.7.2
|    |    +--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |    +--- org.junit:junit-bom:5.7.2 (*)
|    |    \--- org.junit.jupiter:junit-jupiter:5.7.2 (*)
|    +--- org.junit.jupiter:junit-jupiter-api:5.7.2
|    |    +--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |    +--- org.junit.jupiter:junit-jupiter-params:5.7.2 (*)
|    |    +--- org.junit:junit-bom:5.7.2 (*)
|    |    \--- org.junit.jupiter:junit-jupiter:5.7.2 (*)
|    +--- org.junit.platform:junit-platform-commons:1.7.2
|    |    +--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |    +--- org.junit.jupiter:junit-jupiter-api:5.7.2 (*)
|    |    \--- org.junit:junit-bom:5.7.2 (*)
|    \--- org.junit.jupiter:junit-jupiter:5.7.2 (*)
\--- org.springframework.boot:spring-boot-starter-test:2.5.14
     +--- testCompileClasspath (requested org.springframework.boot:spring-boot-starter-test)
     \--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)

org.junit.jupiter:junit-jupiter-api:5.7.2
  Variant apiElements:
    | Attribute Name                      | Provided | Requested         |
    |-------------------------------------|----------|-------------------|
    | org.gradle.status                   | release  |                   |
    | org.jetbrains.kotlin.localToProject | public   |                   |
    | org.jetbrains.kotlin.platform.type  | jvm      |                   |
    | org.gradle.category                 | library  | library           |
    | org.gradle.dependency.bundling      | external | external          |
    | org.gradle.jvm.version              | 8        | 11                |
    | org.gradle.libraryelements          | jar      | classes+resources |
    | org.gradle.usage                    | java-api | java-api          |
    | org.gradle.jvm.environment          |          | standard-jvm      |
   Selection reasons:
      - By constraint
      - Forced

org.junit.jupiter:junit-jupiter-api:5.7.2
+--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT
|    \--- testCompileClasspath
+--- org.junit:junit-bom:5.7.2
|    +--- org.junit.jupiter:junit-jupiter-params:5.7.2
|    |    +--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |    +--- org.junit:junit-bom:5.7.2 (*)
|    |    \--- org.junit.jupiter:junit-jupiter:5.7.2
|    |         +--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |         +--- org.springframework.boot:spring-boot-starter-test:2.5.14
|    |         |    +--- testCompileClasspath (requested org.springframework.boot:spring-boot-starter-test)
|    |         |    \--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |         \--- org.junit:junit-bom:5.7.2 (*)
|    +--- org.junit.jupiter:junit-jupiter-api:5.7.2 (*)
|    +--- org.junit.platform:junit-platform-commons:1.7.2
|    |    +--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |    +--- org.junit.jupiter:junit-jupiter-api:5.7.2 (*)
|    |    \--- org.junit:junit-bom:5.7.2 (*)
|    \--- org.junit.jupiter:junit-jupiter:5.7.2 (*)
+--- org.junit.jupiter:junit-jupiter:5.7.2 (*)
\--- org.junit.jupiter:junit-jupiter-params:5.7.2 (*)

org.junit.jupiter:junit-jupiter-params:5.7.2
  Variant apiElements:
    | Attribute Name                      | Provided | Requested         |
    |-------------------------------------|----------|-------------------|
    | org.gradle.status                   | release  |                   |
    | org.jetbrains.kotlin.localToProject | public   |                   |
    | org.jetbrains.kotlin.platform.type  | jvm      |                   |
    | org.gradle.category                 | library  | library           |
    | org.gradle.dependency.bundling      | external | external          |
    | org.gradle.jvm.version              | 8        | 11                |
    | org.gradle.libraryelements          | jar      | classes+resources |
    | org.gradle.usage                    | java-api | java-api          |
    | org.gradle.jvm.environment          |          | standard-jvm      |
   Selection reasons:
      - By constraint
      - Forced

org.junit.jupiter:junit-jupiter-params:5.7.2
+--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT
|    \--- testCompileClasspath
+--- org.junit:junit-bom:5.7.2
|    +--- org.junit.jupiter:junit-jupiter-params:5.7.2 (*)
|    +--- org.junit.jupiter:junit-jupiter-api:5.7.2
|    |    +--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |    +--- org.junit.jupiter:junit-jupiter-params:5.7.2 (*)
|    |    +--- org.junit:junit-bom:5.7.2 (*)
|    |    \--- org.junit.jupiter:junit-jupiter:5.7.2
|    |         +--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |         +--- org.springframework.boot:spring-boot-starter-test:2.5.14
|    |         |    +--- testCompileClasspath (requested org.springframework.boot:spring-boot-starter-test)
|    |         |    \--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |         \--- org.junit:junit-bom:5.7.2 (*)
|    +--- org.junit.platform:junit-platform-commons:1.7.2
|    |    +--- io.spinnaker.kork:kork-bom:junit5-SNAPSHOT (*)
|    |    +--- org.junit.jupiter:junit-jupiter-api:5.7.2 (*)
|    |    \--- org.junit:junit-bom:5.7.2 (*)
|    \--- org.junit.jupiter:junit-jupiter:5.7.2 (*)
\--- org.junit.jupiter:junit-jupiter:5.7.2 (*)
```