### PR TITLE
chore(dependency): upgrade kotlin to 1.5.32

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.4.32
+kotlinVersion=1.5.32
 org.gradle.parallel=true
 spinnakerGradleVersion=8.31.0
 targetJava11=true

--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -35,7 +35,7 @@ dependencies {
 
 compileTestKotlin {
   kotlinOptions {
-    languageVersion = "1.4"
+    languageVersion = "1.5"
     jvmTarget = "11"
   }
 }

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -37,14 +37,14 @@ dependencies {
 
 compileKotlin {
   kotlinOptions {
-    languageVersion = "1.4"
+    languageVersion = "1.5"
     jvmTarget = "11"
   }
 }
 
 compileTestKotlin {
   kotlinOptions {
-    languageVersion = "1.4"
+    languageVersion = "1.5"
     jvmTarget = "11"
   }
 }

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSecretTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/PluginSecretTest.kt
@@ -113,7 +113,7 @@ class PluginSecretTest : JUnit5Minutests {
   }
 
   @TestConfiguration
-  private class TestSecretEngineConfiguration {
+  class TestSecretEngineConfiguration {
     @Bean
     fun testSecretEngine(): SecretEngine = object : SecretEngine {
       override fun clearCache() = Unit

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/scenarios/ComplexInjectionScenarioTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/scenarios/ComplexInjectionScenarioTest.kt
@@ -115,14 +115,14 @@ class ComplexInjectionScenarioTest : JUnit5Minutests {
 
   @TestConfiguration
   @ComponentScan("com.netflix.spinnaker.kork.plugins.v2.scenarios.fixtures")
-  private class ComplexInjectionTestConfiguration {
+  class ComplexInjectionTestConfiguration {
     @Bean
     fun injectsPluginExtensions(testExtensions: List<TestExtension>): InjectsPluginExtensions {
       return InjectsPluginExtensions(testExtensions)
     }
   }
 
-  private class InjectsPluginExtensions(val testExtensions: List<TestExtension>) {
+  class InjectsPluginExtensions(val testExtensions: List<TestExtension>) {
     @PostConstruct
     fun tryOutExtensions() {
       // Verify that extensions can be used immediately.

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/scenarios/ServiceDependenciesScenarioTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/scenarios/ServiceDependenciesScenarioTest.kt
@@ -78,7 +78,7 @@ class ServiceDependenciesScenarioTest : JUnit5Minutests {
 
   @Configuration
   @ComponentScan("com.netflix.spinnaker.kork.plugins.v2.scenarios.fixtures")
-  private class TestApplicationConfiguration
+  class TestApplicationConfiguration
 
   companion object {
     private val GENERATED = testPlugin {

--- a/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/scenarios/ServiceInjectionScenarioTest.kt
+++ b/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/scenarios/ServiceInjectionScenarioTest.kt
@@ -73,14 +73,14 @@ class ServiceInjectionScenarioTest : JUnit5Minutests {
   }
 
   @TestConfiguration
-  private class ServiceInjectionTestConfiguration {
+  class ServiceInjectionTestConfiguration {
     @Bean
     fun injectsPluginExtensions(testExtensions: List<TestExtension>): InjectsPluginExtensions {
       return InjectsPluginExtensions(testExtensions)
     }
   }
 
-  private class InjectsPluginExtensions(val testExtensions: List<TestExtension>) {
+  class InjectsPluginExtensions(val testExtensions: List<TestExtension>) {
     @PostConstruct
     fun tryOutExtensions() {
       // Verify that extensions can be used immediately.

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -50,7 +50,7 @@ dependencies {
    // 2.16.0 is subject to CVE-2021-45105.  2.17.0 is subject to CVE-2021-44832, so use >= 2.17.1.
   api(platform("org.apache.logging.log4j:log4j-bom:2.20.0"))
 
-  api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.3"))
+  api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.5.2"))
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))


### PR DESCRIPTION
Upgrade kotlin from 1.4.0 to 1.5.32, in order to sync with spring boot 2.5.15. 
https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.5.15/spring-boot-dependencies-2.5.15.pom

Upgrade kotlinx-coroutines-bom to 1.5.2, in order to sync with kotlin 1.5.x. 
https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.2/kotlinx-coroutines-core-jvm-1.5.2.pom

While upgrading kotlin 1.5.32, encounter below errors in kork-plugins module:
```
Unstarted application context org.springframework.boot.test.context.assertj.AssertableApplicationContext[startupFailure=org.springframework.beans.factory.parsing.BeanDefinitionParsingException] failed to start
java.lang.IllegalStateException: Unstarted application context org.springframework.boot.test.context.assertj.AssertableApplicationContext[startupFailure=org.springframework.beans.factory.parsing.BeanDefinitionParsingException] failed to start
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.getStartedApplicationContext(AssertProviderApplicationContextInvocationHandler.java:156)
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.invokeApplicationContextMethod(AssertProviderApplicationContextInvocationHandler.java:147)
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.invoke(AssertProviderApplicationContextInvocationHandler.java:85)
	at com.sun.proxy.$Proxy68.getBeansOfType(Unknown Source)
	at com.netflix.spinnaker.kork.plugins.PluginSecretTest$tests$1$2.invoke$lambda-0(PluginSecretTest.kt:46)
	...
Caused by: org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: @Configuration class 'PluginSecretTest.TestSecretEngineConfiguration' may not be final. Remove the final modifier to continue.
Offending resource: com.netflix.spinnaker.kork.plugins.PluginSecretTest$TestSecretEngineConfiguration
	at app//org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:72)
	at app//org.springframework.context.annotation.ConfigurationClass.validate(ConfigurationClass.java:217)
	at app//org.springframework.context.annotation.ConfigurationClassParser.validate(ConfigurationClassParser.java:215)

Unstarted application context org.springframework.boot.test.context.assertj.AssertableApplicationContext[startupFailure=org.springframework.beans.factory.parsing.BeanDefinitionParsingException] failed to start
java.lang.IllegalStateException: Unstarted application context org.springframework.boot.test.context.assertj.AssertableApplicationContext[startupFailure=org.springframework.beans.factory.parsing.BeanDefinitionParsingException] failed to start
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.getStartedApplicationContext(AssertProviderApplicationContextInvocationHandler.java:156)
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.invokeApplicationContextMethod(AssertProviderApplicationContextInvocationHandler.java:147)
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.invoke(AssertProviderApplicationContextInvocationHandler.java:85)
	at com.sun.proxy.$Proxy68.getBean(Unknown Source)
	at com.netflix.spinnaker.kork.plugins.v2.scenarios.ComplexInjectionScenarioTest$tests$1$2.invoke$lambda-0(ComplexInjectionScenarioTest.kt:55)
	...
Caused by: org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: @Configuration class 'ComplexInjectionScenarioTest.ComplexInjectionTestConfiguration' may not be final. Remove the final modifier to continue.
Offending resource: com.netflix.spinnaker.kork.plugins.v2.scenarios.ComplexInjectionScenarioTest$ComplexInjectionTestConfiguration
	at app//org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:72)
	at app//org.springframework.context.annotation.ConfigurationClass.validate(ConfigurationClass.java:217)
	at app//org.springframework.context.annotation.ConfigurationClassParser.validate(ConfigurationClassParser.java:215)

Unstarted application context org.springframework.boot.test.context.assertj.AssertableApplicationContext[startupFailure=org.springframework.beans.factory.parsing.BeanDefinitionParsingException] failed to start
java.lang.IllegalStateException: Unstarted application context org.springframework.boot.test.context.assertj.AssertableApplicationContext[startupFailure=org.springframework.beans.factory.parsing.BeanDefinitionParsingException] failed to start
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.getStartedApplicationContext(AssertProviderApplicationContextInvocationHandler.java:156)
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.invokeApplicationContextMethod(AssertProviderApplicationContextInvocationHandler.java:147)
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.invoke(AssertProviderApplicationContextInvocationHandler.java:85)
	at com.sun.proxy.$Proxy68.getBean(Unknown Source)
	at com.netflix.spinnaker.kork.plugins.v2.scenarios.ServiceDependenciesScenarioTest$tests$1$2.invoke$lambda-0(ServiceDependenciesScenarioTest.kt:49)
	...
Caused by: org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: @Configuration class 'ServiceDependenciesScenarioTest.TestApplicationConfiguration' may not be final. Remove the final modifier to continue.
Offending resource: com.netflix.spinnaker.kork.plugins.v2.scenarios.ServiceDependenciesScenarioTest$TestApplicationConfiguration
	at app//org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:72)
	at app//org.springframework.context.annotation.ConfigurationClass.validate(ConfigurationClass.java:217)
	at app//org.springframework.context.annotation.ConfigurationClassParser.validate(ConfigurationClassParser.java:215)

Unstarted application context org.springframework.boot.test.context.assertj.AssertableApplicationContext[startupFailure=org.springframework.beans.factory.parsing.BeanDefinitionParsingException] failed to start
java.lang.IllegalStateException: Unstarted application context org.springframework.boot.test.context.assertj.AssertableApplicationContext[startupFailure=org.springframework.beans.factory.parsing.BeanDefinitionParsingException] failed to start
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.getStartedApplicationContext(AssertProviderApplicationContextInvocationHandler.java:156)
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.invokeApplicationContextMethod(AssertProviderApplicationContextInvocationHandler.java:147)
	at org.springframework.boot.test.context.assertj.AssertProviderApplicationContextInvocationHandler.invoke(AssertProviderApplicationContextInvocationHandler.java:85)
	at com.sun.proxy.$Proxy68.getBean(Unknown Source)
	at com.netflix.spinnaker.kork.plugins.v2.scenarios.ServiceInjectionScenarioTest$tests$1$2.invoke$lambda-0(ServiceInjectionScenarioTest.kt:48)
	...
Caused by: org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: @Configuration class 'ServiceInjectionScenarioTest.ServiceInjectionTestConfiguration' may not be final. Remove the final modifier to continue.
Offending resource: com.netflix.spinnaker.kork.plugins.v2.scenarios.ServiceInjectionScenarioTest$ServiceInjectionTestConfiguration
	at app//org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:72)
	at app//org.springframework.context.annotation.ConfigurationClass.validate(ConfigurationClass.java:217)
	at app//org.springframework.context.annotation.ConfigurationClassParser.validate(ConfigurationClassParser.java:215)
```
To fix these errors make `Configuration` classes as generic scope by removing `private`.