### PR TITLE
fix(retrofit): Add exception handler to service factory

### DIFF
--- a/kork-retrofit/kork-retrofit.gradle
+++ b/kork-retrofit/kork-retrofit.gradle
@@ -22,6 +22,8 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "com.netflix.spectator:spectator-reg-micrometer"
   testImplementation "com.squareup.okhttp3:mockwebserver"
+  testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"
+  testImplementation "ru.lanwen.wiremock:wiremock-junit5:1.2.0"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
 }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactory.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactory.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.client.ServiceClientFactory;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import retrofit.Endpoint;
 import retrofit.RequestInterceptor;
@@ -54,6 +55,7 @@ class RetrofitServiceFactory implements ServiceClientFactory {
         .setRequestInterceptor(spinnakerRequestInterceptor)
         .setConverter(new JacksonConverter(objectMapper))
         .setEndpoint(endpoint)
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
         .setClient(new Ok3Client(clientProvider.getClient(serviceEndpoint)))
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(type))

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -42,11 +42,11 @@ import retrofit2.Retrofit;
 @Slf4j
 public class SpinnakerHttpException extends SpinnakerServerException {
 
-  private final Response response;
+  private final transient Response response;
 
   private HttpHeaders headers;
 
-  private final retrofit2.Response<?> retrofit2Response;
+  private final transient retrofit2.Response<?> retrofit2Response;
 
   /**
    * A message derived from a RetrofitError's response body, or null if a custom message has been

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/UpstreamBadRequest.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/UpstreamBadRequest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static retrofit.RetrofitError.Kind.HTTP;
+
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import java.util.Collection;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+/**
+ * UpstreamBadRequest is used as a safe replacement for RetrofitError. RetrofitError poses issues
+ * around serialization due to containing many unserializable fields. Retrofit v2 made changes that
+ * allows for easy exception handling which converts the exception directly upon the response,
+ * rather than what v1 does by wrapping the raw payload in a RetrofitError to later be handled by
+ * users.
+ *
+ * @see <a href="https://github.com/square/retrofit/issues/669">GH issue #669</a>
+ */
+@Log4j2
+public class UpstreamBadRequest extends SpinnakerException {
+  @Getter private final int status;
+  @Getter private final String url;
+  @Getter private final Object error;
+
+  public UpstreamBadRequest(RetrofitError cause) {
+    // we do not pass the retrofit error into the super, since the error is not
+    // serializable.
+    super(cause.getMessage());
+    this.setStackTrace(cause.getStackTrace());
+    Response response = cause.getResponse();
+    // response will be null for network retrofit errors
+    status = (response != null) ? response.getStatus() : 0;
+    url = cause.getUrl();
+    Object body = null;
+    try {
+      // retrofit will pass a type when calling `getBody`, which may not be
+      // serialiazable. So instead we will pass an object and let the object
+      // mapper figure out what type is appropriate.
+      body = cause.getBodyAs(Object.class);
+    } catch (Exception e) {
+      // exceptions that could potentially occur are around converting the
+      // response to an object.
+      //
+      // A common reason could be that the response is not JSON and would thus
+      // fail the conversion. So instead we will ignore the exception
+      log.warn("failed to unmarshal body from response url={}", cause.getUrl(), e);
+    }
+
+    error = body;
+  }
+
+  @Deprecated(since = "2023-10-20", forRemoval = true)
+  public static RuntimeException classifyError(RetrofitError error) {
+    if (error.getKind() == HTTP
+        && error.getResponse().getStatus() < INTERNAL_SERVER_ERROR.value()) {
+      return new UpstreamBadRequest(error);
+    } else {
+      return error;
+    }
+  }
+
+  @Deprecated(since = "2023-10-20", forRemoval = true)
+  public static RuntimeException classifyError(
+      RetrofitError error, Collection<Integer> supportedHttpStatuses) {
+    if (error.getKind() == HTTP
+        && supportedHttpStatuses.contains(error.getResponse().getStatus())) {
+      return new UpstreamBadRequest(error);
+    } else {
+      return error;
+    }
+  }
+
+  public static RuntimeException classifyError(SpinnakerServerException e) {
+    Throwable cause = e.getCause();
+    if (cause instanceof UpstreamBadRequest) {
+      // this can only happen if the exception handler intercepted a
+      // non-RetrofitError.
+      return e;
+    }
+
+    RetrofitError re = e.getRetrofitError();
+    if (re == null) {
+      // this can occur if SpinnakerServerExceptions were constructed from a
+      // throwable that was not a RetrofitError.
+      return e;
+    }
+
+    // if we properly handled the RetrofitError, then this should not occur.
+    return new UpstreamBadRequest(re);
+  }
+}

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactoryTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactoryTest.java
@@ -1,0 +1,75 @@
+package com.netflix.spinnaker.kork.retrofit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.matching.UrlPattern;
+import com.netflix.spinnaker.config.DefaultServiceEndpoint;
+import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import retrofit.RestAdapter;
+import retrofit.client.Response;
+import retrofit.http.GET;
+
+class RetrofitServiceFactoryTest {
+  public interface RestService {
+    @GET("/")
+    Response exec();
+  }
+
+  @Test
+  void TestUnwrappedException() {
+    WireMockServer wireMockServer =
+        new WireMockServer(options().dynamicPort().notifier(new Slf4jNotifier(false)));
+    try {
+      wireMockServer.start();
+      // Exceptions returned by any service will get converted to a retrofit
+      // error from the client's retrofit hooks. So, the expectation here is
+      // that we expect to get the original exception back and not some nested
+      // retrofit error.
+      String body =
+          "{\"timestamp\":\"2023-10-16T22:04:22.207+00:00\",\"status\":500,\"error\":\"Internal Server Error\",\"message\":\"random exception\"}";
+      wireMockServer.stubFor(
+          WireMock.any(UrlPattern.ANY)
+              .inScenario("Retry Scenario")
+              .willReturn(
+                  aResponse()
+                      .withStatus(500)
+                      .withHeader("Content-Type", "application/json")
+                      .withBody(body)
+                      .withFixedDelay(100)));
+
+      OkHttpClientProvider clientProvider = Mockito.mock(OkHttpClientProvider.class);
+      Mockito.when(clientProvider.getClient(Mockito.any())).thenReturn(new OkHttpClient());
+      RetrofitServiceFactory factory =
+          new RetrofitServiceFactory(
+              RestAdapter.LogLevel.NONE,
+              clientProvider,
+              new SpinnakerRequestInterceptor(new OkHttpClientConfigurationProperties()));
+      RestService service =
+          factory.create(
+              RestService.class,
+              new DefaultServiceEndpoint("testUnwrappedExceptionClient", wireMockServer.baseUrl()),
+              new ObjectMapper());
+
+      Response resp = service.exec();
+      fail("HTTP request should have failed, but succeeded");
+    } catch (Exception e) {
+      assertTrue(e instanceof SpinnakerHttpException);
+      assertNotNull(e.getMessage());
+      assertTrue(e.getMessage().contains("random exception"));
+    } finally {
+      wireMockServer.stop();
+    }
+  }
+}

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SerializableExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SerializableExceptionTest.java
@@ -1,0 +1,34 @@
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+import retrofit.converter.JacksonConverter;
+import retrofit.mime.TypedString;
+import wiremock.org.apache.commons.lang3.SerializationUtils;
+
+public class SerializableExceptionTest {
+  @ParameterizedTest
+  @MethodSource("parameters")
+  void ensureSerializable(Function<RetrofitError, Throwable> call) {
+    String url = "http://localhost";
+    int statusCode = 500;
+    String reason = "some reason";
+    String body = "{}";
+    Response response = new Response(url, statusCode, reason, List.of(), new TypedString(body));
+    RetrofitError retrofitError =
+        RetrofitError.httpError(url, response, new JacksonConverter(), Map.class);
+    Throwable e = call.apply(retrofitError);
+    SerializationUtils.roundtrip(e);
+  }
+
+  private static Stream<Function<RetrofitError, Throwable>> parameters() {
+    return Stream.of(
+        SpinnakerHttpException::new, SpinnakerNetworkException::new, SpinnakerServerException::new);
+  }
+}


### PR DESCRIPTION
This commit adds the SpinnakerRetroExceptionHandler when creating service clients which allows us to return a proper exception back instead of relying on RetrofitError.

This commit also moves the UpstreamBadRequest to the more appropriate package of kork-retrofit. This allows for other classes within kork-retrofit to use it without creating a circular dependency. In addition this also makes the UpstreamBadRequest class serializable by not passing the RetrofitError into the super call.