### PR TITLE
chore(dependencies): make snakeyaml version strictly to 1.27

### DIFF
--- a/kork-runtime/kork-runtime.gradle
+++ b/kork-runtime/kork-runtime.gradle
@@ -1,4 +1,6 @@
 dependencies {
+  runtimeOnly(platform(project(":spinnaker-dependencies")))
+
   // Add each included runtime project as a runtime dependency
   gradle.includedRuntimeProjects.each {
     runtimeOnly project(it)

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -181,7 +181,12 @@ dependencies {
     // when we upgrade to spring boot 2.6.x.  It's safe to upgrade beyond 1.29
     // with spring boot >= 2.6.12.  See
     // https://github.com/spring-projects/spring-boot/issues/32228#issue-136185850.0.
-    api("org.yaml:snakeyaml:1.27")
+    // making it strict as some of the modules have it resolved to higher versions (ex: kork-secrets-gcp to 1.30)
+    api("org.yaml:snakeyaml") {
+      version {
+        strictly "1.27"
+      }
+    }
     api("org.springdoc:springdoc-openapi-webmvc-core:${versions.openapi}")
     api("org.springdoc:springdoc-openapi-kotlin:${versions.openapi}")
     api("org.springframework.boot:spring-boot-configuration-processor:${versions.springBoot}")


### PR DESCRIPTION
It is observed that the snakeyaml version is not resolved to intended 1.27 for some of the modules. Hence making it strictly 1.27. 