### PR TITLE
config(crypto): Update the default TLS cipher suites

### DIFF
--- a/kork-crypto/src/main/java/com/netflix/spinnaker/kork/crypto/CipherSuites.java
+++ b/kork-crypto/src/main/java/com/netflix/spinnaker/kork/crypto/CipherSuites.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.crypto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides a common source for lists of TLS cipher suite baselines.
+ *
+ * @see <a href="https://wiki.mozilla.org/Security/Server_Side_TLS">Mozilla Server Side TLS
+ *     recommendations</a>
+ */
+public final class CipherSuites {
+  private static final List<String> REQUIRED =
+      List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256");
+  private static final List<String> BROWSER_COMPATIBILITY =
+      List.of(
+          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+          "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+          "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+          "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+          "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+          "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256");
+  private static final List<String> RESTRICTED =
+      List.of(
+          "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+          "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+          "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256");
+
+  /**
+   * Returns the list of baseline ciphers that should be enabled for TLS. These include the required
+   * ciphers for TLSv1.3.
+   *
+   * @see <a href="https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility">Modern
+   *     compatibility recommendations</a>
+   */
+  public static List<String> getRequiredCiphers() {
+    return REQUIRED;
+  }
+
+  public static List<String> getRecommendedCiphers() {
+    var ciphers = new ArrayList<>(getRequiredCiphers());
+    ciphers.addAll(BROWSER_COMPATIBILITY);
+    return ciphers;
+  }
+
+  public static List<String> getIntermediateCompatibilityCiphers() {
+    var ciphers = getRecommendedCiphers();
+    ciphers.addAll(RESTRICTED);
+    return ciphers;
+  }
+}

--- a/kork-tomcat/kork-tomcat.gradle
+++ b/kork-tomcat/kork-tomcat.gradle
@@ -8,6 +8,7 @@ dependencies {
   implementation("com.netflix.spectator:spectator-api")
   implementation("com.google.guava:guava")
   implementation(project(":kork-core"))
+  implementation(project(":kork-crypto"))
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 }

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/TomcatConfigurationProperties.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/TomcatConfigurationProperties.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.kork.tomcat;
 
+import com.netflix.spinnaker.kork.crypto.CipherSuites;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -31,27 +32,9 @@ public class TomcatConfigurationProperties {
   private String relaxedQueryCharacters = "";
   private String relaxedPathCharacters = "";
 
-  private List<String> tlsVersions = new ArrayList<>(Arrays.asList("TLSv1.2", "TLSv1.1"));
+  private List<String> tlsVersions = new ArrayList<>(Arrays.asList("TLSv1.3", "TLSv1.2"));
 
-  // Defaults from https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-  // with some extra ciphers (non SHA384/256) to support TLSv1.1 and some non EC ciphers
-  private List<String> cipherSuites =
-      new ArrayList<>(
-          Arrays.asList(
-              "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-              "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-              "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-              "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-              "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
-              "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-              "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
-              "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-              "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
-              "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-              "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-              "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-              "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
-              "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"));
+  private List<String> cipherSuites = CipherSuites.getRecommendedCiphers();
 
   private Boolean rejectIllegalHeader;
 

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.okhttp
 
+import com.netflix.spinnaker.kork.crypto.CipherSuites
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 import java.time.Duration
@@ -43,23 +44,8 @@ class OkHttpClientConfigurationProperties {
 
   String secureRandomInstanceType = "NativePRNGNonBlocking"
   // TLS1.1 isn't supported in newer JVMs... do NOT try to add back - it's also insecure
-  List<String> tlsVersions = ["TLSv1.2", "TLSv1.3"]
-  //Defaults from https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-  // with some extra ciphers (non SHA384/256) to support TLSv1.1 and some non EC ciphers
-  List<String> cipherSuites = [
-    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
-    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
-    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
-    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
-  ]
+  List<String> tlsVersions = ["TLSv1.3", "TLSv1.2"]
+  List<String> cipherSuites = CipherSuites.recommendedCiphers
 
   /**
    * Provide backwards compatibility for 'okHttpClient.connectTimoutMs'


### PR DESCRIPTION
This adds a common `CipherSuites` class for listing various profiles of cipher suites for use with TLS. The default cipher suites and TLS versions are updated to a slightly more secure version of the intermediate compatibility baseline from the Mozilla recommendations. These settings are used for both Tomcat and OkHttpClient. Of particular note, this adds in the required ciphers in TLS 1.3 to improve compatibility with modern clients and servers.