### PR TITLE
fix(cve): remove CVE-2022-22965 in springframework libraries

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -191,6 +191,15 @@ dependencies {
     api('org.apache.ant:ant-launcher:1.10.12'){
       because "1.9.15 is resolved transitively through Groovy, removes CVE-2021-36374, CVE-2021-36373, CVE-2020-11979, CVE-2020-15250"
     }
+    api('org.springframework:spring-core:5.3.18') {
+      because "spring-boot-dependencies:2.4.13 brings 5.3.13 and it has CVE-2022-22965, 5.3.18 removes it"
+    }
+    api('org.springframework:spring-beans:5.3.18') {
+      because "spring-boot-dependencies:2.4.13 brings 5.3.13 and it has CVE-2022-22965, 5.3.18 removes it"
+    }
+    api('org.springframework:spring-webmvc:5.3.18') {
+      because "spring-boot-dependencies:2.4.13 brings 5.3.13 and it has CVE-2022-22965, 5.3.18 removes it"
+    }
 
   }
 }


### PR DESCRIPTION
Spinnaker 1.30.x is being affected by the vulnerability CVE-2022-22965 coming from spring-framework dependencies. This is a critical vulnerability we want to fix because it allow to attackers to make remote code execution. Here you will find more info about the vulnerability: https://nvd.nist.gov/vuln/detail/cve-2022-22965

In Spinnaker 1.30.x we use the `spring-boot-dependencies:2.4.13` and it brings `org.springframework:spring-core:5.3.13`, `org.springframework:spring-beans:5.3.13` & `org.springframework:spring-webmvc:5.3.13`. These libraries contains the vulnerability in mention. Here you will find the vulnerabilities in `spring-boot-dependencies:2.4.13` https://mvnrepository.com/artifact/org.springframework.boot/spring-boot/2.4.13

`spring-boot-dependencies` was upgraded in Spinnaker 1.31.x and master and Spinnaker 1.30.x has the latest version of `spring-boot-dependencies:2.4.x` and it is risky to upgrade to a newest minor version in Spinnaker 1.30.x. It also break our rule to don't backport features.

Talking a little bit more about my changes. I included constraint statements to force the version `5.3.18` of `org.springframework:spring-core`, `org.springframework:spring-beans` & `org.springframework:spring-webmvc`. This change force all our OSS services to use `5.3.18` without making risky upgrades in Spring because we upgrade patch version. Here you will find the vulnerability fixed: https://mvnrepository.com/artifact/org.springframework/spring-core/5.3.18

I tested my changes against a few OSS services and I didn't see breaking changes as part of this. Also I generated a custom image and then analyze it with a vulnerability scan tool and the CVE was gone.