### PR TITLE
fix(artifact): Handle exceptions better in artifact store

### DIFF
--- a/kork-artifacts/kork-artifacts.gradle
+++ b/kork-artifacts/kork-artifacts.gradle
@@ -20,5 +20,6 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.mockito:mockito-core"
+  testImplementation project(":kork-core")
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactDeserializer.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactDeserializer.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.netflix.spinnaker.kork.artifacts.ArtifactTypes;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.exceptions.ArtifactStoreIOException;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -44,9 +45,11 @@ public class ArtifactDeserializer extends StdDeserializer<Artifact> {
   public Artifact deserialize(JsonParser parser, DeserializationContext ctx) throws IOException {
     Artifact artifact = defaultObjectMapper.readValue(parser, Artifact.class);
     if (ArtifactTypes.REMOTE_BASE64.getMimeType().equals(artifact.getType())) {
-      return storage.get(
-          ArtifactReferenceURI.parse(artifact.getReference()),
-          new ArtifactMergeReferenceDecorator(artifact));
+      return ArtifactStoreIOException.throwIOException(
+          () ->
+              storage.get(
+                  ArtifactReferenceURI.parse(artifact.getReference()),
+                  new ArtifactMergeReferenceDecorator(artifact)));
     }
 
     return artifact;

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/EmbeddedArtifactSerializer.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/EmbeddedArtifactSerializer.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.netflix.spinnaker.kork.artifacts.ArtifactTypes;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.exceptions.ArtifactStoreIOException;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
 
@@ -45,7 +46,7 @@ public class EmbeddedArtifactSerializer extends StdSerializer<Artifact> {
       return;
     }
 
-    Artifact stored = storage.store(artifact);
+    Artifact stored = ArtifactStoreIOException.throwIOException(() -> storage.store(artifact));
     defaultObjectMapper.writeValue(gen, stored);
   }
 

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/exceptions/ArtifactStoreIOException.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/exceptions/ArtifactStoreIOException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.artifacts.artifactstore.exceptions;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/**
+ * An exception used by the artifact store (de)serializers since the (de)serialize methods only
+ * throw IOExceptions, and if any other exception is thrown jackson assumes it's some JSON error.
+ */
+public class ArtifactStoreIOException extends IOException {
+  public ArtifactStoreIOException(Exception e) {
+    super(e);
+  }
+
+  /**
+   * Helper methods to catch any exception thrown by a method and instead throw an
+   * ArtifactStoreIOException
+   */
+  public static <T> T throwIOException(Supplier<T> fn) throws IOException {
+    try {
+      return fn.get();
+    } catch (Exception e) {
+      throw new ArtifactStoreIOException(e);
+    }
+  }
+}

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/EmbeddedArtifactSerializerTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/EmbeddedArtifactSerializerTest.java
@@ -84,7 +84,7 @@ class EmbeddedArtifactSerializerTest {
                   new ByteArrayOutputStream(),
                   Artifact.builder()
                       .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
-                      .reference("aGVsbG8gd29ybGQK")
+                      .reference("aGVsbG8gd29ybGQK") // arbitrary
                       .build());
             });
 

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/EmbeddedArtifactSerializerTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/EmbeddedArtifactSerializerTest.java
@@ -16,20 +16,29 @@
 package com.netflix.spinnaker.kork.artifacts.artifactstore;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.netflix.spinnaker.kork.artifacts.ArtifactTypes;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.exceptions.ArtifactStoreIOException;
 import com.netflix.spinnaker.kork.artifacts.artifactstore.s3.S3ArtifactStore;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.common.Header;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.stream.Stream;
 import org.apache.commons.codec.binary.Base64;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 class EmbeddedArtifactSerializerTest {
   @ParameterizedTest(name = "{index} {0}")
@@ -49,6 +58,39 @@ class EmbeddedArtifactSerializerTest {
 
     String result = objectMapper.writeValueAsString(artifact);
     assertEquals(expectedJson, result);
+  }
+
+  @Test
+  public void ensureS3ExceptionHasProperMessages() {
+    S3Client client = mock(S3Client.class);
+    when(client.headObject((HeadObjectRequest) Mockito.any()))
+        .thenThrow(S3Exception.builder().statusCode(400).build());
+    AuthenticatedRequest.set(Header.APPLICATION, "my-application");
+    S3ArtifactStore artifactStore =
+        new S3ArtifactStore(client, null, "my-bucket", new ArtifactStoreURISHA256Builder(), null);
+
+    EmbeddedArtifactSerializer serializer =
+        new EmbeddedArtifactSerializer(new ObjectMapper(), artifactStore);
+    ObjectMapper objectMapper = new ObjectMapper();
+    SimpleModule module = new SimpleModule();
+    module.addSerializer(Artifact.class, serializer);
+    objectMapper.registerModule(module);
+
+    ArtifactStoreIOException e =
+        assertThrows(
+            ArtifactStoreIOException.class,
+            () -> {
+              objectMapper.writeValue(
+                  new ByteArrayOutputStream(),
+                  Artifact.builder()
+                      .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
+                      .reference("aGVsbG8gd29ybGQK")
+                      .build());
+            });
+
+    String expectedExceptionMessage =
+        "com.netflix.spinnaker.kork.exceptions.SpinnakerException: Failed to query artifact due to invalid request";
+    assertEquals(expectedExceptionMessage, e.getMessage());
   }
 
   private static Stream<Arguments> generateTestCase() {

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/exceptions/ArtifactStoreIOExceptionTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/exceptions/ArtifactStoreIOExceptionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.artifacts.artifactstore.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class ArtifactStoreIOExceptionTest {
+  @Test
+  public void validateThrowingException() {
+    String expectedMessage = "foobar";
+
+    // assertThrows does not work with closures properly
+    // see https://github.com/junit-team/junit5/issues/1414
+    try {
+      ArtifactStoreIOException.throwIOException(
+          () -> {
+            throw new RuntimeException(expectedMessage);
+          });
+
+      fail();
+    } catch (IOException e) {
+      assertEquals(expectedMessage, e.getCause().getMessage());
+    }
+  }
+
+  @Test
+  public void validateNoThrow() throws IOException {
+    String expected = "foo";
+    String received = ArtifactStoreIOException.throwIOException(() -> "foo");
+
+    assertEquals(expected, received);
+  }
+}

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.artifacts.artifactstore.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.kork.artifacts.ArtifactTypes;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreURISHA256Builder;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.common.Header;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class S3ArtifactStoreTest {
+  @Test
+  public void testExceptionPathOfObjectExists() {
+    S3Client client = mock(S3Client.class);
+    when(client.headObject((HeadObjectRequest) Mockito.any()))
+        .thenThrow(S3Exception.builder().statusCode(400).build());
+    AuthenticatedRequest.set(Header.APPLICATION, "my-application");
+    S3ArtifactStore artifactStore =
+        new S3ArtifactStore(client, null, "my-bucket", new ArtifactStoreURISHA256Builder(), null);
+    String expectedExceptionMessage = "Failed to query artifact due to invalid request";
+    SpinnakerException e =
+        Assertions.assertThrows(
+            SpinnakerException.class,
+            () -> {
+              artifactStore.store(
+                  Artifact.builder()
+                      .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
+                      .reference("aGVsbG8gd29ybGQK")
+                      .build());
+            });
+    assertEquals(expectedExceptionMessage, e.getMessage());
+  }
+}


### PR DESCRIPTION
Prior to this commit, when the head object in s3 artifact store throws an exception in (de)serializer, we get a pretty bland exception back

```json
{"timestamp":"2023-09-25T17:54:02.550+00:00","status":500,"error":"Internal
Server Error"}
```

With this commit we will now see:
```json
{"timestamp":"2023-10-02T23:21:42.183+00:00","status":500,"error":"Internal Server Error","exception":"com.netflix.spinnaker.kork.artifacts.artifactstore.exceptions.ArtifactStoreIOException","message":"com.netflix.spinnaker.kork.exceptions.SpinnakerException: Failed to query artifact due to IAM permissions either on the bucket or object"}
```

The fix here was to intercept any `Exception` from the artifact store calls and ensure we rethrow a `ArtifactStoreIOException`. The reason why we rethrow an `IOException` is due to what jackson does with exceptions. If we do not throw an `IOException`, then jackson will wrap it in a JSON exception which is confusing to end user.