### PR TITLE
feat(artifacts): Add ArtifactReferenceURI to artifact store

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactDeserializer.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactDeserializer.java
@@ -44,7 +44,9 @@ public class ArtifactDeserializer extends StdDeserializer<Artifact> {
   public Artifact deserialize(JsonParser parser, DeserializationContext ctx) throws IOException {
     Artifact artifact = defaultObjectMapper.readValue(parser, Artifact.class);
     if (ArtifactTypes.REMOTE_BASE64.getMimeType().equals(artifact.getType())) {
-      return storage.get(artifact.getReference(), new ArtifactMergeReferenceDecorator(artifact));
+      return storage.get(
+          ArtifactReferenceURI.parse(artifact.getReference()),
+          new ArtifactMergeReferenceDecorator(artifact));
     }
 
     return artifact;

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactReferenceURI.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactReferenceURI.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.artifacts.artifactstore;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * A URI that can parse and allow for ArtifactStorage to easily get specific information about the
+ * URI
+ */
+@Builder
+@Getter
+public class ArtifactReferenceURI {
+  private final String scheme;
+  private final List<String> uriPaths;
+
+  public String uri() {
+    return String.format("%s://%s", scheme, paths());
+  }
+
+  public String paths() {
+    return Strings.join(uriPaths, '/');
+  }
+
+  public static ArtifactReferenceURI parse(String reference) {
+    String noSchemeURI =
+        StringUtils.removeStart(reference, ArtifactStoreURIBuilder.uriScheme + "://");
+    String[] paths = StringUtils.split(noSchemeURI, '/');
+    return ArtifactReferenceURI.builder()
+        .scheme(ArtifactStoreURIBuilder.uriScheme)
+        .uriPaths(Arrays.asList(paths))
+        .build();
+  }
+}

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStore.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStore.java
@@ -34,7 +34,7 @@ public abstract class ArtifactStore {
    * get is used to return an artifact with some id, while also decorating that artifact with any
    * necessary fields needed which should be then be returned by the artifact store.
    */
-  public abstract Artifact get(String id, ArtifactDecorator... decorators);
+  public abstract Artifact get(ArtifactReferenceURI uri, ArtifactDecorator... decorators);
 
   public static void setInstance(ArtifactStore storage) {
     if (!singletonSet.compareAndSet(false, true)) {

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreURIBuilder.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreURIBuilder.java
@@ -32,7 +32,7 @@ public abstract class ArtifactStoreURIBuilder {
    * @param artifact that will be associated with the generated URI.
    * @return the remote URI
    */
-  public abstract String buildArtifactURI(String context, Artifact artifact);
+  public abstract ArtifactReferenceURI buildArtifactURI(String context, Artifact artifact);
 
   /**
    * buildRawURI is used when you have the raw path and context. This method just simply returns the
@@ -56,8 +56,8 @@ public abstract class ArtifactStoreURIBuilder {
    * }</pre>
    *
    * @param context is the context in which this artifact was run in, e.g. the application.
-   * @param raw is the identifier used in the URL, e.g. the hash.
+   * @param paths are any individual path required for distinguishing an artifact.
    * @return a properly formatted artifact store URI
    */
-  public abstract String buildRawURI(String context, String raw);
+  public abstract ArtifactReferenceURI buildURIFromPaths(String context, String... paths);
 }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStore.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStore.java
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.kork.artifacts.artifactstore.s3;
 
 import com.netflix.spinnaker.kork.artifacts.ArtifactTypes;
 import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactDecorator;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactReferenceURI;
 import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStore;
 import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreURIBuilder;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
@@ -89,9 +90,12 @@ public class S3ArtifactStore extends ArtifactStore {
       return artifact;
     }
 
-    String ref = uriBuilder.buildArtifactURI(application, artifact);
+    ArtifactReferenceURI ref = uriBuilder.buildArtifactURI(application, artifact);
     Artifact remoteArtifact =
-        artifact.toBuilder().type(ArtifactTypes.REMOTE_BASE64.getMimeType()).reference(ref).build();
+        artifact.toBuilder()
+            .type(ArtifactTypes.REMOTE_BASE64.getMimeType())
+            .reference(ref.uri())
+            .build();
 
     if (objectExists(ref)) {
       return remoteArtifact;
@@ -104,7 +108,7 @@ public class S3ArtifactStore extends ArtifactStore {
     PutObjectRequest request =
         PutObjectRequest.builder()
             .bucket(bucket)
-            .key(ref)
+            .key(ref.paths())
             .tagging(Tagging.builder().tagSet(accountTag).build())
             .build();
 
@@ -131,14 +135,14 @@ public class S3ArtifactStore extends ArtifactStore {
    * ArtifactDecorator} to further populate the artifact for returning
    */
   @Override
-  public Artifact get(String id, ArtifactDecorator... decorators) {
+  public Artifact get(ArtifactReferenceURI uri, ArtifactDecorator... decorators) {
     hasAuthorization(
-        id,
+        uri,
         AuthenticatedRequest.getSpinnakerUser()
             .orElseThrow(
                 () -> new NoSuchElementException("Could not authenticate due to missing user id")));
 
-    GetObjectRequest request = GetObjectRequest.builder().bucket(bucket).key(id).build();
+    GetObjectRequest request = GetObjectRequest.builder().bucket(bucket).key(uri.paths()).build();
 
     ResponseBytes<GetObjectResponse> resp = s3Client.getObjectAsBytes(request);
     Artifact.ArtifactBuilder builder =
@@ -163,9 +167,9 @@ public class S3ArtifactStore extends ArtifactStore {
    *
    * @throws AuthenticationServiceException when user does not have correct permissions
    */
-  private void hasAuthorization(String id, String userId) {
+  private void hasAuthorization(ArtifactReferenceURI uri, String userId) {
     GetObjectTaggingRequest request =
-        GetObjectTaggingRequest.builder().bucket(bucket).key(id).build();
+        GetObjectTaggingRequest.builder().bucket(bucket).key(uri.paths()).build();
 
     GetObjectTaggingResponse resp = s3Client.getObjectTagging(request);
     Tag tag =
@@ -193,15 +197,16 @@ public class S3ArtifactStore extends ArtifactStore {
    * writes of the same object is important, another filestore/db needs to be used, possibly
    * dynamodb.
    */
-  private boolean objectExists(String id) {
-    HeadObjectRequest request = HeadObjectRequest.builder().bucket(bucket).key(id).build();
+  private boolean objectExists(ArtifactReferenceURI uri) {
+    HeadObjectRequest request = HeadObjectRequest.builder().bucket(bucket).key(uri.paths()).build();
     try {
       s3Client.headObject(request);
+      log.info("Artifact exists. No need to store. reference={}", uri.uri());
       return true;
     } catch (NoSuchKeyException e) {
       // pretty gross that we need to use exceptions as control flow, but the
       // java SDK doesn't have any other way of check if an object exists in s3
-      log.warn("Artifact does not exist reference={}", id, e);
+      log.warn("Artifact does not exist reference={}", uri.uri());
       return false;
     }
   }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStore.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStore.java
@@ -201,12 +201,12 @@ public class S3ArtifactStore extends ArtifactStore {
     HeadObjectRequest request = HeadObjectRequest.builder().bucket(bucket).key(uri.paths()).build();
     try {
       s3Client.headObject(request);
-      log.info("Artifact exists. No need to store. reference={}", uri.uri());
+      log.debug("Artifact exists. No need to store. reference={}", uri.uri());
       return true;
     } catch (NoSuchKeyException e) {
       // pretty gross that we need to use exceptions as control flow, but the
       // java SDK doesn't have any other way of check if an object exists in s3
-      log.warn("Artifact does not exist reference={}", uri.uri());
+      log.info("Artifact does not exist reference={}", uri.uri());
       return false;
     }
   }

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactDeserializerTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactDeserializerTest.java
@@ -43,23 +43,22 @@ class ArtifactDeserializerTest {
     }
 
     @Override
-    public Artifact get(String id, ArtifactDecorator... decorator) {
-      return storageMap.get(id);
+    public Artifact get(ArtifactReferenceURI uri, ArtifactDecorator... decorator) {
+      return storageMap.get(uri.uri());
     }
   }
 
   @Test
   public void simpleDeserialization() throws IOException {
     String artifactJSON =
-        "{\"type\":\"remote/base64\",\"customKind\":false,\"name\":null,\"version\":null,\"location\":null,\"reference\":\"stored://link\",\"metadata\":{},\"artifactAccount\":null,\"provenance\":null,\"uuid\":null}";
+        "{\"type\":\"remote/base64\",\"customKind\":false,\"name\":null,\"version\":null,\"location\":null,\"reference\":\"ref://link\",\"metadata\":{},\"artifactAccount\":null,\"provenance\":null,\"uuid\":null}";
     String expectedReference = "foobar";
     Artifact expectedArtifact =
         Artifact.builder()
             .type(ArtifactTypes.REMOTE_BASE64.getMimeType())
             .reference(expectedReference)
             .build();
-    InMemoryArtifactStore storage =
-        new InMemoryArtifactStore().put("stored://link", expectedArtifact);
+    InMemoryArtifactStore storage = new InMemoryArtifactStore().put("ref://link", expectedArtifact);
     ArtifactDeserializer deserializer = new ArtifactDeserializer(new ObjectMapper(), storage);
 
     // We avoid using an object mapper here since the Artifact class has a

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactReferenceURITest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactReferenceURITest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.artifacts.artifactstore;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+class ArtifactReferenceURITest {
+  @Test
+  public void testParse() {
+    String expectedRef = "ref://path1/path2/path3/path4";
+    ArtifactReferenceURI uri = ArtifactReferenceURI.parse(expectedRef);
+    List<String> expectedPaths = List.of("path1", "path2", "path3", "path4");
+
+    assertEquals(expectedRef, uri.uri());
+    assertEquals(expectedPaths, uri.getUriPaths());
+    assertEquals(StringUtils.join(expectedPaths, '/'), uri.paths());
+  }
+}

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreURISHA256BuilderTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreURISHA256BuilderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.artifacts.artifactstore;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.common.hash.Hashing;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class ArtifactStoreURISHA256BuilderTest {
+  @Test
+  public void testSimpleURI() {
+    ArtifactStoreURIBuilder builder = new ArtifactStoreURISHA256Builder();
+    ArtifactReferenceURI uri = builder.buildURIFromPaths("application", "foo");
+    String expectedURIString = "ref://application/foo";
+    String expectedPaths = "application/foo";
+    assertEquals(expectedURIString, uri.uri());
+    assertEquals(expectedPaths, uri.paths());
+  }
+
+  @Test
+  public void testProperSHA() {
+    ArtifactStoreURIBuilder builder = new ArtifactStoreURISHA256Builder();
+    String reference = "hello world";
+    String expectedSHA =
+        Hashing.sha256().hashBytes(reference.getBytes(StandardCharsets.UTF_8)).toString();
+    Artifact artifact = Artifact.builder().type("embedded/base64").reference(reference).build();
+    ArtifactReferenceURI uri = builder.buildArtifactURI("application", artifact);
+    String expectedURIString = "ref://application/" + expectedSHA;
+    String expectedPaths = "application/" + expectedSHA;
+    assertEquals(expectedURIString, uri.uri());
+    assertEquals(expectedPaths, uri.paths());
+  }
+}

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ArtifactUriToReferenceConverter.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ArtifactUriToReferenceConverter.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.kork.expressions;
 
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactReferenceURI;
 import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStore;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.convert.TypeDescriptor;
@@ -58,6 +59,6 @@ public class ArtifactUriToReferenceConverter implements TypeConverter {
       return defaultTypeConverter.convertValue(value, sourceType, targetType);
     }
 
-    return artifactStore.get((String) value).getReference();
+    return artifactStore.get(ArtifactReferenceURI.parse((String) value)).getReference();
   }
 }

--- a/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupportTest.java
+++ b/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupportTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactDecorator;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactReferenceURI;
 import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStore;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.expressions.config.ExpressionProperties;
@@ -160,8 +161,8 @@ public class ExpressionsSupportTest {
     }
 
     @Override
-    public Artifact get(String id, ArtifactDecorator... decorators) {
-      String reference = cache.get(id);
+    public Artifact get(ArtifactReferenceURI uri, ArtifactDecorator... decorators) {
+      String reference = cache.get(uri.uri());
       Artifact.ArtifactBuilder builder =
           Artifact.builder()
               .reference(


### PR DESCRIPTION
This commit adds a new URI type to the artifact store signature. This allows for storage implementation to more easily use certain pieces of the URI for storage. For example, with this commit, artifacts stored as S3 objects will no longer have the `ref://` prefix, allowing for a better AWS console experience