### PR TITLE
fix(artifacts): references containing '+' break matching

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifact.java
@@ -98,7 +98,23 @@ public final class ExpectedArtifact {
   }
 
   private boolean matches(@Nullable String us, @Nullable String other) {
-    return StringUtils.isEmpty(us) || (other != null && patternMatches(us, other));
+    if (StringUtils.isEmpty(us)) {
+      return true;
+    }
+
+    if (other == null) {
+      return false;
+    }
+
+    // The strict equals is mostly to ensure base64 references can be compared
+    // against each other, since the '+' is a completely valid base64 character.
+    // The '+' in regex has the meaning of one or more, and will change the
+    // semantics of comparing two references.
+    //
+    // So rather than having references implement its own matching, users may
+    // rely on matching artifacts with some regex. To be backwards compatible we
+    // will do a strict comparison as well as pattern matching.
+    return us.equals(other) || patternMatches(us, other);
   }
 
   /**

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactTest.java
@@ -220,6 +220,6 @@ final class ExpectedArtifactTest {
         Arguments.of("SGVsbG8gV29ybGQK", null, false, "other reference as null"),
         Arguments.of("SGVsbG8gV29ybGQK", "", false, "other reference is empty"),
         Arguments.of("", "SGVsbG8gV29ybGQK", true, "match reference is empty"),
-        Arguments.of("+++", "+++", true, "all possible base64 characters"));
+        Arguments.of("+++", "+++", true, "valid base64 but invalid regex"));
   }
 }

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/model/ExpectedArtifactTest.java
@@ -189,4 +189,37 @@ final class ExpectedArtifactTest {
             s -> Artifact.builder().artifactAccount(s).build())
         .map(Arguments::of);
   }
+
+  @ParameterizedTest
+  @MethodSource("referenceCases")
+  void testReferenceMatches(
+      String matchReference, String otherReference, boolean shouldMatch, String caseName) {
+    ExpectedArtifact expectedArtifact =
+        ExpectedArtifact.builder()
+            .id("test")
+            .matchArtifact(
+                Artifact.builder()
+                    .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
+                    .reference(matchReference)
+                    .build())
+            .build();
+
+    assertThat(
+            expectedArtifact.matches(
+                Artifact.builder()
+                    .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
+                    .reference(otherReference)
+                    .build()))
+        .as(caseName)
+        .isEqualTo(shouldMatch);
+  }
+
+  private static Stream<Arguments> referenceCases() {
+    return Stream.of(
+        Arguments.of("SGVsbG8gV29ybGQK", "SGVsbG8gV29ybGQK", true, "simple"),
+        Arguments.of("SGVsbG8gV29ybGQK", null, false, "other reference as null"),
+        Arguments.of("SGVsbG8gV29ybGQK", "", false, "other reference is empty"),
+        Arguments.of("", "SGVsbG8gV29ybGQK", true, "match reference is empty"),
+        Arguments.of("+++", "+++", true, "all possible base64 characters"));
+  }
 }


### PR DESCRIPTION
When expected artifact does matching on a base64 reference, containing special regex characters, it will attempt pattern matching where ‘+’ actually means something in regex and will fail matches because of this. This commit ensures that all base64 characters can be matched against that may not be valid regex expression.

Example pipeline:

```json
{
  "application" : "spinnaker-ci",
  "description" : "This pipeline ensures that artifacts with regex characters like '+' succeed in pipelines.",
  "expectedArtifacts" : [ {
    "defaultArtifact" : {
      "artifactAccount" : "embedded-artifact",
      "id" : "f435c890-c5b6-4bdb-a733-d788413fd5c1",
      "type" : "embedded/base64"
    },
    "displayName" : "regex-artifact",
    "id" : "be22c2c5-6561-4f41-b885-367ef91b8362",
    "matchArtifact" : {
      "artifactAccount" : "embedded-artifact",
      "id" : "cf4891ff-6e56-495b-a41e-46f120783ff8",
      "name" : "match-artifact",
      "reference" : "+++",
      "type" : "embedded/base64"
    },
    "useDefaultArtifact" : false,
    "usePriorArtifact" : false
  } ],
  "id" : "8ed4f44b-a072-37e0-88b5-61a63c5668a9",
  "keepWaitingPipelines" : false,
  "limitConcurrent" : true,
  "name" : "Webhook Trigger Base64 Regex",
  "stages" : [ {
    "completeOtherBranchesThenFail" : false,
    "continuePipeline" : false,
    "expectedArtifacts" : [ {
      "defaultArtifact" : {
        "artifactAccount" : "embedded-artifact",
        "id" : "f435c890-c5b6-4bdb-a733-d788413fd5c1",
        "type" : "embedded/base64"
      },
      "displayName" : "regex-artifact",
      "id" : "be22c2c5-6561-4f41-b885-367ef91b8362",
      "matchArtifact" : {
        "artifactAccount" : "embedded-artifact",
        "id" : "cf4891ff-6e56-495b-a41e-46f120783ff8",
        "name" : "match-artifact",
        "reference" : "+++",
        "type" : "embedded/base64"
      },
      "useDefaultArtifact" : false,
      "usePriorArtifact" : false
    } ],
    "failPipeline" : true,
    "inputArtifacts" : [ {
      "account" : "embedded-artifact",
      "id" : "be22c2c5-6561-4f41-b885-367ef91b8362"
    } ],
    "name" : "Bake (Manifest)",
    "namespace" : "my-namespace",
    "outputName" : "nginx",
    "refId" : "1",
    "requisiteStageRefIds" : [ ],
    "templateRenderer" : "HELM3",
    "type" : "bakeManifest"
  } ],
  "triggers" : [ {
    "enabled" : true,
    "expectedArtifactIds" : [ "be22c2c5-6561-4f41-b885-367ef91b8362" ],
    "id" : "391f8418-3805-406e-82fb-2bb1ea02ff5d",
    "payloadConstraints" : { },
    "source" : "base64-regex-test",
    "type" : "webhook"
  } ]
}
```

curl with
```bash
curl http://localhost:8084/webhooks/webhook/base64-regex-test -d '{"artifacts":[{"artifactAccount":"embedded-artifact","name":"match-artifact","reference":"+++","type":"embedded/base64"}],"expectedArtifactIds":["be22c2c5-6561-4f41-b885-367ef91b8362"],"expectedArtifacts":[{"defaultArtifact":{"artifactAccount":"embedded-artifact","id":"f435c890-c5b6-4bdb-a733-d788413fd5c1","type":"embedded/base64"},"displayName":"regex-artifact","id":"be22c2c5-6561-4f41-b885-367ef91b8362","matchArtifact":{"artifactAccount":"embedded-artifact","id":"cf4891ff-6e56-495b-a41e-46f120783ff8","name":"match-artifact","reference":"+++","type":"embedded/base64"},"useDefaultArtifact":false,"usePriorArtifact":false}]}
```

echo will log this exception
```
java.util.regex.PatternSyntaxException: Dangling meta character '+' near index 0
```

This commit addresses this error by instead doing a simple string comparison and if that fails, then we do the regex.