### PR TITLE
fix(retrofit): change retrofit and retrofit2 into api dependencies

### DIFF
--- a/kork-retrofit/kork-retrofit.gradle
+++ b/kork-retrofit/kork-retrofit.gradle
@@ -4,14 +4,14 @@ apply from: "$rootDir/gradle/lombok.gradle"
 
 dependencies {
   api(platform(project(":spinnaker-dependencies")))
+  api "com.squareup.retrofit:retrofit"
+  api "com.squareup.retrofit2:retrofit"
 
   implementation project(":kork-web")
 
-  implementation "com.squareup.retrofit:retrofit"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "io.zipkin.brave:brave-instrumentation-okhttp3"
-  implementation "com.squareup.retrofit2:retrofit"
   implementation "com.squareup.retrofit2:converter-jackson"
   implementation "com.squareup.okhttp3:logging-interceptor"
   implementation "com.google.guava:guava"


### PR DESCRIPTION
With RetrofitError (from retrofit1) and retrofit2.client.Response and retrofit2.Response as SpinnakerHttpException constructor arguments, code that uses SpinnakerHttpException needs these jars.

Without them,
https://github.com/spinnaker/clouddriver/actions/runs/5967605769/job/16189606342 fails with:
```
./gradlew :clouddriver-aws:integrationTest

> Task :clouddriver-aws:compileTestGroovy FAILED

FAILURE: Build failed with an exception.

* What went wrong: Execution failed for task ':clouddriver-aws:compileTestGroovy'.
> retrofit2.Response
```