### PR TITLE
refactor(jedis-test): replace use of io.spinnaker.embedded-redis:embe…

### DIFF
--- a/kork-jedis-test/kork-jedis-test.gradle
+++ b/kork-jedis-test/kork-jedis-test.gradle
@@ -4,5 +4,5 @@ dependencies {
   api(platform(project(":spinnaker-dependencies")))
 
   api "redis.clients:jedis"
-  api "io.spinnaker.embedded-redis:embedded-redis"
+  implementation "org.testcontainers:testcontainers"
 }

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -125,7 +125,6 @@ dependencies {
     api("com.netflix.spectator:spectator-web-spring:${versions.spectator}")
     api("com.netflix.spectator:spectator-reg-micrometer:${versions.spectator}")
     api("com.nimbusds:nimbus-jose-jwt:7.9")
-    api("io.spinnaker.embedded-redis:embedded-redis:0.9.0")
     api("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
     api("com.nhaarman:mockito-kotlin:1.6.0")
     api("com.ninja-squad:springmockk:2.0.3")


### PR DESCRIPTION
…dded-redis with testcontainers

so we no longer need to maintain https://github.com/spinnaker/embedded-redis

and because after upgrading my mac to Sonoma (14.1), I see test failures with:
```
Caused by:
 java.lang.RuntimeException: Can't start redis server. Check logs for details.
     at redis.embedded.AbstractRedisInstance.awaitRedisServerReady(AbstractRedisInstance.java:60)
     at redis.embedded.AbstractRedisInstance.start(AbstractRedisInstance.java:36)
     at redis.embedded.RedisServer.start(RedisServer.java:9)
     at com.netflix.spinnaker.kork.jedis.EmbeddedRedis.<init>(EmbeddedRedis.java:29)
     at com.netflix.spinnaker.kork.jedis.EmbeddedRedis.embed(EmbeddedRedis.java:65)
     at com.netflix.spinnaker.kork.jedis.EmbeddedRedis$embed.call(Unknown Source)
```
The OS upgrade may not be the cause, but testcontainers works, and is generally a cleaner solution, so let's use it.

Change the return value of getPool to the more specific JedisPool (from Pool<Jedis>) so it's useful by e.g. gate's RedisTestConfig class.

Note that embedded-redis 0.9 was using version [4.0.10 of redis](https://github.com/spinnaker/embedded-redis/blob/v0.9.0/src/main/java/redis/embedded/RedisExecProvider.java#L30-L34).  Use 5-alpine to match [fiat](https://github.com/spinnaker/fiat/blob/b64c9ea249bd262c84a7421faf071cabdd3fdf77/fiat-web/src/test/groovy/com/netflix/spinnaker/config/RedisContainerConfig.groovy#L35).