### PR TITLE
fix(retrofit): remove duplicate http response code from SpinnakerHttpException message

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -105,7 +105,7 @@ public class SpinnakerHttpException extends SpinnakerServerException {
     url = e.getUrl();
     responseCode = response.getStatus();
     reason = response.getReason();
-    rawMessage = tmpMessage != null ? tmpMessage : e.getMessage();
+    rawMessage = tmpMessage != null ? tmpMessage : reason;
   }
 
   /**

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java
@@ -143,8 +143,7 @@ public class SpinnakerHttpExceptionTest {
     assertThat(spinnakerHttpException.getResponseBody()).isNull();
     assertThat(spinnakerHttpException.getResponseCode()).isEqualTo(statusCode);
     assertThat(spinnakerHttpException.getMessage())
-        .isEqualTo(
-            "Status: " + statusCode + ", URL: " + url + ", Message: " + retrofitError.getMessage());
+        .isEqualTo("Status: " + statusCode + ", URL: " + url + ", Message: " + reason);
     assertThat(spinnakerHttpException.getUrl()).isEqualTo(url);
     assertThat(spinnakerHttpException.getReason()).isEqualTo(reason);
   }


### PR DESCRIPTION
when there's no message from the http response body

For example:

before: Status: 500, URL: https://some-url, Message: 500 arbitrary reason
after: Status: 500, URL: https://some-url, Message: arbitrary reason