### PR TITLE
feat(retrofit): move url attribute from SpinnakerHttpException to SpinnakerServerException

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/ErrorHandlingExecutorCallAdapterFactory.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/ErrorHandlingExecutorCallAdapterFactory.java
@@ -153,11 +153,11 @@ public class ErrorHandlingExecutorCallAdapterFactory extends CallAdapter.Factory
         }
       } catch (JsonProcessingException jpe) {
         throw new SpinnakerConversionException(
-            "Failed to process response body", jpe, delegate.request().url().toString());
+            "Failed to process response body", jpe, delegate.request());
       } catch (IOException e) {
-        throw new SpinnakerNetworkException(e, delegate.request().url().toString());
+        throw new SpinnakerNetworkException(e, delegate.request());
       } catch (Exception e) {
-        throw new SpinnakerServerException(e, delegate.request().url().toString());
+        throw new SpinnakerServerException(e, delegate.request());
       }
       throw new SpinnakerHttpException(syncResp, retrofit);
     }
@@ -251,11 +251,11 @@ public class ErrorHandlingExecutorCallAdapterFactory extends CallAdapter.Factory
 
       SpinnakerServerException exception;
       if (t instanceof IOException) {
-        exception = new SpinnakerNetworkException(t, call.request().url().toString());
+        exception = new SpinnakerNetworkException(t, call.request());
       } else if (t instanceof SpinnakerHttpException) {
         exception = (SpinnakerHttpException) t;
       } else {
-        exception = new SpinnakerServerException(t, call.request().url().toString());
+        exception = new SpinnakerServerException(t, call.request());
       }
       final SpinnakerServerException finalException = exception;
       callbackExecutor.execute(

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/ErrorHandlingExecutorCallAdapterFactory.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/ErrorHandlingExecutorCallAdapterFactory.java
@@ -152,11 +152,12 @@ public class ErrorHandlingExecutorCallAdapterFactory extends CallAdapter.Factory
           return syncResp;
         }
       } catch (JsonProcessingException jpe) {
-        throw new SpinnakerConversionException("Failed to process response body", jpe);
+        throw new SpinnakerConversionException(
+            "Failed to process response body", jpe, delegate.request().url().toString());
       } catch (IOException e) {
-        throw new SpinnakerNetworkException(e);
+        throw new SpinnakerNetworkException(e, delegate.request().url().toString());
       } catch (Exception e) {
-        throw new SpinnakerServerException(e);
+        throw new SpinnakerServerException(e, delegate.request().url().toString());
       }
       throw new SpinnakerHttpException(syncResp, retrofit);
     }
@@ -250,11 +251,11 @@ public class ErrorHandlingExecutorCallAdapterFactory extends CallAdapter.Factory
 
       SpinnakerServerException exception;
       if (t instanceof IOException) {
-        exception = new SpinnakerNetworkException(t);
+        exception = new SpinnakerNetworkException(t, call.request().url().toString());
       } else if (t instanceof SpinnakerHttpException) {
         exception = (SpinnakerHttpException) t;
       } else {
-        exception = new SpinnakerServerException(t);
+        exception = new SpinnakerServerException(t, call.request().url().toString());
       }
       final SpinnakerServerException finalException = exception;
       callbackExecutor.execute(

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2SyncCall.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2SyncCall.java
@@ -33,7 +33,7 @@ public class Retrofit2SyncCall<T> {
     try {
       return call.execute().body();
     } catch (IOException e) {
-      throw new SpinnakerNetworkException(e);
+      throw new SpinnakerNetworkException(e, call.request().url().toString());
     }
   }
 }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2SyncCall.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2SyncCall.java
@@ -33,7 +33,7 @@ public class Retrofit2SyncCall<T> {
     try {
       return call.execute().body();
     } catch (IOException e) {
-      throw new SpinnakerNetworkException(e, call.request().url().toString());
+      throw new SpinnakerNetworkException(e, call.request());
     }
   }
 }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerConversionException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerConversionException.java
@@ -22,17 +22,28 @@ import retrofit.RetrofitError;
 /** Wraps an exception converting a successful retrofit http response body to its indicated type */
 public class SpinnakerConversionException extends SpinnakerServerException {
 
+  /**
+   * Construct a SpinnakerServerException from retrofit2 with a message and cause (e.g. an exception
+   * converting a response to the specified type).
+   */
   public SpinnakerConversionException(String message, Throwable cause, Request request) {
     super(message, cause, request);
     setRetryable(false);
   }
 
+  /**
+   * Construct a SpinnakerConversionException from another SpinnakerConversionException (e.g. via
+   * newInstance).
+   */
   public SpinnakerConversionException(String message, SpinnakerConversionException cause) {
     super(message, cause);
+    setRetryable(false);
   }
 
+  /** Construct a SpinnakerConversionException corresponding to a RetrofitError. */
   public SpinnakerConversionException(RetrofitError e) {
     super(e);
+    setRetryable(false);
   }
 
   @Override

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerConversionException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerConversionException.java
@@ -16,12 +16,22 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
+import retrofit.RetrofitError;
+
 /** Wraps an exception converting a successful retrofit http response body to its indicated type */
 public class SpinnakerConversionException extends SpinnakerServerException {
 
-  public SpinnakerConversionException(String message, Throwable cause) {
-    super(message, cause);
+  public SpinnakerConversionException(String message, Throwable cause, String url) {
+    super(message, cause, url);
     setRetryable(false);
+  }
+
+  public SpinnakerConversionException(String message, SpinnakerConversionException cause) {
+    super(message, cause);
+  }
+
+  public SpinnakerConversionException(RetrofitError e) {
+    super(e);
   }
 
   @Override

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerConversionException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerConversionException.java
@@ -16,13 +16,14 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
+import okhttp3.Request;
 import retrofit.RetrofitError;
 
 /** Wraps an exception converting a successful retrofit http response body to its indicated type */
 public class SpinnakerConversionException extends SpinnakerServerException {
 
-  public SpinnakerConversionException(String message, Throwable cause, String url) {
-    super(message, cause, url);
+  public SpinnakerConversionException(String message, Throwable cause, Request request) {
+    super(message, cause, request);
     setRetryable(false);
   }
 

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -64,6 +64,7 @@ public class SpinnakerHttpException extends SpinnakerServerException {
    */
   private final String reason;
 
+  /** Construct a SpinnakerHttpException corresponding to a RetrofitError. */
   public SpinnakerHttpException(RetrofitError e) {
     super(e);
 

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -110,7 +110,7 @@ public class SpinnakerHttpException extends SpinnakerServerException {
    */
   public SpinnakerHttpException(
       retrofit2.Response<?> retrofit2Response, retrofit2.Retrofit retrofit) {
-    super(retrofit2Response);
+    super(retrofit2Response.raw().request());
     this.response = null;
     this.retrofit2Response = retrofit2Response;
     if ((retrofit2Response.code() == HttpStatus.NOT_FOUND.value())

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -56,8 +56,6 @@ public class SpinnakerHttpException extends SpinnakerServerException {
 
   private final Map<String, Object> responseBody;
 
-  private final String url;
-
   private final int responseCode;
 
   /**
@@ -101,7 +99,6 @@ public class SpinnakerHttpException extends SpinnakerServerException {
     if (responseBody != null) {
       tmpMessage = (String) responseBody.get("message");
     }
-    url = e.getUrl();
     responseCode = response.getStatus();
     reason = response.getReason();
     rawMessage = tmpMessage != null ? tmpMessage : reason;
@@ -113,6 +110,7 @@ public class SpinnakerHttpException extends SpinnakerServerException {
    */
   public SpinnakerHttpException(
       retrofit2.Response<?> retrofit2Response, retrofit2.Retrofit retrofit) {
+    super(retrofit2Response);
     this.response = null;
     this.retrofit2Response = retrofit2Response;
     if ((retrofit2Response.code() == HttpStatus.NOT_FOUND.value())
@@ -120,7 +118,6 @@ public class SpinnakerHttpException extends SpinnakerServerException {
       setRetryable(false);
     }
     responseBody = this.getErrorBodyAs(retrofit);
-    url = retrofit2Response.raw().request().url().toString();
     responseCode = retrofit2Response.code();
     reason = retrofit2Response.message();
     this.rawMessage =
@@ -159,7 +156,6 @@ public class SpinnakerHttpException extends SpinnakerServerException {
     this.retrofit2Response = cause.retrofit2Response;
     rawMessage = null;
     this.responseBody = cause.responseBody;
-    this.url = cause.url;
     this.responseCode = cause.responseCode;
     this.reason = cause.reason;
   }
@@ -197,7 +193,8 @@ public class SpinnakerHttpException extends SpinnakerServerException {
       return super.getMessage();
     }
 
-    return String.format("Status: %s, URL: %s, Message: %s", responseCode, url, getRawMessage());
+    return String.format(
+        "Status: %s, URL: %s, Message: %s", responseCode, this.getUrl(), getRawMessage());
   }
 
   @Override
@@ -207,10 +204,6 @@ public class SpinnakerHttpException extends SpinnakerServerException {
 
   public Map<String, Object> getResponseBody() {
     return this.responseBody;
-  }
-
-  public String getUrl() {
-    return this.url;
   }
 
   public String getReason() {

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
@@ -22,12 +22,16 @@ import retrofit.RetrofitError;
 /** Wraps an exception of kind {@link RetrofitError.Kind} NETWORK. */
 @NonnullByDefault
 public final class SpinnakerNetworkException extends SpinnakerServerException {
-  public SpinnakerNetworkException(Throwable cause) {
-    super(cause);
+  public SpinnakerNetworkException(Throwable cause, String url) {
+    super(cause, url);
   }
 
-  public SpinnakerNetworkException(String message, Throwable cause) {
+  public SpinnakerNetworkException(String message, SpinnakerNetworkException cause) {
     super(message, cause);
+  }
+
+  public SpinnakerNetworkException(RetrofitError e) {
+    super(e);
   }
 
   @Override

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
@@ -17,13 +17,14 @@
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import okhttp3.Request;
 import retrofit.RetrofitError;
 
 /** Wraps an exception of kind {@link RetrofitError.Kind} NETWORK. */
 @NonnullByDefault
 public final class SpinnakerNetworkException extends SpinnakerServerException {
-  public SpinnakerNetworkException(Throwable cause, String url) {
-    super(cause, url);
+  public SpinnakerNetworkException(Throwable cause, Request request) {
+    super(cause, request);
   }
 
   public SpinnakerNetworkException(String message, SpinnakerNetworkException cause) {

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerNetworkException.java
@@ -20,17 +20,27 @@ import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import okhttp3.Request;
 import retrofit.RetrofitError;
 
-/** Wraps an exception of kind {@link RetrofitError.Kind} NETWORK. */
+/** Represents a network error while attempting to execute a retrofit http client request. */
 @NonnullByDefault
 public final class SpinnakerNetworkException extends SpinnakerServerException {
+
+  /**
+   * Construct a SpinnakerNetworkException from retrofit2 with a cause (e.g. an exception sending a
+   * request or processing a response).
+   */
   public SpinnakerNetworkException(Throwable cause, Request request) {
     super(cause, request);
   }
 
+  /**
+   * Construct a SpinnakerNetworkException from another SpinnakerNetworkException (e.g. via
+   * newInstance).
+   */
   public SpinnakerNetworkException(String message, SpinnakerNetworkException cause) {
     super(message, cause);
   }
 
+  /** Construct a SpinnakerNetworkException corresponding to a RetrofitError. */
   public SpinnakerNetworkException(RetrofitError e) {
     super(e);
   }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandler.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandler.java
@@ -59,11 +59,11 @@ public final class SpinnakerRetrofitErrorHandler implements ErrorHandler {
         }
         return retval;
       case NETWORK:
-        return new SpinnakerNetworkException(e.getMessage(), e.getCause());
+        return new SpinnakerNetworkException(e);
       case CONVERSION:
-        return new SpinnakerConversionException(e.getMessage(), e.getCause());
+        return new SpinnakerConversionException(e);
       default:
-        return new SpinnakerServerException(e.getMessage(), e.getCause());
+        return new SpinnakerServerException(e);
     }
   }
 

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import okhttp3.Request;
 import retrofit.RetrofitError;
-import retrofit2.Response;
 
 /** Represents an error while attempting to execute a retrofit http client request. */
 @NonnullByDefault
@@ -32,19 +32,19 @@ public class SpinnakerServerException extends SpinnakerException {
     url = e.getUrl();
   }
 
-  public SpinnakerServerException(Response retrofit2Response) {
+  public SpinnakerServerException(Request request) {
     super();
-    url = retrofit2Response.raw().request().url().toString();
+    url = request.url().toString();
   }
 
-  public SpinnakerServerException(Throwable cause, String url) {
+  public SpinnakerServerException(Throwable cause, Request request) {
     super(cause);
-    this.url = url;
+    this.url = request.url().toString();
   }
 
-  public SpinnakerServerException(String message, Throwable cause, String url) {
+  public SpinnakerServerException(String message, Throwable cause, Request request) {
     super(message, cause);
-    this.url = url;
+    this.url = request.url().toString();
   }
 
   public SpinnakerServerException(String message, SpinnakerServerException cause) {

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import lombok.Getter;
 import okhttp3.Request;
 import retrofit.RetrofitError;
 
@@ -25,7 +26,7 @@ import retrofit.RetrofitError;
 @NonnullByDefault
 public class SpinnakerServerException extends SpinnakerException {
 
-  private final String url;
+  @Getter private final String url;
 
   /** Construct a SpinnakerServerException corresponding to a RetrofitError. */
   public SpinnakerServerException(RetrofitError e) {
@@ -72,9 +73,5 @@ public class SpinnakerServerException extends SpinnakerException {
   @Override
   public SpinnakerServerException newInstance(String message) {
     return new SpinnakerServerException(message, this);
-  }
-
-  public String getUrl() {
-    return this.url;
   }
 }

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -27,26 +27,43 @@ public class SpinnakerServerException extends SpinnakerException {
 
   private final String url;
 
+  /** Construct a SpinnakerServerException corresponding to a RetrofitError. */
   public SpinnakerServerException(RetrofitError e) {
     super(e.getMessage(), e.getCause());
     url = e.getUrl();
   }
 
+  /**
+   * Construct a SpinnakerServerException from retrofit2 with no cause (e.g. a non-200 http
+   * response).
+   */
   public SpinnakerServerException(Request request) {
     super();
     url = request.url().toString();
   }
 
+  /**
+   * Construct a SpinnakerServerException from retrofit2 with a cause (e.g. an exception sending a
+   * request or processing a response).
+   */
   public SpinnakerServerException(Throwable cause, Request request) {
     super(cause);
     this.url = request.url().toString();
   }
 
+  /**
+   * Construct a SpinnakerServerException from retrofit2 with a message and cause (e.g. an exception
+   * converting a response to the specified type).
+   */
   public SpinnakerServerException(String message, Throwable cause, Request request) {
     super(message, cause);
     this.url = request.url().toString();
   }
 
+  /**
+   * Construct a SpinnakerServerException from another SpinnakerServerException (e.g. via
+   * newInstance).
+   */
   public SpinnakerServerException(String message, SpinnakerServerException cause) {
     super(message, cause);
     this.url = cause.getUrl();

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -18,23 +18,46 @@ package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import retrofit.RetrofitError;
+import retrofit2.Response;
 
 /** Represents an error while attempting to execute a retrofit http client request. */
 @NonnullByDefault
 public class SpinnakerServerException extends SpinnakerException {
 
-  public SpinnakerServerException(String message, Throwable cause) {
-    super(message, cause);
+  private final String url;
+
+  public SpinnakerServerException(RetrofitError e) {
+    super(e.getMessage(), e.getCause());
+    url = e.getUrl();
   }
 
-  public SpinnakerServerException(Throwable cause) {
+  public SpinnakerServerException(Response retrofit2Response) {
+    super();
+    url = retrofit2Response.raw().request().url().toString();
+  }
+
+  public SpinnakerServerException(Throwable cause, String url) {
     super(cause);
+    this.url = url;
   }
 
-  public SpinnakerServerException() {}
+  public SpinnakerServerException(String message, Throwable cause, String url) {
+    super(message, cause);
+    this.url = url;
+  }
+
+  public SpinnakerServerException(String message, SpinnakerServerException cause) {
+    super(message, cause);
+    this.url = cause.getUrl();
+  }
 
   @Override
   public SpinnakerServerException newInstance(String message) {
     return new SpinnakerServerException(message, this);
+  }
+
+  public String getUrl() {
+    return this.url;
   }
 }

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/Retrofit2SyncCallTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/Retrofit2SyncCallTest.java
@@ -16,38 +16,36 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import retrofit2.Call;
 import retrofit2.Response;
 
-public class Retrofit2SyncCallTest {
+class Retrofit2SyncCallTest {
 
   @Test
-  public void testExecuteSuccss() throws IOException {
-    Call<String> mockcall = Mockito.mock(Call.class);
-    when(mockcall.execute()).thenReturn(Response.success("testing"));
-    String execute = Retrofit2SyncCall.execute(mockcall);
-    assertEquals("testing", execute);
+  void testExecuteSuccess() throws IOException {
+    Call<String> mockCall = mock(Call.class);
+    String responseBody = "testing";
+    when(mockCall.execute()).thenReturn(Response.success(responseBody));
+    String execute = Retrofit2SyncCall.execute(mockCall);
+    assertThat(execute).isEqualTo(responseBody);
   }
 
   @Test
-  public void testExecuteThrowException() throws IOException {
-    Call<String> mockcall = Mockito.mock(Call.class);
+  void testExecuteThrowException() throws IOException {
+    Call<String> mockCall = mock(Call.class);
     IOException ioException = new IOException("exception test");
-    when(mockcall.execute()).thenThrow(ioException);
-    SpinnakerNetworkException networkEx =
-        assertThrows(
-            SpinnakerNetworkException.class,
-            () -> {
-              Retrofit2SyncCall.execute(mockcall);
-            });
-    assertEquals(ioException, networkEx.getCause());
+    when(mockCall.execute()).thenThrow(ioException);
+    SpinnakerNetworkException thrown =
+        catchThrowableOfType(
+            () -> Retrofit2SyncCall.execute(mockCall), SpinnakerNetworkException.class);
+    assertThat(thrown).hasCause(ioException);
   }
 }

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/Retrofit2SyncCallTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/Retrofit2SyncCallTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.when;
 
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import java.io.IOException;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
 import org.junit.jupiter.api.Test;
 import retrofit2.Call;
 import retrofit2.Response;
@@ -43,9 +45,16 @@ class Retrofit2SyncCallTest {
     Call<String> mockCall = mock(Call.class);
     IOException ioException = new IOException("exception test");
     when(mockCall.execute()).thenThrow(ioException);
+
+    HttpUrl url = HttpUrl.parse("http://arbitrary-url");
+    Request mockRequest = mock(Request.class);
+    when(mockCall.request()).thenReturn(mockRequest);
+    when(mockRequest.url()).thenReturn(url);
+
     SpinnakerNetworkException thrown =
         catchThrowableOfType(
             () -> Retrofit2SyncCall.execute(mockCall), SpinnakerNetworkException.class);
     assertThat(thrown).hasCause(ioException);
+    assertThat(thrown.getUrl()).isEqualTo(url.toString());
   }
 }

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java
@@ -19,9 +19,6 @@ package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
@@ -39,11 +36,11 @@ import retrofit.mime.TypedString;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
-public class SpinnakerHttpExceptionTest {
+class SpinnakerHttpExceptionTest {
   private static final String CUSTOM_MESSAGE = "custom message";
 
   @Test
-  public void testSpinnakerHttpExceptionFromRetrofitError() {
+  void testSpinnakerHttpExceptionFromRetrofitError() {
     String url = "http://localhost";
     int statusCode = 200;
     String message = "arbitrary message";
@@ -69,7 +66,7 @@ public class SpinnakerHttpExceptionTest {
   }
 
   @Test
-  public void testSpinnakerHttpExceptionFromRetrofitException() {
+  void testSpinnakerHttpExceptionFromRetrofitException() {
     final String validJsonResponseBodyString = "{\"name\":\"test\"}";
     ResponseBody responseBody =
         ResponseBody.create(
@@ -86,19 +83,19 @@ public class SpinnakerHttpExceptionTest {
     assertThat(retrofit2Service.baseUrl().toString()).isEqualTo(url);
     SpinnakerHttpException notFoundException =
         new SpinnakerHttpException(response, retrofit2Service);
-    assertNotNull(notFoundException.getResponseBody());
+    assertThat(notFoundException.getResponseBody()).isNotNull();
     assertThat(notFoundException.getUrl()).isEqualTo(url);
     assertThat(notFoundException.getReason())
         .isEqualTo("Response.error()"); // set by Response.error
     Map<String, Object> errorResponseBody = notFoundException.getResponseBody();
-    assertEquals(errorResponseBody.get("name"), "test");
-    assertEquals(HttpStatus.NOT_FOUND.value(), notFoundException.getResponseCode());
-    assertTrue(
-        notFoundException.getMessage().contains(String.valueOf(HttpStatus.NOT_FOUND.value())));
+    assertThat(errorResponseBody.get("name")).isEqualTo("test");
+    assertThat(notFoundException.getResponseCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    assertThat(notFoundException)
+        .hasMessageContaining(String.valueOf(HttpStatus.NOT_FOUND.value()));
   }
 
   @Test
-  public void testSpinnakerHttpException_NewInstance() {
+  void testSpinnakerHttpException_NewInstance() {
     String url = "http://localhost";
     String reason = "reason";
     Response response = new Response(url, 200, reason, List.of(), null);
@@ -108,10 +105,11 @@ public class SpinnakerHttpExceptionTest {
     } catch (SpinnakerException e) {
       SpinnakerException newException = e.newInstance(CUSTOM_MESSAGE);
 
-      assertTrue(newException instanceof SpinnakerHttpException);
-      assertEquals(CUSTOM_MESSAGE, newException.getMessage());
-      assertEquals(e, newException.getCause());
-      assertEquals(response.getStatus(), ((SpinnakerHttpException) newException).getResponseCode());
+      assertThat(newException).isInstanceOf(SpinnakerHttpException.class);
+      assertThat(newException).hasMessage(CUSTOM_MESSAGE);
+      assertThat(newException).hasCause(e);
+      assertThat(((SpinnakerHttpException) newException).getResponseCode())
+          .isEqualTo(response.getStatus());
       SpinnakerHttpException spinnakerHttpException = (SpinnakerHttpException) newException;
       assertThat(spinnakerHttpException.getUrl()).isEqualTo(url);
       assertThat(spinnakerHttpException.getReason()).isEqualTo(reason);

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
@@ -16,12 +16,9 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
@@ -40,7 +37,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
-public class SpinnakerRetrofit2ErrorHandleTest {
+class SpinnakerRetrofit2ErrorHandleTest {
 
   private static Retrofit2Service retrofit2Service;
 
@@ -51,7 +48,7 @@ public class SpinnakerRetrofit2ErrorHandleTest {
   private static String baseUrl = mockWebServer.url("/").toString();
 
   @BeforeAll
-  public static void setupOnce() throws Exception {
+  static void setupOnce() throws Exception {
 
     Map<String, String> responseBodyMap = new HashMap<>();
     responseBodyMap.put("timestamp", "123123123123");
@@ -73,61 +70,65 @@ public class SpinnakerRetrofit2ErrorHandleTest {
   }
 
   @AfterAll
-  public static void shutdownOnce() throws Exception {
+  static void shutdownOnce() throws Exception {
     mockWebServer.shutdown();
   }
 
   @Test
-  public void testRetrofitNotFoundIsNotRetryable() {
+  void testRetrofitNotFoundIsNotRetryable() {
 
     mockWebServer.enqueue(
         new MockResponse()
             .setResponseCode(HttpStatus.NOT_FOUND.value())
             .setBody(responseBodyString));
     SpinnakerHttpException notFoundException =
-        assertThrows(SpinnakerHttpException.class, () -> retrofit2Service.getRetrofit2().execute());
-    assertNotNull(notFoundException.getRetryable());
-    assertFalse(notFoundException.getRetryable());
+        catchThrowableOfType(
+            () -> retrofit2Service.getRetrofit2().execute(), SpinnakerHttpException.class);
+    assertThat(notFoundException.getRetryable()).isNotNull();
+    assertThat(notFoundException.getRetryable()).isFalse();
   }
 
   @Test
-  public void testRetrofitBadRequestIsNotRetryable() {
+  void testRetrofitBadRequestIsNotRetryable() {
 
     mockWebServer.enqueue(
         new MockResponse()
             .setResponseCode(HttpStatus.NOT_FOUND.value())
             .setBody(responseBodyString));
     SpinnakerHttpException spinnakerHttpException =
-        assertThrows(SpinnakerHttpException.class, () -> retrofit2Service.getRetrofit2().execute());
-    assertNotNull(spinnakerHttpException.getRetryable());
-    assertFalse(spinnakerHttpException.getRetryable());
+        catchThrowableOfType(
+            () -> retrofit2Service.getRetrofit2().execute(), SpinnakerHttpException.class);
+    assertThat(spinnakerHttpException.getRetryable()).isNotNull();
+    assertThat(spinnakerHttpException.getRetryable()).isFalse();
   }
 
   @Test
-  public void testRetrofitOtherClientErrorHasNullRetryable() {
+  void testRetrofitOtherClientErrorHasNullRetryable() {
 
     mockWebServer.enqueue(
         new MockResponse().setResponseCode(HttpStatus.GONE.value()).setBody(responseBodyString));
     SpinnakerHttpException spinnakerHttpException =
-        assertThrows(SpinnakerHttpException.class, () -> retrofit2Service.getRetrofit2().execute());
-    assertNull(spinnakerHttpException.getRetryable());
+        catchThrowableOfType(
+            () -> retrofit2Service.getRetrofit2().execute(), SpinnakerHttpException.class);
+    assertThat(spinnakerHttpException.getRetryable()).isNull();
   }
 
   @Test
-  public void testRetrofitSimpleSpinnakerNetworkException() {
+  void testRetrofitSimpleSpinnakerNetworkException() {
     mockWebServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
-
-    assertThrows(SpinnakerNetworkException.class, () -> retrofit2Service.getRetrofit2().execute());
+    assertThatExceptionOfType(SpinnakerNetworkException.class)
+        .isThrownBy(() -> retrofit2Service.getRetrofit2().execute());
   }
 
   @Test
-  public void testRetrofitSimpleSpinnakerServerException() {
+  void testRetrofitSimpleSpinnakerServerException() {
     mockWebServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    assertThrows(SpinnakerServerException.class, () -> retrofit2Service.getRetrofit2().execute());
+    assertThatExceptionOfType(SpinnakerServerException.class)
+        .isThrownBy(() -> retrofit2Service.getRetrofit2().execute());
   }
 
   @Test
-  public void testResponseHeadersInException() {
+  void testResponseHeadersInException() {
 
     // Check response headers are retrievable from a SpinnakerHttpException
     mockWebServer.enqueue(
@@ -136,35 +137,33 @@ public class SpinnakerRetrofit2ErrorHandleTest {
             .setBody(responseBodyString)
             .setHeader("Test", "true"));
     SpinnakerHttpException spinnakerHttpException =
-        assertThrows(SpinnakerHttpException.class, () -> retrofit2Service.getRetrofit2().execute());
-    assertTrue(spinnakerHttpException.getHeaders().containsKey("Test"));
-    assertTrue(spinnakerHttpException.getHeaders().get("Test").contains("true"));
+        catchThrowableOfType(
+            () -> retrofit2Service.getRetrofit2().execute(), SpinnakerHttpException.class);
+    assertThat(spinnakerHttpException.getHeaders().containsKey("Test")).isTrue();
+    assertThat(spinnakerHttpException.getHeaders().get("Test").contains("true")).isTrue();
   }
 
   @Test
-  public void testNotParameterizedException() {
-
+  void testNotParameterizedException() {
     IllegalArgumentException illegalArgumentException =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> retrofit2Service.testNotParameterized().execute());
-
-    assertEquals(
-        "Call return type must be parameterized as Call<Foo> or Call<? extends Foo>",
-        illegalArgumentException.getCause().getMessage());
+        catchThrowableOfType(
+            () -> retrofit2Service.testNotParameterized().execute(),
+            IllegalArgumentException.class);
+    assertThat(illegalArgumentException.getCause().getMessage())
+        .isEqualTo("Call return type must be parameterized as Call<Foo> or Call<? extends Foo>");
   }
 
   @Test
-  public void testWrongReturnTypeException() {
+  void testWrongReturnTypeException() {
 
     IllegalArgumentException illegalArgumentException =
-        assertThrows(
-            IllegalArgumentException.class, () -> retrofit2Service.testWrongReturnType().execute());
+        catchThrowableOfType(
+            () -> retrofit2Service.testWrongReturnType().execute(), IllegalArgumentException.class);
 
-    assertEquals(
-        "Unable to create call adapter for interface com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofit2ErrorHandleTest$DummyWithExecute\n"
-            + "    for method Retrofit2Service.testWrongReturnType",
-        illegalArgumentException.getMessage());
+    assertThat(illegalArgumentException)
+        .hasMessage(
+            "Unable to create call adapter for interface com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofit2ErrorHandleTest$DummyWithExecute\n"
+                + "    for method Retrofit2Service.testWrongReturnType");
   }
 
   interface Retrofit2Service {
@@ -189,14 +188,13 @@ public class SpinnakerRetrofit2ErrorHandleTest {
             .setBody(invalidJsonTypeResponseBody));
 
     SpinnakerConversionException spinnakerConversionException =
-        assertThrows(
-            SpinnakerConversionException.class, () -> retrofit2Service.getRetrofit2().execute());
-
-    assertEquals("Failed to process response body", spinnakerConversionException.getMessage());
+        catchThrowableOfType(
+            () -> retrofit2Service.getRetrofit2().execute(), SpinnakerConversionException.class);
+    assertThat(spinnakerConversionException).hasMessage("Failed to process response body");
   }
 
   @Test
-  public void testNonJsonHttpErrorResponse() {
+  void testNonJsonHttpErrorResponse() {
 
     String invalidJsonTypeResponseBody = "{'errorResponse': 'Failure'";
     int responseCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
@@ -206,14 +204,14 @@ public class SpinnakerRetrofit2ErrorHandleTest {
     mockWebServer.enqueue(
         new MockResponse().setResponseCode(responseCode).setBody(invalidJsonTypeResponseBody));
     SpinnakerHttpException spinnakerHttpException =
-        assertThrows(SpinnakerHttpException.class, () -> retrofit2Service.getRetrofit2().execute());
-    assertNull(spinnakerHttpException.getResponseBody());
-    assertEquals(responseCode, spinnakerHttpException.getResponseCode());
-    assertEquals(
-        "Status: " + responseCode + ", URL: " + url + ", Message: " + reason,
-        spinnakerHttpException.getMessage());
-    assertEquals(url, spinnakerHttpException.getUrl());
-    assertEquals(reason, spinnakerHttpException.getReason());
+        catchThrowableOfType(
+            () -> retrofit2Service.getRetrofit2().execute(), SpinnakerHttpException.class);
+    assertThat(spinnakerHttpException.getResponseBody()).isNull();
+    assertThat(spinnakerHttpException.getResponseCode()).isEqualTo(responseCode);
+    assertThat(spinnakerHttpException)
+        .hasMessage("Status: " + responseCode + ", URL: " + url + ", Message: " + reason);
+    assertThat(spinnakerHttpException.getUrl()).isEqualTo(url);
+    assertThat(spinnakerHttpException.getReason()).isEqualTo(reason);
   }
 
   interface DummyWithExecute {

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -121,8 +120,11 @@ class SpinnakerRetrofit2ErrorHandleTest {
   @Test
   void testRetrofitSimpleSpinnakerNetworkException() {
     mockWebServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
-    assertThatExceptionOfType(SpinnakerNetworkException.class)
-        .isThrownBy(() -> retrofit2Service.getRetrofit2().execute());
+    SpinnakerNetworkException spinnakerNetworkException =
+        catchThrowableOfType(
+            () -> retrofit2Service.getRetrofit2().execute(), SpinnakerNetworkException.class);
+    assertThat(spinnakerNetworkException.getUrl())
+        .isEqualTo(mockWebServer.url("/retrofit2").toString());
   }
 
   @Test
@@ -191,6 +193,8 @@ class SpinnakerRetrofit2ErrorHandleTest {
         catchThrowableOfType(
             () -> retrofit2Service.getRetrofit2().execute(), SpinnakerConversionException.class);
     assertThat(spinnakerConversionException).hasMessage("Failed to process response body");
+    assertThat(spinnakerConversionException.getUrl())
+        .isEqualTo(mockWebServer.url("/retrofit2").toString());
   }
 
   @Test

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
@@ -126,13 +126,6 @@ class SpinnakerRetrofit2ErrorHandleTest {
   }
 
   @Test
-  void testRetrofitSimpleSpinnakerServerException() {
-    mockWebServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    assertThatExceptionOfType(SpinnakerServerException.class)
-        .isThrownBy(() -> retrofit2Service.getRetrofit2().execute());
-  }
-
-  @Test
   void testResponseHeadersInException() {
 
     // Check response headers are retrievable from a SpinnakerHttpException

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
@@ -86,6 +86,7 @@ class SpinnakerRetrofit2ErrorHandleTest {
             () -> retrofit2Service.getRetrofit2().execute(), SpinnakerHttpException.class);
     assertThat(notFoundException.getRetryable()).isNotNull();
     assertThat(notFoundException.getRetryable()).isFalse();
+    assertThat(notFoundException.getUrl()).isEqualTo(mockWebServer.url("/retrofit2").toString());
   }
 
   @Test
@@ -100,6 +101,8 @@ class SpinnakerRetrofit2ErrorHandleTest {
             () -> retrofit2Service.getRetrofit2().execute(), SpinnakerHttpException.class);
     assertThat(spinnakerHttpException.getRetryable()).isNotNull();
     assertThat(spinnakerHttpException.getRetryable()).isFalse();
+    assertThat(spinnakerHttpException.getUrl())
+        .isEqualTo(mockWebServer.url("/retrofit2").toString());
   }
 
   @Test
@@ -111,6 +114,8 @@ class SpinnakerRetrofit2ErrorHandleTest {
         catchThrowableOfType(
             () -> retrofit2Service.getRetrofit2().execute(), SpinnakerHttpException.class);
     assertThat(spinnakerHttpException.getRetryable()).isNull();
+    assertThat(spinnakerHttpException.getUrl())
+        .isEqualTo(mockWebServer.url("/retrofit2").toString());
   }
 
   @Test
@@ -141,6 +146,8 @@ class SpinnakerRetrofit2ErrorHandleTest {
             () -> retrofit2Service.getRetrofit2().execute(), SpinnakerHttpException.class);
     assertThat(spinnakerHttpException.getHeaders().containsKey("Test")).isTrue();
     assertThat(spinnakerHttpException.getHeaders().get("Test").contains("true")).isTrue();
+    assertThat(spinnakerHttpException.getUrl())
+        .isEqualTo(mockWebServer.url("/retrofit2").toString());
   }
 
   @Test

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
@@ -192,6 +192,8 @@ class SpinnakerRetrofit2ErrorHandleTest {
     SpinnakerConversionException spinnakerConversionException =
         catchThrowableOfType(
             () -> retrofit2Service.getRetrofit2().execute(), SpinnakerConversionException.class);
+    assertThat(spinnakerConversionException.getRetryable()).isNotNull();
+    assertThat(spinnakerConversionException.getRetryable()).isFalse();
     assertThat(spinnakerConversionException).hasMessage("Failed to process response body");
     assertThat(spinnakerConversionException.getUrl())
         .isEqualTo(mockWebServer.url("/retrofit2").toString());

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -197,6 +197,8 @@ class SpinnakerRetrofitErrorHandlerTest {
 
     SpinnakerConversionException spinnakerConversionException =
         catchThrowableOfType(() -> retrofitService.getData(), SpinnakerConversionException.class);
+    assertThat(spinnakerConversionException.getRetryable()).isNotNull();
+    assertThat(spinnakerConversionException.getRetryable()).isFalse();
     assertThat(spinnakerConversionException)
         .hasMessageContaining("Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $");
     assertThat(spinnakerConversionException.getUrl())

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -128,8 +127,9 @@ class SpinnakerRetrofitErrorHandlerTest {
     // "..."
     //
     // so make sure we get a SpinnakerHttpException from calling getFoo
-    assertThatExceptionOfType(SpinnakerHttpException.class)
-        .isThrownBy(retrofitServiceTestConverter::getFoo);
+    SpinnakerHttpException spinnakerHttpException =
+        catchThrowableOfType(retrofitServiceTestConverter::getFoo, SpinnakerHttpException.class);
+    assertThat(spinnakerHttpException.getUrl()).isEqualTo(mockWebServer.url("/foo").toString());
   }
 
   @Test
@@ -139,6 +139,7 @@ class SpinnakerRetrofitErrorHandlerTest {
         catchThrowableOfType(() -> retrofitService.getFoo(), SpinnakerHttpException.class);
     assertThat(spinnakerHttpException.getRetryable()).isNotNull();
     assertThat(spinnakerHttpException.getRetryable()).isFalse();
+    assertThat(spinnakerHttpException.getUrl()).isEqualTo(mockWebServer.url("/foo").toString());
   }
 
   @Test
@@ -149,6 +150,7 @@ class SpinnakerRetrofitErrorHandlerTest {
     SpinnakerHttpException spinnakerHttpException =
         catchThrowableOfType(() -> retrofitService.getFoo(), SpinnakerHttpException.class);
     assertThat(spinnakerHttpException.getRetryable()).isNull();
+    assertThat(spinnakerHttpException.getUrl()).isEqualTo(mockWebServer.url("/foo").toString());
   }
 
   @Test
@@ -162,6 +164,7 @@ class SpinnakerRetrofitErrorHandlerTest {
         catchThrowableOfType(() -> retrofitService.getFoo(), SpinnakerHttpException.class);
     assertThat(spinnakerHttpException.getHeaders().containsKey("Test")).isTrue();
     assertThat(spinnakerHttpException.getHeaders().get("Test").contains("true")).isTrue();
+    assertThat(spinnakerHttpException.getUrl()).isEqualTo(mockWebServer.url("/foo").toString());
   }
 
   @Test

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -26,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -68,6 +70,13 @@ class SpinnakerRetrofitErrorHandlerTest {
         catchThrowableOfType(() -> retrofitService.getFoo(), SpinnakerHttpException.class);
     assertThat(notFoundException.getRetryable()).isNotNull();
     assertThat(notFoundException.getRetryable()).isFalse();
+  }
+
+  @Test
+  void testSpinnakerNetworkException() {
+    mockWebServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
+    assertThatExceptionOfType(SpinnakerNetworkException.class)
+        .isThrownBy(() -> retrofitService.getFoo());
   }
 
   @ParameterizedTest(name = "Deserialize response using {0}")

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -180,10 +180,14 @@ class SpinnakerRetrofitErrorHandlerTest {
   void testSimpleSpinnakerNetworkException() {
     String message = "my custom message";
     IOException e = new IOException(message);
-    RetrofitError retrofitError = RetrofitError.networkError("http://localhost", e);
+    String url = "http://localhost";
+    RetrofitError retrofitError = RetrofitError.networkError(url, e);
     SpinnakerRetrofitErrorHandler handler = SpinnakerRetrofitErrorHandler.getInstance();
     Throwable throwable = handler.handleError(retrofitError);
     assertThat(throwable).hasMessage(message);
+    assertThat(throwable).isInstanceOf(SpinnakerNetworkException.class);
+    SpinnakerNetworkException spinnakerNetworkException = (SpinnakerNetworkException) throwable;
+    assertThat(spinnakerNetworkException.getUrl()).isEqualTo(url);
   }
 
   @Test
@@ -195,6 +199,8 @@ class SpinnakerRetrofitErrorHandlerTest {
         catchThrowableOfType(() -> retrofitService.getData(), SpinnakerConversionException.class);
     assertThat(spinnakerConversionException)
         .hasMessageContaining("Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $");
+    assertThat(spinnakerConversionException.getUrl())
+        .isEqualTo(mockWebServer.url("/data").toString());
   }
 
   @Test
@@ -205,7 +211,9 @@ class SpinnakerRetrofitErrorHandlerTest {
     String newMessage = "new message";
 
     IOException originalException = new IOException(originalMessage);
-    RetrofitError retrofitError = RetrofitError.networkError("http://localhost", originalException);
+
+    String url = "http://localhost";
+    RetrofitError retrofitError = RetrofitError.networkError(url, originalException);
 
     Throwable newException =
         handler.handleError(
@@ -215,6 +223,8 @@ class SpinnakerRetrofitErrorHandlerTest {
     assertThat(newException).isInstanceOf(SpinnakerNetworkException.class);
     assertThat(newException).hasMessage("new message: original message");
     assertThat(newException.getCause()).hasMessage(originalMessage);
+    SpinnakerNetworkException spinnakerNetworkException = (SpinnakerNetworkException) newException;
+    assertThat(spinnakerNetworkException.getUrl()).isEqualTo(url);
   }
 
   interface RetrofitService {

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlersTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlersTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,7 +74,7 @@ class SpinnakerRetrofitExceptionHandlersTest {
   private MemoryAppender memoryAppender;
 
   @BeforeEach
-  private void setup(TestInfo testInfo) {
+  void setup(TestInfo testInfo) {
     System.out.println("--------------- Test " + testInfo.getDisplayName());
     memoryAppender = new MemoryAppender(SpinnakerRetrofitExceptionHandlers.class);
   }
@@ -84,8 +84,8 @@ class SpinnakerRetrofitExceptionHandlersTest {
     URI uri = getUri("/spinnakerServerException");
 
     ResponseEntity<String> entity = restTemplate.getForEntity(uri, String.class);
-    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, entity.getStatusCode());
-    assertEquals(1, memoryAppender.countEventsForLevel(Level.ERROR));
+    assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(memoryAppender.countEventsForLevel(Level.ERROR)).isEqualTo(1);
   }
 
   @Test
@@ -93,11 +93,11 @@ class SpinnakerRetrofitExceptionHandlersTest {
     URI uri = getUri("/chainedSpinnakerServerException");
 
     ResponseEntity<String> entity = restTemplate.getForEntity(uri, String.class);
-    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, entity.getStatusCode());
-    assertEquals(1, memoryAppender.countEventsForLevel(Level.ERROR));
+    assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(memoryAppender.countEventsForLevel(Level.ERROR)).isEqualTo(1);
 
     // Make sure the message is what we expect.
-    assertEquals(1, memoryAppender.search(CUSTOM_MESSAGE, Level.ERROR).size());
+    assertThat(memoryAppender.search(CUSTOM_MESSAGE, Level.ERROR)).hasSize(1);
   }
 
   @ParameterizedTest(name = "testSpinnakerHttpException status = {0}")
@@ -106,15 +106,15 @@ class SpinnakerRetrofitExceptionHandlersTest {
     URI uri = getUri("/spinnakerHttpException/" + String.valueOf(status));
 
     ResponseEntity<String> entity = restTemplate.getForEntity(uri, String.class);
-    assertEquals(status, entity.getStatusCode().value());
+    assertThat(entity.getStatusCode().value()).isEqualTo(status);
 
     // Only expect error logging for a server error, debug otherwise.  No need
     // to fill up logs with client errors assuming the server is doing the best
     // it can.
-    assertEquals(
-        1,
-        memoryAppender.countEventsForLevel(
-            HttpStatus.resolve(status).is5xxServerError() ? Level.ERROR : Level.DEBUG));
+    assertThat(
+            memoryAppender.countEventsForLevel(
+                HttpStatus.resolve(status).is5xxServerError() ? Level.ERROR : Level.DEBUG))
+        .isEqualTo(1);
   }
 
   @ParameterizedTest(name = "testChainedSpinnakerHttpException status = {0}")
@@ -123,24 +123,22 @@ class SpinnakerRetrofitExceptionHandlersTest {
     URI uri = getUri("/chainedSpinnakerHttpException/" + String.valueOf(status));
 
     ResponseEntity<String> entity = restTemplate.getForEntity(uri, String.class);
-    assertEquals(status, entity.getStatusCode().value());
+    assertThat(entity.getStatusCode().value()).isEqualTo(status);
 
     // Only expect error logging for a server error, debug otherwise.  No need
     // to fill up logs with client errors assuming the server is doing the best
     // it can.
-    assertEquals(
-        1,
-        memoryAppender.countEventsForLevel(
-            HttpStatus.resolve(status).is5xxServerError() ? Level.ERROR : Level.DEBUG));
+    assertThat(
+            memoryAppender.countEventsForLevel(
+                HttpStatus.resolve(status).is5xxServerError() ? Level.ERROR : Level.DEBUG))
+        .isEqualTo(1);
 
     // Make sure the message is what we expect.
-    assertEquals(
-        1,
-        memoryAppender
-            .search(
+    assertThat(
+            memoryAppender.search(
                 CUSTOM_MESSAGE,
-                HttpStatus.resolve(status).is5xxServerError() ? Level.ERROR : Level.DEBUG)
-            .size());
+                HttpStatus.resolve(status).is5xxServerError() ? Level.ERROR : Level.DEBUG))
+        .hasSize(1);
   }
 
   private URI getUri(String path) {

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.gson.Gson;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
@@ -30,11 +29,11 @@ import retrofit.converter.ConversionException;
 import retrofit.converter.GsonConverter;
 import retrofit.mime.TypedByteArray;
 
-public class SpinnakerServerExceptionTest {
+class SpinnakerServerExceptionTest {
   private static final String CUSTOM_MESSAGE = "custom message";
 
   @Test
-  public void testSpinnakerNetworkException_NewInstance() {
+  void testSpinnakerNetworkException_NewInstance() {
     IOException initialException = new IOException("message");
     try {
       RetrofitError error = RetrofitError.networkError("http://localhost", initialException);
@@ -42,14 +41,14 @@ public class SpinnakerServerExceptionTest {
     } catch (SpinnakerException e) {
       SpinnakerException newException = e.newInstance(CUSTOM_MESSAGE);
 
-      assertTrue(newException instanceof SpinnakerNetworkException);
-      assertEquals(CUSTOM_MESSAGE, newException.getMessage());
-      assertEquals(e, newException.getCause());
+      assertThat(newException).isInstanceOf(SpinnakerNetworkException.class);
+      assertThat(newException).hasMessage(CUSTOM_MESSAGE);
+      assertThat(newException).hasCause(e);
     }
   }
 
   @Test
-  public void testSpinnakerServerException_NewInstance() {
+  void testSpinnakerServerException_NewInstance() {
     Throwable cause = new Throwable("message");
     try {
       RetrofitError error = RetrofitError.unexpectedError("http://localhost", cause);
@@ -57,14 +56,14 @@ public class SpinnakerServerExceptionTest {
     } catch (SpinnakerException e) {
       SpinnakerException newException = e.newInstance(CUSTOM_MESSAGE);
 
-      assertTrue(newException instanceof SpinnakerServerException);
-      assertEquals(CUSTOM_MESSAGE, newException.getMessage());
-      assertEquals(e, newException.getCause());
+      assertThat(newException).isInstanceOf(SpinnakerServerException.class);
+      assertThat(newException).hasMessage(CUSTOM_MESSAGE);
+      assertThat(newException).hasCause(e);
     }
   }
 
   @Test
-  public void testSpinnakerConversionException_NewInstance() {
+  void testSpinnakerConversionException_NewInstance() {
     String url = "http://localhost";
     String reason = "reason";
 
@@ -86,9 +85,9 @@ public class SpinnakerServerExceptionTest {
     } catch (SpinnakerException e) {
       SpinnakerException newException = e.newInstance(CUSTOM_MESSAGE);
 
-      assertTrue(newException instanceof SpinnakerConversionException);
-      assertEquals(CUSTOM_MESSAGE, newException.getMessage());
-      assertEquals(e, newException.getCause());
+      assertThat(newException).isInstanceOf(SpinnakerConversionException.class);
+      assertThat(newException).hasMessage(CUSTOM_MESSAGE);
+      assertThat(newException).hasCause(e);
     }
   }
 }

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
@@ -22,6 +22,7 @@ import com.google.gson.Gson;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import java.io.IOException;
 import java.util.List;
+import okhttp3.Request;
 import org.junit.jupiter.api.Test;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
@@ -35,8 +36,10 @@ class SpinnakerServerExceptionTest {
   @Test
   void testSpinnakerNetworkExceptionWithUrl() {
     Throwable cause = new Throwable("arbitrary message");
-    String url = "some-url";
-    SpinnakerNetworkException spinnakerNetworkException = new SpinnakerNetworkException(cause, url);
+    String url = "http://some-url/";
+    Request request = new Request.Builder().url(url).build();
+    SpinnakerNetworkException spinnakerNetworkException =
+        new SpinnakerNetworkException(cause, request);
     assertThat(spinnakerNetworkException.getUrl()).isEqualTo(url);
   }
 
@@ -62,8 +65,10 @@ class SpinnakerServerExceptionTest {
   @Test
   void testSpinnakerServerExceptionWithUrl() {
     Throwable cause = new Throwable("arbitrary message");
-    String url = "some-url";
-    SpinnakerServerException spinnakerServerException = new SpinnakerServerException(cause, url);
+    String url = "http://some-url/";
+    Request request = new Request.Builder().url(url).build();
+    SpinnakerServerException spinnakerServerException =
+        new SpinnakerServerException(cause, request);
     assertThat(spinnakerServerException.getUrl()).isEqualTo(url);
   }
 

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
@@ -118,6 +118,8 @@ class SpinnakerServerExceptionTest {
       assertThat(newException).hasCause(e);
       SpinnakerConversionException spinnakerConversionException =
           (SpinnakerConversionException) newException;
+      assertThat(spinnakerConversionException.getRetryable()).isNotNull();
+      assertThat(spinnakerConversionException.getRetryable()).isFalse();
       assertThat(spinnakerConversionException.getUrl()).isEqualTo(url);
     }
   }

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
@@ -33,10 +33,19 @@ class SpinnakerServerExceptionTest {
   private static final String CUSTOM_MESSAGE = "custom message";
 
   @Test
+  void testSpinnakerNetworkExceptionWithUrl() {
+    Throwable cause = new Throwable("arbitrary message");
+    String url = "some-url";
+    SpinnakerNetworkException spinnakerNetworkException = new SpinnakerNetworkException(cause, url);
+    assertThat(spinnakerNetworkException.getUrl()).isEqualTo(url);
+  }
+
+  @Test
   void testSpinnakerNetworkException_NewInstance() {
     IOException initialException = new IOException("message");
+    String url = "http://localhost";
     try {
-      RetrofitError error = RetrofitError.networkError("http://localhost", initialException);
+      RetrofitError error = RetrofitError.networkError(url, initialException);
       throw new SpinnakerNetworkException(error);
     } catch (SpinnakerException e) {
       SpinnakerException newException = e.newInstance(CUSTOM_MESSAGE);
@@ -44,14 +53,26 @@ class SpinnakerServerExceptionTest {
       assertThat(newException).isInstanceOf(SpinnakerNetworkException.class);
       assertThat(newException).hasMessage(CUSTOM_MESSAGE);
       assertThat(newException).hasCause(e);
+      SpinnakerNetworkException spinnakerNetworkException =
+          (SpinnakerNetworkException) newException;
+      assertThat(spinnakerNetworkException.getUrl()).isEqualTo(url);
     }
+  }
+
+  @Test
+  void testSpinnakerServerExceptionWithUrl() {
+    Throwable cause = new Throwable("arbitrary message");
+    String url = "some-url";
+    SpinnakerServerException spinnakerServerException = new SpinnakerServerException(cause, url);
+    assertThat(spinnakerServerException.getUrl()).isEqualTo(url);
   }
 
   @Test
   void testSpinnakerServerException_NewInstance() {
     Throwable cause = new Throwable("message");
+    String url = "http://localhost";
     try {
-      RetrofitError error = RetrofitError.unexpectedError("http://localhost", cause);
+      RetrofitError error = RetrofitError.unexpectedError(url, cause);
       throw new SpinnakerServerException(error);
     } catch (SpinnakerException e) {
       SpinnakerException newException = e.newInstance(CUSTOM_MESSAGE);
@@ -59,6 +80,8 @@ class SpinnakerServerExceptionTest {
       assertThat(newException).isInstanceOf(SpinnakerServerException.class);
       assertThat(newException).hasMessage(CUSTOM_MESSAGE);
       assertThat(newException).hasCause(e);
+      SpinnakerServerException spinnakerServerException = (SpinnakerServerException) newException;
+      assertThat(spinnakerServerException.getUrl()).isEqualTo(url);
     }
   }
 
@@ -81,13 +104,16 @@ class SpinnakerServerExceptionTest {
       RetrofitError retrofitError =
           RetrofitError.conversionError(
               url, response, new GsonConverter(new Gson()), null, conversionException);
-      throw new SpinnakerConversionException(retrofitError.getMessage(), retrofitError.getCause());
+      throw new SpinnakerConversionException(retrofitError);
     } catch (SpinnakerException e) {
       SpinnakerException newException = e.newInstance(CUSTOM_MESSAGE);
 
       assertThat(newException).isInstanceOf(SpinnakerConversionException.class);
       assertThat(newException).hasMessage(CUSTOM_MESSAGE);
       assertThat(newException).hasCause(e);
+      SpinnakerConversionException spinnakerConversionException =
+          (SpinnakerConversionException) newException;
+      assertThat(spinnakerConversionException.getUrl()).isEqualTo(url);
     }
   }
 }


### PR DESCRIPTION
so it's available to exception handling code that currently has access to the url via RetrofitError.