### PR TITLE
chore(deps): use version mysql:mysql-connector-java from spring boot

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -137,7 +137,6 @@ dependencies {
     api("io.swagger:swagger-annotations:${versions.swagger}")
     api("javax.annotation:javax.annotation-api:1.3.2")
     api("javax.xml.bind:jaxb-api:2.3.1")
-    api("mysql:mysql-connector-java:8.0.20")
     api("net.logstash.logback:logstash-logback-encoder:4.11")
     api("org.apache.commons:commons-exec:1.3")
     // TODO(jvz): beginning in BC 1.71, this should use the -jdk18on artifacts


### PR DESCRIPTION
to stay up to date and to resolve CVE-2021-2471 and CVE-2022-21363

[Spring boot 2.5.15](https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.5.15/spring-boot-dependencies-2.5.15.pom) uses version 8.0.33.