### PR TITLE
chore(dependencies): add dependencies on spinnaker-dependencies

### DIFF
--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -20,6 +20,7 @@
 apply plugin: "kotlin"
 
 dependencies {
+  testImplementation(platform(project(":spinnaker-dependencies")))
   testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 
   testImplementation "org.junit.jupiter:junit-jupiter-api"
@@ -29,6 +30,7 @@ dependencies {
   testImplementation "dev.minutest:minutest"
   testImplementation "io.mockk:mockk"
 
+  testRuntimeOnly(platform(project(":spinnaker-dependencies")))
   testRuntimeOnly "org.junit.platform:junit-platform-launcher"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -19,6 +19,7 @@ apply plugin: "kotlin-spring"
 apply plugin: "io.gitlab.arturbosch.detekt"
 
 dependencies {
+  testImplementation(platform(project(":spinnaker-dependencies")))
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.spekframework.spek2:spek-dsl-jvm"
@@ -28,6 +29,7 @@ dependencies {
   testImplementation "dev.minutest:minutest"
   testImplementation "io.mockk:mockk"
 
+  testRuntimeOnly(platform(project(":spinnaker-dependencies")))
   testRuntimeOnly "org.junit.platform:junit-platform-launcher"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
   testRuntimeOnly "org.junit.vintage:junit-vintage-engine"

--- a/gradle/lombok.gradle
+++ b/gradle/lombok.gradle
@@ -1,8 +1,10 @@
 dependencies {
   compileOnly "org.projectlombok:lombok"
+  compileOnly(platform(project(":spinnaker-dependencies")))
   annotationProcessor "org.projectlombok:lombok"
   annotationProcessor(platform(project(":spinnaker-dependencies")))
   testCompileOnly "org.projectlombok:lombok"
+  testCompileOnly(platform(project(":spinnaker-dependencies")))
   testAnnotationProcessor(platform(project(":spinnaker-dependencies")))
   testAnnotationProcessor "org.projectlombok:lombok"
 }

--- a/kork-actuator/kork-actuator.gradle
+++ b/kork-actuator/kork-actuator.gradle
@@ -19,6 +19,7 @@ apply plugin: "java-library"
 apply from: "$rootDir/gradle/kotlin-test.gradle"
 
 dependencies {
+  compileOnly(platform(project(":spinnaker-dependencies")))
   implementation(platform(project(":spinnaker-dependencies")))
   implementation "org.springframework.security:spring-security-core"
   implementation "org.springframework.boot:spring-boot-starter-security"

--- a/kork-plugins-spring-api/kork-plugins-spring-api.gradle
+++ b/kork-plugins-spring-api/kork-plugins-spring-api.gradle
@@ -18,7 +18,7 @@ apply plugin: "java-library"
 apply from: "${project.rootDir}/gradle/kotlin-test.gradle"
 
 dependencies {
-  implementation(platform(project(":spinnaker-dependencies")))
+  api(platform(project(":spinnaker-dependencies")))
 
   api project(":kork-plugins-api")
   api "org.springframework.boot:spring-boot-starter-web"


### PR DESCRIPTION
When projects have dependencies on artifacts, but depend on spinnaker-dependencies to provide the version, this makes the version available and removes failures from ./gradlew dependencies output.

Some examples of failures that this removes:
```
testRuntimeOnlyDependenciesMetadata
+--- org.junit.jupiter:junit-jupiter-engine FAILED \--- org.junit.platform:junit-platform-launcher FAILED

compileOnly - Compile only dependencies for compilation 'main' (target  (jvm)). \--- org.projectlombok:lombok FAILED

compileOnlyDependenciesMetadata
\--- org.projectlombok:lombok FAILED

testCompileOnly - Compile only dependencies for compilation 'test' (target  (jvm)). \--- org.projectlombok:lombok FAILED

testCompileOnlyDependenciesMetadata
\--- org.projectlombok:lombok FAILED
```