### PR TITLE
Credentials management API and SDK

### DIFF
--- a/kork-api/src/main/java/com/netflix/spinnaker/kork/api/exceptions/ConstraintViolation.java
+++ b/kork-api/src/main/java/com/netflix/spinnaker/kork/api/exceptions/ConstraintViolation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.api.exceptions;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@NonnullByDefault
+public class ConstraintViolation {
+  private final String message;
+  private final String errorCode;
+  private final String path;
+  private final Object validatedObject;
+  private final Object invalidValue;
+  @Builder.Default private final Map<String, Object> additionalAttributes = Map.of();
+}

--- a/kork-api/src/main/java/com/netflix/spinnaker/kork/api/exceptions/ConstraintViolationContext.java
+++ b/kork-api/src/main/java/com/netflix/spinnaker/kork/api/exceptions/ConstraintViolationContext.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.api.exceptions;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Holder for additional {@link ConstraintViolation} metadata when performing constraint validation.
+ * A request-scoped bean of this class should be registered for use with an exception handler.
+ */
+@NonnullByDefault
+public interface ConstraintViolationContext {
+  void addViolation(ConstraintViolation violation);
+
+  default Optional<ConstraintViolation> removeMatchingViolation(
+      Predicate<ConstraintViolation> predicate) {
+    Iterator<ConstraintViolation> iterator = getConstraintViolations().iterator();
+    while (iterator.hasNext()) {
+      ConstraintViolation violation = iterator.next();
+      if (predicate.test(violation)) {
+        iterator.remove();
+        return Optional.of(violation);
+      }
+    }
+    return Optional.empty();
+  }
+
+  List<ConstraintViolation> getConstraintViolations();
+}

--- a/kork-api/src/main/java/com/netflix/spinnaker/kork/api/exceptions/DefaultConstraintViolationContext.java
+++ b/kork-api/src/main/java/com/netflix/spinnaker/kork/api/exceptions/DefaultConstraintViolationContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.api.exceptions;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+/**
+ * Default implementation of {@link ConstraintViolationContext}. This should be registered as a
+ * request-scoped bean so that a request exception handler can use it.
+ */
+@Getter
+@NonnullByDefault
+public class DefaultConstraintViolationContext implements ConstraintViolationContext {
+  private final List<ConstraintViolation> constraintViolations = new ArrayList<>();
+
+  @Override
+  public void addViolation(ConstraintViolation violation) {
+    constraintViolations.add(violation);
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/ObjectNodeErrors.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/jackson/ObjectNodeErrors.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.jackson;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import org.springframework.validation.AbstractBindingResult;
+
+/**
+ * Generic {@link org.springframework.validation.Errors} container for validating a parsed JSON
+ * object.
+ */
+@NonnullByDefault
+public class ObjectNodeErrors extends AbstractBindingResult {
+  private final ObjectNode target;
+
+  public ObjectNodeErrors(ObjectNode target, String objectName) {
+    super(objectName);
+    this.target = target;
+  }
+
+  @Override
+  public Object getTarget() {
+    return target;
+  }
+
+  @Override
+  protected Object getActualFieldValue(String field) {
+    return target.get(field);
+  }
+}

--- a/kork-credentials-api/kork-credentials-api.gradle
+++ b/kork-credentials-api/kork-credentials-api.gradle
@@ -21,12 +21,19 @@ dependencies {
   implementation(platform(project(":spinnaker-dependencies")))
   implementation project(":kork-annotations")
   implementation project(":kork-exceptions")
+  implementation project(":kork-plugins-api")
   implementation 'javax.annotation:javax.annotation-api'
+  implementation 'jakarta.validation:jakarta.validation-api'
+  implementation "org.springframework:spring-beans"
+  implementation "org.apache.logging.log4j:log4j-api"
+  implementation "io.micrometer:micrometer-core"
 
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 
+  testImplementation 'org.springframework.boot:spring-boot-starter-test'
+  testImplementation 'org.springframework.boot:spring-boot-starter-validation'
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsError.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsError.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+/** Describes an error encountered loading or parsing credentials. */
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Data
+public class CredentialsError {
+  @Nonnull private String errorCode;
+  @Nonnull private String message;
+  @Nullable private String field;
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsSource.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsSource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+
+/** Describes where these credentials come from. */
+@Alpha
+public enum CredentialsSource {
+  /**
+   * Describes credentials stored in {@linkplain CredentialsDefinitionRepository account storage}.
+   */
+  STORAGE,
+  /** Describes credentials stored in configuration files. */
+  CONFIG,
+  /** Describes credentials provided by a plugin. */
+  PLUGIN,
+  /**
+   * Describes credentials provided from an external source such as a custom resource definition.
+   */
+  EXTERNAL,
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsView.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsView.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Provides a view into a credential definition for a user. */
+@Data
+@Alpha
+@NoArgsConstructor
+@AllArgsConstructor
+public class CredentialsView {
+  /**
+   * Provides metadata regarding a credential definition including the account name, the source from
+   * which it came, and the type of credentials (corresponding to its {@link CredentialsType} type
+   * discriminator value).
+   *
+   * @see CredentialsSource
+   */
+  private Metadata metadata = new Metadata();
+
+  /**
+   * Provides the current specification of the credentials. This may be an instance of a {@link
+   * Map}, a {@code JsonNode}, or a {@link CredentialsDefinition} depending on how far the parser
+   * gets before encountering an error. For a map result, this will contain a key named {@code data}
+   * pointing to a string containing the invalid JSON data. For a {@code JsonNode} result, this is
+   * valid JSON but not in the expected form of a {@link CredentialsDefinition}. For a {@link
+   * CredentialsDefinition}, this will not have any secrets decrypted. If more than one credential
+   * is available from multiple services, this will be a list of them.
+   */
+  private Object spec;
+
+  /** Describes the status of this credential definition. */
+  private final Status status = new Status();
+
+  @Data
+  public static class Metadata {
+    /** Provides the name of the account. May be null if unknown (and is not likely parseable). */
+    @Nullable private String name;
+    /** Provides the type discriminator of the credentials. May be null if unknown. */
+    @Nullable private String type;
+    /** Provides the entity tag of the credentials. If no history is tracked, this may be null. */
+    @Nullable private String eTag;
+    /**
+     * Provides the instant these credentials were last modified. If untracked, this may be null.
+     */
+    @Nullable private Instant lastModified;
+
+    /** Describes the source of this credential definition. */
+    private CredentialsSource source;
+  }
+
+  @Data
+  public static class Status {
+    /**
+     * Indicates if these credentials are valid. If false, then the errors list will be non-empty.
+     */
+    private boolean valid = true;
+    /** Lists the errors encountered if the account is invalid. */
+    private List<CredentialsError> errors = new ArrayList<>();
+
+    /** Adds an error to this status and resets the {@link #isValid()} flag to {@code false}. */
+    public void addError(CredentialsError error) {
+      valid = false;
+      errors.add(error);
+    }
+
+    /**
+     * Adds a collection of errors to this status and resets the {@link #isValid()} flag to {@code
+     * false}.
+     */
+    public void addErrors(Collection<CredentialsError> credentialsErrors) {
+      valid = false;
+      errors.addAll(credentialsErrors);
+    }
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionConstraintValidator.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionConstraintValidator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import java.util.regex.Pattern;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.util.StringUtils;
+
+/**
+ * Constraint validator implementation for the {@link ValidatedCredentials} annotation. Validation
+ * of credentials includes checking that its name matches the configured {@link
+ * CredentialsDefinitionNamePatternProvider} bean-provided regular expression using the credentials
+ * type name extracted by the configured {@link CredentialsDefinitionTypeExtractor} bean along with
+ * any other {@link CredentialsDefinitionValidator} beans found at runtime.
+ */
+@RequiredArgsConstructor
+public class CredentialsDefinitionConstraintValidator
+    implements ConstraintValidator<ValidatedCredentials, CredentialsDefinition> {
+  private final CredentialsDefinitionTypeExtractor typeExtractor;
+  private final CredentialsDefinitionNamePatternProvider namePatternProvider;
+  private final ObjectProvider<CredentialsDefinitionValidator> validators;
+
+  @Override
+  public boolean isValid(CredentialsDefinition value, ConstraintValidatorContext context) {
+    context.disableDefaultConstraintViolation();
+    String name = value.getName();
+    if (!StringUtils.hasText(name)) {
+      context
+          .buildConstraintViolationWithTemplate("missing account name")
+          .addPropertyNode("name")
+          .addConstraintViolation();
+      return false;
+    }
+    String type = typeExtractor.getCredentialsType(value);
+    if (type == null) {
+      context.buildConstraintViolationWithTemplate("missing account type").addConstraintViolation();
+      return false;
+    }
+    Pattern pattern = namePatternProvider.getPatternForType(type);
+    boolean valid = pattern.matcher(name).matches();
+    if (!valid) {
+      context
+          .buildConstraintViolationWithTemplate("account name does not match pattern " + pattern)
+          .addPropertyNode("name")
+          .addConstraintViolation();
+    }
+    for (CredentialsDefinitionValidator validator : validators) {
+      valid &= validator.isValid(value, context);
+    }
+    return valid;
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionNamePatternProvider.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionNamePatternProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import java.util.regex.Pattern;
+
+/**
+ * Provides validation patterns for {@linkplain CredentialsDefinition#getName() credentials names}.
+ * A bean of this type (along with {@link CredentialsDefinitionTypeExtractor}) must be registered in
+ * order to use the {@link ValidatedCredentials} constraint annotation on credentials.
+ *
+ * @see CredentialsDefinitionTypeExtractor
+ * @see ValidatedCredentials
+ */
+@FunctionalInterface
+public interface CredentialsDefinitionNamePatternProvider {
+  Pattern getPatternForType(String type);
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionTypeExtractor.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionTypeExtractor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import javax.annotation.Nullable;
+
+/**
+ * Strategy for extracting a credentials type name from a credential definition. A bean of this type
+ * must be registered (along with {@link CredentialsDefinitionNamePatternProvider}) to use the
+ * {@link ValidatedCredentials} constraint annotation on credentials.
+ *
+ * @see com.netflix.spinnaker.credentials.definition.CredentialsType
+ * @see CredentialsDefinitionNamePatternProvider
+ * @see ValidatedCredentials
+ */
+@FunctionalInterface
+public interface CredentialsDefinitionTypeExtractor {
+  @Nullable
+  String getCredentialsType(CredentialsDefinition definition);
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionValidator.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionValidator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
+import javax.validation.ConstraintValidator;
+
+/**
+ * Validates a {@link CredentialsDefinition} instance. Beans of this type are used when validating
+ * the {@link ValidatedCredentials} constraint annotation.
+ */
+public interface CredentialsDefinitionValidator
+    extends SpinnakerExtensionPoint,
+        ConstraintValidator<ValidatedCredentials, CredentialsDefinition> {}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/ValidatedCredentials.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/ValidatedCredentials.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Validation annotation to apply to {@link CredentialsDefinition} classes and parameters to ensure
+ * that the annotated credentials have been validated.
+ *
+ * @see CredentialsDefinitionValidator
+ * @see CredentialsDefinitionTypeExtractor
+ * @see CredentialsDefinitionNamePatternProvider
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.PARAMETER})
+@Constraint(validatedBy = CredentialsDefinitionConstraintValidator.class)
+public @interface ValidatedCredentials {
+  String message() default "";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/package-info.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonnullByDefault
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CompositeCredentialsNavigator.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CompositeCredentialsNavigator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Composite implementation of {@link CredentialsNavigator} for combining a collection of {@link
+ * CredentialsDefinitionSource} beans of the same credential type.
+ *
+ * @param <T> type of credentials
+ */
+@Alpha
+@RequiredArgsConstructor
+public class CompositeCredentialsNavigator<T extends CredentialsDefinition>
+    implements CredentialsNavigator<T> {
+  private final List<CredentialsDefinitionSource<T>> sources;
+  @Getter private final Class<T> type;
+  @Getter private final String typeName;
+
+  @Override
+  public List<T> getCredentialsDefinitions() {
+    return sources.stream()
+        .flatMap(source -> source.getCredentialsDefinitions().stream())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<CredentialsView> listCredentialsViews() {
+    return sources.stream()
+        .flatMap(
+            source -> {
+              if (source instanceof CredentialsNavigator<?>) {
+                // this source already knows how to list views
+                return ((CredentialsNavigator<T>) source).listCredentialsViews().stream();
+              }
+              // otherwise, create views just like super::listCredentialsViews
+              return source.getCredentialsDefinitions().stream()
+                  .map(
+                      definition -> {
+                        var metadata = new CredentialsView.Metadata();
+                        metadata.setType(getTypeName());
+                        metadata.setName(definition.getName());
+                        metadata.setSource(source.getSource());
+                        return new CredentialsView(metadata, definition);
+                      });
+            })
+        .collect(Collectors.toList());
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinition.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinition.java
@@ -17,14 +17,18 @@
 package com.netflix.spinnaker.credentials.definition;
 
 import com.netflix.spinnaker.credentials.Credentials;
+import com.netflix.spinnaker.credentials.constraint.ValidatedCredentials;
 
 /**
  * Contains properties that define {@link Credentials}. {@link CredentialsDefinition} can be POJOs
  * deserialized from configuration or an external system. These are optional but useful to use
- * built-in {@link CredentialsParser}.
+ * built-in {@link CredentialsParser}. Implementations that wish to support account storage must
+ * also be annotated with {@link CredentialsType} corresponding to the type discriminator to use for
+ * serialization and deserialization.
  *
  * <p>equals is checked to detect change in definitions
  */
+@ValidatedCredentials
 public interface CredentialsDefinition {
   String getName();
 }

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionRepository.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionRepository.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.credentials.definition.error.DuplicateCredentialsDefinitionException;
+import com.netflix.spinnaker.credentials.definition.error.GenericCredentialsDefinitionRepositoryException;
+import com.netflix.spinnaker.credentials.definition.error.InvalidCredentialsDefinitionException;
+import com.netflix.spinnaker.credentials.definition.error.NoMatchingCredentialsException;
+import com.netflix.spinnaker.credentials.definition.error.NoSuchCredentialsDefinitionException;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import com.netflix.spinnaker.kork.exceptions.InvalidCredentialsTypeException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import lombok.Getter;
+
+/** Provides CRUD persistence operations for account {@link CredentialsDefinition} instances. */
+@Alpha
+public interface CredentialsDefinitionRepository {
+
+  /**
+   * Searches for an existing credentials definition with the given name. If the credentials contain
+   * secret references, then those will be fetched and decrypted.
+   *
+   * @param name name of credentials to look up
+   * @return the credentials with that name or empty if none exist
+   */
+  @Nullable
+  CredentialsDefinition findByName(String name);
+
+  @Nullable
+  CredentialsView.Metadata findMetadataByName(String name);
+
+  /**
+   * Lists credentials definitions for a given credentials type. Credential types correspond to the
+   * value in the {@link CredentialsType} or {@code com.fasterxml.jackson.annotation.JsonTypeName}
+   * annotation present on the corresponding {@link CredentialsDefinition} class. If the credentials
+   * contain secret references, then those will be fetched and decrypted.
+   *
+   * @param typeName credential type to search for
+   * @return list of all stored credentials definitions matching the given credentials type name
+   */
+  List<CredentialsDefinition> listByType(String typeName);
+
+  /**
+   * Lists credentials definitions for a given credentials class. This works similarly to {@link
+   * #listByType(String)}, though the type name is extracted from the given class, and the result is
+   * safely cast to the provided class.
+   *
+   * @param type credential type to search for
+   * @return list of all stored credentials definitions with the given type
+   * @param <T> type of credentials
+   */
+  <T extends CredentialsDefinition> List<T> listByType(Class<T> type);
+
+  /**
+   * Lists credentials views for a given credentials type. These views should be post-processed by a
+   * {@link CredentialsNavigator}
+   *
+   * @return list of accessible credentials and their statuses
+   */
+  List<CredentialsView> listCredentialsViews(String typeName);
+
+  /**
+   * Creates a new credentials definition using the provided data. Secrets should use {@code
+   * UserSecretReference} encrypted URIs (e.g., {@code
+   * secret://secrets-manager?r=us-west-2&s=my-account-credentials}); raw secrets on sensitive
+   * fields will be excluded by default. Encrypted URIs will only be decrypted when loading account
+   * definitions, not when storing them. Note that account definitions correspond to the JSON
+   * representation of the underlying {@link CredentialsDefinition} object along with a JSON type
+   * discriminator field with the key {@code type} and value of the corresponding {@link
+   * CredentialsType} annotation. If an existing account exists for the same name, then this should
+   * return the existing account and metadata in a thrown {@link
+   * DuplicateCredentialsDefinitionException}.
+   *
+   * @param definition credentials definition to store as a new account
+   * @return metadata for the created credentials
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while saving the
+   *     credentials
+   * @throws InvalidCredentialsTypeException if the class of the provided credentials is not
+   *     annotated with @CredentialsType
+   * @throws InvalidCredentialsDefinitionException if there is an error serializing the provided
+   *     credentials
+   * @throws DuplicateCredentialsDefinitionException if credentials already exist with the same name
+   */
+  CredentialsView.Metadata create(CredentialsDefinition definition);
+
+  /**
+   * Creates or updates a credentials definition using the provided data. This is also known as an
+   * upsert operation. See {@link #create(CredentialsDefinition)} for more details.
+   *
+   * @param definition account definition to save
+   * @return metadata for the saved credentials
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while saving the
+   *     credentials
+   * @throws InvalidCredentialsTypeException if the class of the provided credentials is not
+   *     annotated with @CredentialsType
+   * @throws InvalidCredentialsDefinitionException if there is an error serializing the provided
+   *     credentials
+   */
+  CredentialsView.Metadata save(CredentialsDefinition definition);
+
+  /**
+   * Creates or updates credentials definitions in bulk.
+   *
+   * @return list of views of saved account definitions
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while saving the
+   *     credentials
+   * @throws InvalidCredentialsTypeException if the class of the provided credentials is not
+   *     annotated with @CredentialsType
+   * @throws InvalidCredentialsDefinitionException if there is an error serializing the provided
+   *     credentials
+   */
+  List<CredentialsView> saveAll(Collection<CredentialsDefinition> definitions);
+
+  /**
+   * Updates an existing credentials definition using the provided data. See details in {@link
+   * #create(CredentialsDefinition)} for details on the format.
+   *
+   * @param definition updated account definition to replace an existing account
+   * @return metadata of the updated account definition
+   * @throws NoSuchCredentialsDefinitionException if no account exists with the same name
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while saving the
+   *     account
+   * @throws InvalidCredentialsTypeException if the class of the provided credentials is not
+   *     annotated with @CredentialsType
+   * @throws InvalidCredentialsDefinitionException if there is an error serializing the provided
+   *     credentials
+   * @see #create(CredentialsDefinition)
+   */
+  CredentialsView.Metadata update(CredentialsDefinition definition);
+
+  /**
+   * Updates an existing credentials definition conditional on its existing etag matching one of the
+   * provided etag values.
+   *
+   * @param definition updated account definition to replace an existing account
+   * @param ifMatches list of one or more etag values to match an existing account against
+   * @return metadata of the updated account definition
+   * @throws NoSuchCredentialsDefinitionException if no account exists with the same name
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while saving the
+   *     account
+   * @throws InvalidCredentialsTypeException if the class of the provided credentials is not
+   *     annotated with @CredentialsType
+   * @throws InvalidCredentialsDefinitionException if there is an error serializing the provided
+   *     credentials
+   * @throws NoMatchingCredentialsException if an account exists with the same name and type but
+   *     does not match any of the provided etag values
+   * @see #create(CredentialsDefinition)
+   */
+  CredentialsView.Metadata updateIfMatch(CredentialsDefinition definition, List<String> ifMatches);
+
+  /**
+   * Returns the subset of names unknown to this repository from the provided collection of names.
+   * If this repository has credentials for all the provided names (or {@code names} is empty), then
+   * this returns an empty set.
+   *
+   * @param names credentials names to check
+   * @return subset of unknown credentials names
+   */
+  Set<String> getUnknownNames(Collection<String> names);
+
+  /**
+   * Deletes credentials by name.
+   *
+   * @param name name of account to delete
+   * @throws NoSuchCredentialsDefinitionException if no account exists with the same name
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while deleting the
+   *     account
+   */
+  void delete(String name);
+
+  /**
+   * Deletes multiple credentials by name.
+   *
+   * @param names names of accounts to delete
+   * @throws NoSuchCredentialsDefinitionException if one or more accounts requested do not exist
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while deleting the
+   *     accounts
+   */
+  void deleteAll(Collection<String> names);
+
+  /**
+   * Looks up the revision history of credentials by name. Revisions are sorted by latest version
+   * first.
+   *
+   * @param name account name to look up history for
+   * @return history of account updates for the given account name
+   */
+  List<Revision> revisionHistory(String name);
+
+  /**
+   * Provides metadata for a credentials definition revision when making updates to credentials via
+   * {@link CredentialsDefinitionRepository} APIs.
+   */
+  @Getter
+  class Revision {
+    /** Returns the revision id. Revision ids increase over time and are unique within a service. */
+    private final long revision;
+
+    /** Returns the instant when this revision was made. */
+    private final Instant timestamp;
+
+    /**
+     * Returns the credentials definition used in this revision. Returns {@code null} when this
+     * revision corresponds to a deletion.
+     */
+    private final @Nullable CredentialsDefinition account;
+
+    /**
+     * Returns the user who created this revision. May return {@code null} if this revision was made
+     * before this data began being tracked.
+     */
+    private final @Nullable String user;
+
+    /** Constructs a revision entry with a revision id, timestamp, and credentials definition. */
+    public Revision(long revision, Instant timestamp, @Nullable CredentialsDefinition account) {
+      this.revision = revision;
+      this.timestamp = timestamp;
+      this.account = account;
+      this.user = null;
+    }
+
+    /** Constructs a revision entry from a revision id, timestamp, definition, and userid. */
+    public Revision(
+        long revision,
+        Instant timestamp,
+        @Nullable CredentialsDefinition account,
+        @Nullable String user) {
+      this.revision = revision;
+      this.timestamp = timestamp;
+      this.account = account;
+      this.user = user;
+    }
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionSource.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionSource.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.credentials.definition;
 
+import com.netflix.spinnaker.credentials.CredentialsSource;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
 import java.util.List;
 
 /**
@@ -24,6 +26,13 @@ import java.util.List;
  *
  * @param <T>
  */
-public interface CredentialsDefinitionSource<T extends CredentialsDefinition> {
+public interface CredentialsDefinitionSource<T extends CredentialsDefinition>
+    extends SpinnakerExtensionPoint {
+  /** Returns the list of credential definitions provided by this source. */
   List<T> getCredentialsDefinitions();
+
+  /** Returns the type of source where these credential definitions are provided. */
+  default CredentialsSource getSource() {
+    return CredentialsSource.CONFIG;
+  }
 }

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionTypeProvider.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionTypeProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
+import java.util.Map;
+
+/**
+ * Provides subtypes of {@link CredentialsDefinition} for registration as account definition types.
+ * All beans of this type contribute zero or more account classes.
+ */
+@Alpha
+public interface CredentialsDefinitionTypeProvider extends SpinnakerExtensionPoint {
+  Map<String, Class<? extends CredentialsDefinition>> getCredentialsTypes();
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsLoader.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsLoader.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.credentials.Credentials;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
+
+public interface CredentialsLoader<T extends Credentials> extends SpinnakerExtensionPoint {
+  CredentialsRepository<T> getCredentialsRepository();
+
+  void load();
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsNavigator.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsNavigator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Navigates the sea of credentials provided by a Spinnaker service.
+ *
+ * @param <T> type of credentials definition tracked
+ */
+@Alpha
+public interface CredentialsNavigator<T extends CredentialsDefinition>
+    extends CredentialsDefinitionSource<T> {
+
+  /** Returns the {@link CredentialsType} type name tracked by this navigator. */
+  String getTypeName();
+
+  /** Returns the class of the credentials definition type supported. */
+  Class<T> getType();
+
+  /**
+   * Lists all views into credentials accessible to the current user of the type tracked by this
+   * navigator.
+   */
+  default List<CredentialsView> listCredentialsViews() {
+    return getCredentialsDefinitions().stream()
+        .map(
+            definition -> {
+              var metadata = new CredentialsView.Metadata();
+              metadata.setType(getTypeName());
+              metadata.setName(definition.getName());
+              metadata.setSource(getSource());
+              return new CredentialsView(metadata, definition);
+            })
+        .collect(Collectors.toList());
+  }
+
+  default Optional<T> findByName(String name) {
+    Class<T> type = getType();
+    return getCredentialsDefinitions().stream()
+        .filter(definition -> type.isInstance(definition) && name.equals(definition.getName()))
+        .map(type::cast)
+        .findFirst();
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/SafeCredentialsParser.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/SafeCredentialsParser.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.credentials.Credentials;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Wrapper for a {@link CredentialsParser} instance that prevents exceptions thrown during parsing
+ * from propagating to the caller. Invalid credentials are instead logged about and counted in
+ * metrics.
+ */
+@Log4j2
+@RequiredArgsConstructor
+public class SafeCredentialsParser<T extends CredentialsDefinition, U extends Credentials>
+    implements CredentialsParser<T, U> {
+  private final Counter parseErrors = Metrics.counter("credentials.parse.error");
+  private final CredentialsParser<T, U> delegate;
+
+  @Nullable
+  @Override
+  public U parse(T definition) {
+    try {
+      return delegate.parse(definition);
+    } catch (VirtualMachineError | ThreadDeath e) {
+      // these exceptions are unrecoverable and unremarkable (nothing to track here that JVM metrics
+      // don't already)
+      throw e;
+    } catch (Throwable t) {
+      parseErrors.increment();
+      log.warn("Unable to parse credentials definition with name '{}'", definition.getName(), t);
+      return null;
+    }
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/CredentialsDefinitionRepositoryException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/CredentialsDefinitionRepositoryException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.Getter;
+
+/**
+ * Base exception type for exceptions thrown by {@link CredentialsDefinitionRepository}. This
+ * exception type may also be used for wrapping transitive exceptions.
+ */
+public class CredentialsDefinitionRepositoryException extends SpinnakerException {
+  @Getter protected final Map<String, Object> additionalAttributes = new HashMap<>();
+
+  protected CredentialsDefinitionRepositoryException(String name, String message) {
+    this(name, message, null);
+  }
+
+  protected CredentialsDefinitionRepositoryException(Collection<String> names, String message) {
+    this(names, message, null);
+  }
+
+  protected CredentialsDefinitionRepositoryException(
+      String name, String message, @Nullable Throwable cause) {
+    super(message, cause);
+    additionalAttributes.put("name", name);
+  }
+
+  protected CredentialsDefinitionRepositoryException(
+      Collection<String> names, String message, @Nullable Throwable cause) {
+    super(message, cause);
+    additionalAttributes.put("names", names);
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/DuplicateCredentialsDefinitionException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/DuplicateCredentialsDefinitionException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import java.time.Instant;
+import javax.annotation.Nullable;
+import lombok.Getter;
+
+/** Exception thrown when a credentials definition already exists for a given name. */
+public class DuplicateCredentialsDefinitionException
+    extends CredentialsDefinitionRepositoryException {
+  @Getter private final Object existing;
+  @Getter private final String eTag;
+  @Getter private final Instant lastModified;
+
+  public DuplicateCredentialsDefinitionException(
+      Object existing, String name, String eTag, Instant lastModified, @Nullable Throwable cause) {
+    super(name, "Duplicate credentials", cause);
+    this.existing = existing;
+    this.eTag = eTag;
+    this.lastModified = lastModified;
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/GenericCredentialsDefinitionRepositoryException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/GenericCredentialsDefinitionRepositoryException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import java.util.Collection;
+
+/**
+ * Exception thrown when an unknown error occurs in {@link CredentialsDefinitionRepository} actions.
+ */
+public class GenericCredentialsDefinitionRepositoryException
+    extends CredentialsDefinitionRepositoryException {
+
+  public GenericCredentialsDefinitionRepositoryException(
+      String name, String message, Throwable cause) {
+    super(name, message, cause);
+  }
+
+  public GenericCredentialsDefinitionRepositoryException(
+      Collection<String> names, String message, Throwable cause) {
+    super(names, message, cause);
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/InvalidCredentialsDefinitionException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/InvalidCredentialsDefinitionException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+
+/**
+ * Exception thrown when an attempt is made to store invalid credentials into a {@link
+ * CredentialsDefinitionRepository}.
+ */
+public class InvalidCredentialsDefinitionException
+    extends CredentialsDefinitionRepositoryException {
+  public InvalidCredentialsDefinitionException(String name, String message, Throwable cause) {
+    super(name, message, cause);
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/NoMatchingCredentialsException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/NoMatchingCredentialsException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import java.time.Instant;
+import javax.annotation.Nullable;
+import lombok.Getter;
+
+/** Exception thrown when a conditional update fails to match any requested etag. */
+public class NoMatchingCredentialsException extends CredentialsDefinitionRepositoryException {
+  @Getter private final Object existing;
+  @Getter private final String eTag;
+  @Getter private final Instant lastModified;
+
+  public NoMatchingCredentialsException(
+      Object existing, String name, String eTag, Instant lastModified) {
+    this(existing, name, eTag, lastModified, null);
+  }
+
+  public NoMatchingCredentialsException(
+      Object existing, String name, String eTag, Instant lastModified, @Nullable Throwable cause) {
+    super(name, "No matching credentials", cause);
+    this.existing = existing;
+    this.eTag = eTag;
+    this.lastModified = lastModified;
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/NoSuchCredentialsDefinitionException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/NoSuchCredentialsDefinitionException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import java.util.Collection;
+import javax.annotation.Nullable;
+
+/**
+ * Exception thrown when no credentials definitions exist for a given name or collection of names
+ * (bulk operations).
+ */
+public class NoSuchCredentialsDefinitionException extends CredentialsDefinitionRepositoryException {
+  public NoSuchCredentialsDefinitionException(String name, String message) {
+    super(name, message);
+  }
+
+  public NoSuchCredentialsDefinitionException(
+      String name, String message, @Nullable Throwable cause) {
+    super(name, message, cause);
+  }
+
+  public NoSuchCredentialsDefinitionException(Collection<String> names, String message) {
+    super(names, message);
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/package-info.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonnullByDefault
+package com.netflix.spinnaker.credentials.definition.error;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;

--- a/kork-credentials-sql/kork-credentials-sql.gradle
+++ b/kork-credentials-sql/kork-credentials-sql.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'java-library'
+apply from: "$rootDir/gradle/kotlin.gradle"
+apply from: "$rootDir/gradle/kotlin-test.gradle"
+
+dependencies {
+  api(platform(project(':spinnaker-dependencies')))
+  api project(':kork-credentials-api')
+  api project(':kork-credentials')
+  api project(':kork-sql')
+  api 'org.apache.logging.log4j:log4j-api-kotlin'
+
+  testImplementation 'org.springframework.boot:spring-boot-starter-test'
+  testImplementation 'org.springframework.security:spring-security-test'
+  testImplementation project(':kork-sql-test')
+  testRuntimeOnly 'org.postgresql:postgresql'
+}

--- a/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/CredentialsData.kt
+++ b/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/CredentialsData.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.sql
+
+import com.fasterxml.jackson.annotation.JsonRawValue
+import com.fasterxml.jackson.annotation.JsonValue
+import org.jooq.JSON
+
+/**
+ * Wraps an encoded credentials definition JSON string so that it won't be doubly encoded in API responses.
+ */
+data class CredentialsData(@JsonValue @JsonRawValue val data: String) {
+  constructor(json: JSON) : this(json.data())
+}

--- a/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/SqlCredentialsAutoConfiguration.kt
+++ b/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/SqlCredentialsAutoConfiguration.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.sql
+
+import com.netflix.spinnaker.credentials.ConditionalOnSelfServiceEnabled
+import com.netflix.spinnaker.credentials.secrets.CredentialsDefinitionMapper
+import org.jooq.DSLContext
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+@EnableConfigurationProperties
+@ConditionalOnSelfServiceEnabled
+@ConditionalOnProperty("sql.enabled")
+class SqlCredentialsAutoConfiguration {
+  @Bean
+  @ConfigurationProperties("credentials.sql")
+  fun sqlCredentialsDefinitionProperties(): SqlCredentialsDefinitionProperties = SqlCredentialsDefinitionProperties()
+
+  @Bean
+  @Primary
+  fun sqlCredentialsDefinitionRepository(
+    jooq: DSLContext,
+    properties: SqlCredentialsDefinitionProperties,
+    mapper: CredentialsDefinitionMapper
+  ): SqlCredentialsDefinitionRepository = SqlCredentialsDefinitionRepository(jooq, properties, mapper)
+}

--- a/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/SqlCredentialsDefinitionProperties.kt
+++ b/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/SqlCredentialsDefinitionProperties.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.sql
+
+data class SqlCredentialsDefinitionProperties(
+  var writeBatchSize: Int = 250,
+  var poolName: String = "accounts",
+)

--- a/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/SqlCredentialsDefinitionRepository.kt
+++ b/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/SqlCredentialsDefinitionRepository.kt
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.sql
+
+import com.netflix.spinnaker.credentials.CredentialsTypes
+import com.netflix.spinnaker.credentials.CredentialsView
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository.Revision
+import com.netflix.spinnaker.credentials.definition.error.GenericCredentialsDefinitionRepositoryException
+import com.netflix.spinnaker.credentials.definition.error.NoSuchCredentialsDefinitionException
+import com.netflix.spinnaker.credentials.secrets.CredentialsDefinitionMapper
+import com.netflix.spinnaker.kork.sql.routing.readWithPool
+import com.netflix.spinnaker.kork.sql.routing.withPool
+import io.micrometer.core.annotation.Timed
+import org.apache.logging.log4j.kotlin.Logging
+import org.jooq.DSLContext
+import org.jooq.TransactionalRunnable
+import org.jooq.exception.DataAccessException
+import org.jooq.exception.NoDataFoundException
+
+// class must be open to allow for CGLIB proxying
+open class SqlCredentialsDefinitionRepository(
+  private val jooq: DSLContext,
+  private val properties: SqlCredentialsDefinitionProperties,
+  private val mapper: CredentialsDefinitionMapper,
+) : CredentialsDefinitionRepository {
+
+  @Timed("credentials.find.definition")
+  override fun findByName(name: String): CredentialsDefinition? =
+    jooq.readWithPool(properties.poolName) {
+      selectFrom(Account)
+        .where(Account.id.eq(name))
+        .fetchOne(mapper::deserializeWithSecrets)
+    }
+
+  @Timed("credentials.find.metadata")
+  override fun findMetadataByName(name: String): CredentialsView.Metadata? =
+    jooq.readWithPool(properties.poolName) {
+      selectFrom(Account)
+        .where(Account.id.eq(name))
+        .fetchOne(AccountRecord::intoMetadata)
+    }
+
+  @Timed("credentials.list.type.name")
+  override fun listByType(typeName: String): List<CredentialsDefinition> =
+    jooq.readWithPool(properties.poolName) {
+      selectFrom(Account)
+        .where(Account.type.eq(typeName))
+        .fetch(mapper::deserializeWithSecrets)
+        .filterNotNull()
+    }
+
+  @Timed("credentials.list.type.class")
+  override fun <T : CredentialsDefinition?> listByType(type: Class<T>): List<T> =
+    jooq.readWithPool(properties.poolName) {
+      selectFrom(Account)
+        .where(Account.type.eq(CredentialsTypes.getRequiredCredentialsTypeName(type)))
+        .fetch(mapper::deserializeWithSecrets)
+        .filterNotNull()
+        .map(type::cast)
+    }
+
+  @Timed("credentials.list.view")
+  override fun listCredentialsViews(typeName: String): List<CredentialsView> = jooq.readWithPool(properties.poolName) {
+    selectFrom(Account)
+      .where(Account.type.eq(typeName))
+      .fetch(mapper::deserializeToValidatingView)
+  }
+
+  @Timed("credentials.create")
+  override fun create(definition: CredentialsDefinition): CredentialsView.Metadata {
+    val record = Account.newRecord().apply {
+      id = definition.name
+      type = definition.type
+      body = mapper.serializeIntoWrapper(definition)
+      lastModifiedBy = currentUser
+    }
+    return withPool(properties.poolName) {
+      try {
+        jooq.transactionResult(createAccount(record))
+      } catch (e: DataAccessException) {
+        e.rethrowAsCredentialsDefinitionRepositoryException(jooq, record.id)
+      }
+    }
+  }
+
+  @Timed("credentials.save.single")
+  override fun save(definition: CredentialsDefinition): CredentialsView.Metadata {
+    val record = Account.newRecord().apply {
+      id = definition.name
+      type = definition.type
+      body = mapper.serializeIntoWrapper(definition)
+      lastModifiedBy = currentUser
+    }
+    return withPool(properties.poolName) {
+      try {
+        jooq.transactionResult(saveAccount(record))
+      } catch (e: DataAccessException) {
+        throw GenericCredentialsDefinitionRepositoryException(
+          definition.name, "Error while trying to save credentials: ${e.message}", e
+        )
+      }
+    }
+  }
+
+  @Timed("credentials.save.multi")
+  override fun saveAll(definitions: Collection<CredentialsDefinition>): List<CredentialsView> {
+    val user = currentUser
+    val records = definitions.map {
+      Account.newRecord().apply {
+        id = it.name
+        type = it.type
+        body = mapper.serializeIntoWrapper(it)
+        lastModifiedBy = user
+      }
+    }
+    val metadata = try {
+      jooq.transactionResult { cfg ->
+        records.chunked(properties.writeBatchSize, ::saveAccounts)
+          .flatMap { it.run(cfg).entries }
+          .associate { it.toPair() }
+      }
+    } catch (e: DataAccessException) {
+      throw GenericCredentialsDefinitionRepositoryException(
+        definitions.map(CredentialsDefinition::getName),
+        "Error while trying to save batch of credentials: ${e.message}",
+        e
+      )
+    }
+    return definitions.map { CredentialsView(metadata.getValue(it.name), it) }
+  }
+
+  @Timed("credentials.update.single")
+  override fun update(definition: CredentialsDefinition): CredentialsView.Metadata {
+    val name = definition.name
+    val record = Account.newRecord().apply {
+      id = name
+      type = definition.type
+      body = mapper.serializeIntoWrapper(definition)
+      lastModifiedBy = currentUser
+    }
+    return try {
+      jooq.transactionResult(updateAccount(record))
+    } catch (e: NoDataFoundException) {
+      throw NoSuchCredentialsDefinitionException(name, "Cannot update credentials that do not exist", e)
+    } catch (e: DataAccessException) {
+      throw GenericCredentialsDefinitionRepositoryException(
+        name, "Error while trying to update credentials: ${e.message}", e
+      )
+    }
+  }
+
+  @Timed("credentials.update.conditional")
+  override fun updateIfMatch(definition: CredentialsDefinition, ifMatches: List<String>): CredentialsView.Metadata {
+    val name = definition.name
+    val record = Account.newRecord().apply {
+      id = name
+      type = definition.type
+      body = mapper.serializeIntoWrapper(definition)
+      lastModifiedBy = currentUser
+    }
+    return try {
+      jooq.transactionResult(updateAccountIfMatches(record, ifMatches))
+    } catch (e: NoDataFoundException) {
+      throw NoSuchCredentialsDefinitionException(
+        name, "Cannot update credentials that do not exist", e
+      )
+    } catch (e: DataAccessException) {
+      throw GenericCredentialsDefinitionRepositoryException(
+        name,
+        "Error while conditionally updating credentials: ${e.message}",
+        e
+      )
+    }
+  }
+
+  @Timed("credentials.list.unknown")
+  override fun getUnknownNames(names: Collection<String>): Set<String> = jooq.readWithPool(properties.poolName) {
+    val foundIds = select(Account.id).from(Account).where(Account.id.`in`(names)).fetchSet(Account.id)
+    names.toHashSet().apply { removeAll(foundIds) }
+  }
+
+  @Timed("credentials.delete.single")
+  override fun delete(name: String) {
+    try {
+      jooq.transaction(deleteAccount(name))
+    } catch (e: NoDataFoundException) {
+      throw NoSuchCredentialsDefinitionException(name, "Cannot delete credentials that do not exist", e)
+    } catch (e: DataAccessException) {
+      throw GenericCredentialsDefinitionRepositoryException(
+        name, "Error while trying to delete credentials: ${e.message}", e
+      )
+    }
+  }
+
+  @Timed("credentials.delete.multi")
+  override fun deleteAll(names: Collection<String>) {
+    val transaction = TransactionalRunnable.of(names.chunked(properties.writeBatchSize, ::deleteAccounts))
+    withPool(properties.poolName) {
+      try {
+        jooq.transaction(transaction)
+      } catch (e: DataAccessException) {
+        throw GenericCredentialsDefinitionRepositoryException(
+          names, "Error while trying to delete batch of credentials: ${e.message}", e
+        )
+      }
+    }
+  }
+
+  @Timed("credentials.list.history")
+  override fun revisionHistory(name: String): List<Revision> =
+    jooq.readWithPool(properties.poolName) {
+      selectFrom(AccountHistory)
+        .where(AccountHistory.id.eq(name))
+        .orderBy(AccountHistory.revision.desc())
+        .fetch(mapper::deserializeToRevision)
+    }
+
+  companion object : Logging
+}

--- a/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/extensions.kt
+++ b/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/extensions.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.sql
+
+import com.netflix.spinnaker.credentials.CredentialsTypes
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition
+import com.netflix.spinnaker.security.SpinnakerUsers
+
+internal val CredentialsDefinition.type: String
+  get() = CredentialsTypes.getRequiredCredentialsTypeName(javaClass)
+
+internal val currentUser: String
+  get() = SpinnakerUsers.getCurrentUserId()

--- a/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/mappers.kt
+++ b/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/mappers.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials.sql
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.netflix.spinnaker.credentials.CredentialsSource
+import com.netflix.spinnaker.credentials.CredentialsView
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository.Revision
+import com.netflix.spinnaker.credentials.definition.error.InvalidCredentialsDefinitionException
+import com.netflix.spinnaker.credentials.secrets.CredentialsDefinitionMapper
+import com.netflix.spinnaker.kork.exceptions.InvalidCredentialsTypeException
+import com.netflix.spinnaker.kork.secrets.SecretException
+import io.micrometer.core.instrument.Metrics
+import org.apache.logging.log4j.kotlin.loggerOf
+import org.jooq.JSON
+import org.jooq.JSON.json
+import java.lang.IllegalArgumentException
+
+private val logger = loggerOf(CredentialsDefinitionMapper::class.java)
+private val errorsDeserializingAccounts = Metrics.counter("credentials.sql.account.deserialization.errors")
+private val errorsDeserializingRevisions = Metrics.counter("credentials.sql.revision.deserialization.errors")
+private val errorsDecryptingSecrets = Metrics.counter("credentials.sql.secret.decryption.errors")
+private val errorsSerializingAccounts = Metrics.counter("credentials.sql.account.serialization.errors")
+
+/**
+ * Record mapper for translating account records into credentials definitions. This fetches and decrypts
+ * referenced secrets.
+ */
+internal fun CredentialsDefinitionMapper.deserializeWithSecrets(record: AccountRecord): CredentialsDefinition? = try {
+  deserializeWithSecrets(record.body.data())
+} catch (e: SecretException) {
+  logger.info(e) { "Unable to decrypt secret from credentials with type ${record.type}, name '${record.id}'" } // , and version ${record.version}
+  errorsDecryptingSecrets.increment()
+  null
+} catch (e: JsonProcessingException) {
+  logger.warn(e) { "Unable to parse credentials with type ${record.type}, name '${record.id}'" } // , and version ${record.version}
+  errorsDeserializingAccounts.increment()
+  null
+} catch (e: InvalidCredentialsTypeException) {
+  logger.warn(e) { "Unable to parse credentials with type ${record.type}, name '${record.id}" }
+  errorsDeserializingAccounts.increment()
+  null
+} catch (e: IllegalArgumentException) {
+  logger.warn(e) { "Unable to parse credentials with type ${record.type}, name '${record.id}" }
+  errorsDeserializingAccounts.increment()
+  null
+}
+
+/**
+ * Record mapper for translating account records into validated views of credentials. This validates but does
+ * not substitute referenced secrets.
+ */
+internal fun CredentialsDefinitionMapper.deserializeToValidatingView(record: AccountRecord): CredentialsView =
+  deserializeWithErrors(record.body.data()).apply {
+    metadata.apply {
+      if (name == null) {
+        name = record.id
+      }
+      if (type == null) {
+        type = record.type
+      }
+      eTag = record.eTag
+      lastModified = record.lastModifiedAt
+      source = CredentialsSource.STORAGE
+    }
+  }
+
+/**
+ * Record mapper for translating account history records into revisions. This does not attempt to validate or
+ * decrypt any referenced secrets.
+ */
+internal fun CredentialsDefinitionMapper.deserializeToRevision(record: AccountHistoryRecord): Revision = record.body?.let {
+  try {
+    deserialize(it.data())
+  } catch (e: JsonProcessingException) {
+    logger.warn(e) { "Unable to parse credentials revision with type ${record.type}, name '${record.id}', and revision ${record.revision}" }
+    errorsDeserializingRevisions.increment()
+    null
+  }
+}.let { Revision(record.revision, record.lastModifiedAt, it, record.modifiedBy) }
+
+/**
+ * Serializes the provided credentials definition into a wrapped [JSON] instance.
+ *
+ * @throws InvalidCredentialsDefinitionException if there is an error serializing the credentials
+ * @throws InvalidCredentialsTypeException if the provided credentials are not annotated with `@CredentialsType`
+ */
+internal fun CredentialsDefinitionMapper.serializeIntoWrapper(definition: CredentialsDefinition): JSON = try {
+  json(serialize(definition))
+} catch (e: JsonProcessingException) {
+  errorsSerializingAccounts.increment()
+  throw InvalidCredentialsDefinitionException(
+    definition.name, "Error while serializing credentials into JSON: ${e.message}", e
+  )
+}

--- a/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/models.kt
+++ b/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/models.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.sql
+
+import com.netflix.spinnaker.credentials.CredentialsSource
+import com.netflix.spinnaker.credentials.CredentialsView
+import org.jooq.*
+import org.jooq.impl.CustomRecord
+import org.jooq.impl.CustomTable
+import org.jooq.impl.DSL.*
+import org.jooq.impl.Internal
+import org.jooq.impl.SQLDataType
+import java.time.Instant
+
+val Account = AccountTable()
+val AccountHistory = AccountHistoryTable()
+
+class AccountTable : CustomTable<AccountRecord>(name("accounts")) {
+  val id: TableField<AccountRecord, String> =
+    createField(name("id"), SQLDataType.VARCHAR.nullable(false))
+  val type: TableField<AccountRecord, String> =
+    createField(name("type"), SQLDataType.VARCHAR.nullable(false))
+  val body: TableField<AccountRecord, JSON> =
+    createField(name("body"), SQLDataType.JSON.nullable(false))
+  val createdAt: TableField<AccountRecord, Instant> =
+    createField(name("ctime"), SQLDataType.INSTANT.nullable(false))
+  val lastModifiedAt: TableField<AccountRecord, Instant> =
+    createField(name("mtime"), SQLDataType.INSTANT.nullable(false))
+  val lastModifiedBy: TableField<AccountRecord, String> =
+    createField(name("last_modified_by"), SQLDataType.VARCHAR.nullable(false))
+  val eTag: TableField<AccountRecord, String> =
+    createField(name("etag"), SQLDataType.VARCHAR(32))
+
+  private val primaryKey = Internal.createUniqueKey(this, id)
+  private val identity = Internal.createIdentity(this, id)
+
+  override fun getRecordType(): Class<out AccountRecord> = AccountRecord::class.java
+  override fun getPrimaryKey(): UniqueKey<AccountRecord> = primaryKey
+  override fun getIdentity(): Identity<AccountRecord, *> = identity
+  override fun getKeys(): List<UniqueKey<AccountRecord>> = listOf(primaryKey)
+}
+
+class AccountRecord : CustomRecord<AccountRecord>(Account) {
+  var id: String
+    get() = this[Account.id]
+    set(value) {
+      this[Account.id] = value
+    }
+
+  var type: String
+    get() = this[Account.type]
+    set(value) {
+      this[Account.type] = value
+    }
+
+  var body: JSON
+    get() = this[Account.body]
+    set(value) {
+      this[Account.body] = value
+    }
+
+  var createdAt: Instant
+    get() = this[Account.createdAt]
+    set(value) {
+      this[Account.createdAt] = value
+    }
+
+  var lastModifiedAt: Instant
+    get() = this[Account.lastModifiedAt]
+    set(value) {
+      this[Account.lastModifiedAt] = value
+    }
+
+  var lastModifiedBy: String
+    get() = this[Account.lastModifiedBy]
+    set(value) {
+      this[Account.lastModifiedBy] = value
+    }
+
+  var eTag: String
+    get() = this[Account.eTag]
+    set(value) {
+      this[Account.eTag] = value
+    }
+
+  /**
+   * Maps the metadata of this account record into a [CredentialsView.Metadata] instance.
+   */
+  fun intoMetadata(): CredentialsView.Metadata = CredentialsView.Metadata().also {
+    it.name = id
+    it.type = type
+    it.eTag = eTag
+    it.lastModified = lastModifiedAt
+    it.source = CredentialsSource.STORAGE
+  }
+}
+
+class AccountHistoryTable : CustomTable<AccountHistoryRecord>(name("accounts_history")) {
+  val id: TableField<AccountHistoryRecord, String> =
+    createField(name("id"), SQLDataType.VARCHAR.nullable(false))
+  val revision: TableField<AccountHistoryRecord, Long> =
+    createField(name("revision"), SQLDataType.BIGINT.nullable(false))
+  val type: TableField<AccountHistoryRecord, String?> =
+    createField(name("type"), SQLDataType.VARCHAR.nullable(true))
+  val body: TableField<AccountHistoryRecord, JSON?> =
+    createField(name("body"), SQLDataType.JSON.nullable(true))
+  val lastModifiedAt: TableField<AccountHistoryRecord, Instant> =
+    createField(name("mtime"), SQLDataType.INSTANT.nullable(false))
+  val modifiedBy: TableField<AccountHistoryRecord, String?> =
+    createField(name("modified_by"), SQLDataType.VARCHAR.nullable(true))
+  val deleted: TableField<AccountHistoryRecord, Boolean> =
+    createField(name("is_deleted"), SQLDataType.BOOLEAN.nullable(false))
+  private val primaryKey = Internal.createUniqueKey(this, revision)
+
+  override fun getRecordType(): Class<out AccountHistoryRecord> = AccountHistoryRecord::class.java
+  override fun getPrimaryKey(): UniqueKey<AccountHistoryRecord> = primaryKey
+  override fun getKeys(): List<UniqueKey<AccountHistoryRecord>> = listOf(primaryKey)
+}
+
+class AccountHistoryRecord : CustomRecord<AccountHistoryRecord>(AccountHistory) {
+  var id: String
+    get() = this[AccountHistory.id]
+    set(value) {
+      this[AccountHistory.id] = value
+    }
+
+  val revision: Long
+    get() = this[AccountHistory.revision]
+
+  var type: String?
+    get() = this[AccountHistory.type]
+    set(value) {
+      this[AccountHistory.type] = value
+    }
+
+  var body: JSON?
+    get() = this[AccountHistory.body]
+    set(value) {
+      this[AccountHistory.body] = value
+    }
+
+  var lastModifiedAt: Instant
+    get() = this[AccountHistory.lastModifiedAt]
+    set(value) {
+      this[AccountHistory.lastModifiedAt] = value
+    }
+
+  var modifiedBy: String?
+    get() = this[AccountHistory.modifiedBy]
+    set(value) {
+      this[AccountHistory.modifiedBy] = value
+    }
+
+  var deleted: Boolean
+    get() = this[AccountHistory.deleted]
+    set(value) {
+      this[AccountHistory.deleted] = value
+    }
+}

--- a/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/queries.kt
+++ b/kork-credentials-sql/src/main/kotlin/com/netflix/spinnaker/credentials/sql/queries.kt
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.sql
+
+import com.netflix.spinnaker.credentials.definition.error.CredentialsDefinitionRepositoryException
+import com.netflix.spinnaker.credentials.definition.error.DuplicateCredentialsDefinitionException
+import com.netflix.spinnaker.credentials.definition.error.GenericCredentialsDefinitionRepositoryException
+import com.netflix.spinnaker.credentials.definition.error.NoMatchingCredentialsException
+import com.netflix.spinnaker.credentials.definition.error.NoSuchCredentialsDefinitionException
+import com.netflix.spinnaker.credentials.sql.SqlCredentialsDefinitionRepository.Companion.logger
+import com.netflix.spinnaker.kork.exceptions.InvalidCredentialsTypeException
+import com.netflix.spinnaker.kork.sql.routing.excluded
+import com.netflix.spinnaker.kork.sql.routing.transactional
+import com.netflix.spinnaker.kork.sql.routing.transactionalResult
+import org.jooq.*
+import org.jooq.exception.DataAccessException
+import org.jooq.exception.NoDataFoundException
+import org.jooq.impl.DSL.*
+import java.sql.SQLIntegrityConstraintViolationException
+import com.netflix.spinnaker.credentials.CredentialsView.Metadata as CredentialsMetadata
+
+/**
+ * Inserts an account record if it does not exist and returns its entity tag. This synchronizes the
+ * account history, too.
+ *
+ * @throws DataAccessException if an error occurs inserting the account or its history
+ */
+internal fun createAccount(account: AccountRecord): TransactionalCallable<CredentialsMetadata> = transactionalResult {
+  val metadata = with(insertQuery(Account)) {
+    setRecord(account)
+    setReturning()
+    execute()
+    returnedRecord?.intoMetadata()
+      ?: throw NoDataFoundException("Unable to fetch metadata of newly inserted credentials for name '${account.id}'")
+  }
+  execute(syncAccountHistory(listOf(account.id)))
+  metadata
+}
+
+/**
+ * Converts a [DataAccessException] into an appropriate [CredentialsDefinitionRepositoryException] and throws it.
+ */
+internal fun DataAccessException.rethrowAsCredentialsDefinitionRepositoryException(
+  ctx: DSLContext, id: String
+): Nothing = throw getCause(SQLIntegrityConstraintViolationException::class.java)?.let {
+  try {
+    ctx.selectFrom(Account)
+      .where(Account.id.eq(id))
+      .fetchSingle()
+      .run {
+        val existing = CredentialsData(body)
+        DuplicateCredentialsDefinitionException(existing, id, eTag, lastModifiedAt, it)
+      }
+  } catch (e: DataAccessException) {
+    GenericCredentialsDefinitionRepositoryException(id, "Error while looking up existing credentials: $message", e)
+  }
+} ?: GenericCredentialsDefinitionRepositoryException(id, "Error while saving credentials: $message", this)
+
+/**
+ * Saves a single account record by creating or updating an account row and syncing its history.
+ *
+ * @throws DataAccessException if an error occurs while saving the account or its history
+ */
+internal fun saveAccount(account: AccountRecord): TransactionalCallable<CredentialsMetadata> = transactionalResult {
+  with(insertQuery(Account)) {
+    setRecord(account)
+    onDuplicateKeyUpdate(true)
+    addValuesForUpdate(accountValuesForUpsert)
+    setReturning()
+    execute()
+    returnedRecord?.intoMetadata()
+      ?: throw NoDataFoundException("Unable to fetch updated metadata for credentials with name '${account.id}'")
+  }.also {
+    execute(syncAccountHistory(listOf(account.id)))
+  }
+}
+
+/**
+ * Saves multiple accounts by creating or updating account rows using the provided records. New versions
+ * will be set on the records along with synchronizing account history.
+ *
+ * @param accounts batch of account records to save
+ * @return map of metadata for saved accounts keyed by name
+ * @throws DataAccessException if an error occurs saving any account or history
+ */
+internal fun saveAccounts(accounts: Iterable<AccountRecord>): TransactionalCallable<Map<String, CredentialsMetadata>> =
+  transactionalResult {
+    with(insertQuery(Account)) {
+      accounts.forEach(::addRecord)
+      onDuplicateKeyUpdate(true)
+      addValuesForUpdate(accountValuesForUpsert)
+      setReturning()
+      execute()
+      returnedRecords.intoMap(Account.id, AccountRecord::intoMetadata)
+    }.also {
+      execute(syncAccountHistory(it.keys))
+    }
+  }
+
+private val Scope.accountValuesForUpsert: Map<*, *>
+  get() = listOf(
+    Account.type, Account.body, Account.lastModifiedAt, Account.lastModifiedBy
+  ).associateWith { excluded(it) }
+
+/**
+ * Updates an account using the provided record if it exists and returns its entity tag.
+ *
+ * @throws NoDataFoundException if no account exists with the given name
+ * @throws InvalidCredentialsTypeException if the given account type does not match its existing type
+ * @throws DataAccessException if an error occurs updating the account or synchronizing its history
+ */
+internal fun updateAccount(account: AccountRecord): TransactionalCallable<CredentialsMetadata> = transactionalResult {
+  val condition = Account.id.eq(account.id)
+  val existingType =
+    select(Account.type).from(Account).where(condition).forUpdate().of(Account).fetchSingleInto(String::class.java)
+  val proposedType = account.type
+  validateAccountType(account.id, proposedType, existingType)
+  updateAccount(account)
+}
+
+/**
+ * Updates an account using the provided record only if it exists and has an entity tag matching one of the
+ * provided matches.
+ *
+ * @throws NoDataFoundException if no account exists with the given name
+ * @throws InvalidCredentialsTypeException if the given account type does not match its existing type
+ * @throws DataAccessException if an error occurs updating the account or synchronizing its history
+ * @throws NoMatchingCredentialsException if an account exists with the given name but does not match any of the given
+ * entity tags
+ */
+internal fun updateAccountIfMatches(
+  account: AccountRecord, ifMatches: List<String>
+): TransactionalCallable<CredentialsMetadata> = transactionalResult {
+  logger.debug { "Attempting to update ${account.id} with '${account.body.data()}' using if-match $ifMatches" }
+  val condition = Account.id.eq(account.id)
+  val existing = selectFrom(Account).where(condition).forUpdate().of(Account).fetchSingle()
+  val proposedType = account.type
+  val existingType = existing.type
+  validateAccountType(account.id, proposedType, existingType)
+  if (existing.eTag !in ifMatches) {
+    logger.warn { "Unable to conditionally update credentials for ${account.id} as its etag ${existing.eTag} is not in $ifMatches" }
+    throw NoMatchingCredentialsException(
+      CredentialsData(existing.body), existing.id, existing.eTag, existing.lastModifiedAt
+    )
+  }
+  updateAccount(account)
+}
+
+private fun validateAccountType(name: String, proposedType: String, existingType: String) {
+  if (proposedType != existingType) {
+    logger.warn { "Unable to update credentials for $name as the existing type $existingType does not match the proposed type $proposedType" }
+    throw InvalidCredentialsTypeException("Existing credentials type $existingType does not match proposed type $proposedType").apply {
+      additionalAttributes["name"] = name
+    }
+  }
+}
+
+private fun DSLContext.updateAccount(account: AccountRecord): CredentialsMetadata =
+  with(updateQuery(Account)) {
+    setRecord(account)
+    addValue(Account.lastModifiedAt, currentInstant())
+    addConditions(Account.id.eq(account.id))
+    setReturning()
+    execute()
+    returnedRecord?.intoMetadata()
+      ?: throw NoDataFoundException("Unable to fetch updated metadata for credentials with name '${account.id}'")
+  }.also {
+    execute(syncAccountHistory(listOf(account.id)))
+  }
+
+private fun syncAccountHistory(ids: Collection<String>): Query =
+  insertInto(AccountHistory)
+    .columns(
+      AccountHistory.id,
+      AccountHistory.type,
+      AccountHistory.body,
+      AccountHistory.lastModifiedAt,
+      AccountHistory.modifiedBy
+    )
+    .select(
+      select(
+        Account.id,
+        Account.type,
+        Account.body,
+        Account.lastModifiedAt,
+        Account.lastModifiedBy
+      )
+        .from(Account)
+        .where(Account.id.`in`(ids))
+    )
+
+/**
+ * Deletes an account by name and synchronizes its account history.
+ *
+ * @throws NoDataFoundException if no account exists with the given name
+ * @throws DataAccessException if an error occurs while deleting the account or syncing history
+ */
+internal fun deleteAccount(id: String): TransactionalRunnable = transactional {
+  val condition = Account.id.eq(id)
+  val exists = select(value(1))
+    .from(Account)
+    .where(condition)
+    .forUpdate().of(Account)
+    .fetchSingleInto(Int::class.java)
+  // should already have thrown an exception
+  check(exists > 0)
+  with(insertQuery(AccountHistory)) {
+    addValue(AccountHistory.id, id)
+    addValue(AccountHistory.deleted, true)
+    addValue(AccountHistory.modifiedBy, currentUser)
+    execute()
+  }
+  with(deleteQuery(Account)) {
+    addConditions(condition)
+    execute()
+  }
+}
+
+/**
+ * Deletes a batch of accounts by name and synchronizes their history.
+ *
+ * @throws NoSuchCredentialsDefinitionException if one or more of the requested accounts do not exist
+ * @throws DataAccessException if an error occurs while deleting the accounts or syncing histories
+ */
+internal fun deleteAccounts(ids: Collection<String>): TransactionalRunnable = transactional {
+  val condition = Account.id.`in`(ids)
+  val deleted = with(deleteQuery(Account)) {
+    addConditions(condition)
+    execute()
+  }
+  if (deleted != ids.size) {
+    val foundIds = select(Account.id)
+      .from(Account)
+      .where(condition)
+      .fetchSet(Account.id)
+    val missingIds = ids.toHashSet().apply { removeAll(foundIds) }
+    if (missingIds.isNotEmpty()) {
+      throw NoSuchCredentialsDefinitionException(missingIds, "Unable to delete non-existent credentials")
+    }
+  }
+  val user = currentUser
+  with(insertQuery(AccountHistory)) {
+    ids.forEach { id ->
+      newRecord()
+      addValue(AccountHistory.id, id)
+      addValue(AccountHistory.deleted, true)
+      addValue(AccountHistory.modifiedBy, user)
+    }
+    execute()
+  }
+}

--- a/kork-credentials-sql/src/main/resources/META-INF/spring.factories
+++ b/kork-credentials-sql/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.netflix.spinnaker.credentials.sql.SqlCredentialsAutoConfiguration

--- a/kork-credentials-sql/src/main/resources/db/changelog/20210927-accounts.yml
+++ b/kork-credentials-sql/src/main/resources/db/changelog/20210927-accounts.yml
@@ -1,0 +1,162 @@
+databaseChangeLog:
+- changeSet:
+    id: create-accounts-table
+    author: msicker
+    # in case you're in clouddriver and already have this table, let's skip this step
+    preConditions:
+      - onFail: MARK_RAN
+      - not:
+          tableExists:
+            tableName: accounts
+    changes:
+    - createTable:
+        tableName: accounts
+        columns:
+        - column:
+            name: id
+            type: varchar(255)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: type
+            type: varchar(50)
+            constraints:
+              nullable: false
+        - column:
+            name: body
+            type: json
+            constraints:
+              nullable: false
+        - column:
+            name: created_at
+            type: bigint
+            constraints:
+              nullable: false
+        - column:
+            name: last_modified_at
+            type: bigint
+            constraints:
+              nullable: false
+        - column:
+            name: last_modified_by
+            type: varchar(255)
+            constraints:
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci"
+    - modifySql:
+        dbms: postgresql
+        replace:
+          replace: json
+          with: jsonb
+    rollback:
+      - dropTable:
+          tableName: accounts
+
+- changeSet:
+    id: create-accounts-table-index
+    author: jcavanagh
+    preConditions:
+      - onFail: MARK_RAN
+      - not:
+          indexExists:
+            indexName: accounts_type_index
+            tableName: accounts
+    changes:
+    - createIndex:
+        indexName: accounts_type_index
+        tableName: accounts
+        columns:
+        - column:
+            name: id
+        - column:
+            name: type
+    - createIndex:
+        indexName: accounts_timestamp_index
+        tableName: accounts
+        columns:
+        - column:
+            name: id
+        - column:
+            name: type
+        - column:
+            name: created_at
+        - column:
+            name: last_modified_at
+    rollback:
+      - dropIndex:
+          indexName: accounts_type_index
+          tableName: accounts
+      - dropIndex:
+          indexName: accounts_timestamp_index
+          tableName: accounts
+
+- changeSet:
+    id: create-accounts-history-table
+    author: msicker
+    # in case you're in clouddriver and already have this table, let's skip this step
+    preConditions:
+      - onFail: MARK_RAN
+      - not:
+          tableExists:
+            tableName: accounts_history
+    validCheckSum:
+      # original checksum from when this was part of clouddriver
+      - 8:128b46fd7cb5101d166d502875178609
+      # and other checksums from when the file was moved
+      - 8:70a48f38c83bfa9eb5e146011be548b8
+      # and furthermore, fixed the sorting of the version column
+      - 8:91ef81247dea4dfb592dc7cad44f856f
+    changes:
+    - createTable:
+        tableName: accounts_history
+        columns:
+        - column:
+            name: id
+            type: varchar(255)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: type
+            type: varchar(50)
+            constraints:
+              nullable: true
+        - column:
+            name: body
+            type: json
+            constraints:
+              nullable: true
+        - column:
+            name: last_modified_at
+            type: bigint
+            constraints:
+              nullable: false
+        - column:
+            name: version
+            type: int
+            descending: true
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: is_deleted
+            type: boolean
+            defaultValueBoolean: false
+            constraints:
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci"
+    - modifySql:
+        dbms: postgresql
+        replace:
+          replace: json
+          with: jsonb
+    rollback:
+    - dropTable:
+        tableName: accounts_history

--- a/kork-credentials-sql/src/main/resources/db/changelog/20230217-accounts-body-typefix.yml
+++ b/kork-credentials-sql/src/main/resources/db/changelog/20230217-accounts-body-typefix.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: fix-accounts-body-column
+      author: msicker
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: postgresql
+      changes:
+        - modifyDataType:
+            tableName: accounts
+            columnName: body
+            newDataType: jsonb
+        - modifyDataType:
+            tableName: accounts_history
+            columnName: body
+            newDataType: jsonb

--- a/kork-credentials-sql/src/main/resources/db/changelog/20230418-accounts-timestamps.yml
+++ b/kork-credentials-sql/src/main/resources/db/changelog/20230418-accounts-timestamps.yml
@@ -1,0 +1,198 @@
+databaseChangeLog:
+  - changeSet:
+      id: migrate-timestamps-types-postgres
+      author: msicker
+      preConditions:
+        - dbms:
+            type: postgresql
+        - onFail: MARK_RAN
+      changes:
+        - addColumn:
+            tableName: accounts
+            columns:
+              - column:
+                  name: ctime
+                  type: timestamp(3)
+                  valueComputed: 'to_timestamp(created_at / 1000.0)'
+                  defaultValueComputed: now()
+                  constraints:
+                    nullable: false
+              - column:
+                  name: mtime
+                  type: timestamp(3)
+                  valueComputed: 'to_timestamp(last_modified_at / 1000.0)'
+                  defaultValueComputed: now()
+                  constraints:
+                    nullable: false
+        - addColumn:
+            tableName: accounts_history
+            columns:
+              - column:
+                  name: mtime
+                  type: timestamp(3)
+                  valueComputed: 'to_timestamp(last_modified_at / 1000.0)'
+                  defaultValueComputed: now()
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: accounts
+            columns:
+              - column:
+                  name: ctime
+              - column:
+                  name: mtime
+        - dropColumn:
+            tableName: accounts_history
+            columnName: mtime
+
+  - changeSet:
+      id: migrate-timestamp-types-mysql
+      author: msicker
+      preConditions:
+        - dbms:
+            type: mysql,mariadb
+        - onFail: MARK_RAN
+      validCheckSum:
+        # original checksum
+        - 8:83978a8be20e32eb1e4d52a452906eee
+        # later changed to update valueComputed and defaultValueComputed
+        - 8:61e246aa8e76f43acddee9cad734260c
+      changes:
+        - addColumn:
+            tableName: accounts
+            columns:
+              - column:
+                  name: ctime
+                  type: timestamp(3)
+                  valueComputed: 'from_unixtime(greatest(created_at, 86400000) / 1000.0)'
+                  defaultValueComputed: now(3)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: mtime
+                  type: timestamp(3)
+                  valueComputed: 'from_unixtime(greatest(last_modified_at, 86400000) / 1000.0)'
+                  defaultValueComputed: now(3)
+                  constraints:
+                    nullable: false
+        - addColumn:
+            tableName: accounts_history
+            columns:
+              - column:
+                  name: mtime
+                  type: timestamp(3)
+                  valueComputed: 'from_unixtime(greatest(last_modified_at, 86400000) / 1000.0)'
+                  defaultValueComputed: now(3)
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: accounts
+            columns:
+              - column:
+                  name: ctime
+              - column:
+                  name: mtime
+        - dropColumn:
+            tableName: accounts_history
+            columnName: mtime
+
+  - changeSet:
+      id: drop-bigint-timestamp-columns
+      author: msicker
+      changes:
+        - dropIndex:
+            tableName: accounts
+            indexName: accounts_timestamp_index
+        - dropColumn:
+            tableName: accounts
+            columns:
+              - column:
+                  name: created_at
+              - column:
+                  name: last_modified_at
+        - dropColumn:
+            tableName: accounts_history
+            columnName: last_modified_at
+
+  - changeSet:
+      id: add-accounts-etag-column
+      author: msicker
+      changes:
+        - sql:
+            sql: >
+              alter table accounts
+              add etag varchar(32) generated always as (md5(body)) stored
+        - modifySql:
+            dbms: postgresql
+            replace:
+              replace: body
+              with: body::text
+      rollback:
+        - dropColumn:
+            tableName: accounts
+            columnName: etag
+
+  - changeSet:
+      id: drop-accounts-history-version-column
+      author: msicker
+      preConditions:
+        - dbms:
+            type: postgresql
+        - onFail: MARK_RAN
+      changes:
+        - dropUniqueConstraint:
+            tableName: accounts_history
+            constraintName: accounts_history_pkey
+        - dropColumn:
+            tableName: accounts_history
+            columnName: version
+
+  - changeSet:
+      id: drop-accounts-history-version-column-mysql
+      author: msicker
+      preConditions:
+        - dbms:
+            type: mysql,mariadb
+        - onFail: MARK_RAN
+      changes:
+        - dropPrimaryKey:
+            tableName: accounts_history
+        - dropColumn:
+            tableName: accounts_history
+            columnName: version
+
+  - changeSet:
+      id: add-accounts-history-revision-column
+      author: msicker
+      changes:
+        - addColumn:
+            tableName: accounts_history
+            columns:
+              - column:
+                  name: revision
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: accounts_history
+            columnName: revision
+
+  - changeSet:
+      id: add-accounts-history-id-index
+      author: msicker
+      changes:
+        - createIndex:
+            tableName: accounts_history
+            indexName: accounts_history_id_idx
+            columns:
+              - column:
+                  name: id
+      rollback:
+        - dropIndex:
+            tableName: accounts_history
+            indexName: accounts_history_id_idx

--- a/kork-credentials-sql/src/main/resources/db/changelog/20230928-accounts-history-audit.yml
+++ b/kork-credentials-sql/src/main/resources/db/changelog/20230928-accounts-history-audit.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-last-modified-by-to-accounts-history
+      author: msicker
+      changes:
+        - addColumn:
+            tableName: accounts_history
+            columns:
+              - column:
+                  name: modified_by
+                  type: varchar(255)
+      rollback:
+        - dropColumn:
+            columnName: modified_by
+            tableName: accounts_history

--- a/kork-credentials-sql/src/main/resources/db/changelog/accounts.yml
+++ b/kork-credentials-sql/src/main/resources/db/changelog/accounts.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - include:
+      file: 20210927-accounts.yml
+      relativeToChangelogFile: true
+  - include:
+      file: 20230217-accounts-body-typefix.yml
+      relativeToChangelogFile: true
+  - include:
+      file: 20230418-accounts-timestamps.yml
+      relativeToChangelogFile: true
+  - include:
+      file: 20230928-accounts-history-audit.yml
+      relativeToChangelogFile: true

--- a/kork-credentials-sql/src/test/kotlin/com/netflix/spinnaker/credentials/sql/CredentialsDataTest.kt
+++ b/kork-credentials-sql/src/test/kotlin/com/netflix/spinnaker/credentials/sql/CredentialsDataTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.sql
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.credentials.test.TestCredentialsDefinition
+import com.netflix.spinnaker.security.Authorization
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+
+class CredentialsDataTest {
+  @Test
+  fun avoidDoubleWrapping() {
+    val mapper = Jackson2ObjectMapperBuilder.json().build<ObjectMapper>()
+    val credentials =
+      TestCredentialsDefinition("jackson", mapOf("bugs" to "features"), mapOf(Authorization.READ to setOf("johnson")))
+    val json = mapper.writeValueAsString(credentials)
+    val wrapped = CredentialsData(json)
+    val string = mapper.writeValueAsString(wrapped)
+    val unwrapped = mapper.readValue(string, TestCredentialsDefinition::class.java)
+    assertEquals("jackson", unwrapped.name)
+  }
+}

--- a/kork-credentials-sql/src/test/kotlin/com/netflix/spinnaker/credentials/sql/SqlCredentialsDefinitionRepositoryTest.kt
+++ b/kork-credentials-sql/src/test/kotlin/com/netflix/spinnaker/credentials/sql/SqlCredentialsDefinitionRepositoryTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.sql
+
+import com.netflix.spinnaker.credentials.CredentialsAutoConfiguration
+import com.netflix.spinnaker.credentials.CredentialsSource
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository
+import com.netflix.spinnaker.credentials.test.TestCredentialsDefinition
+import com.netflix.spinnaker.kork.sql.test.AutoConfigureDatabase
+import com.netflix.spinnaker.security.Authorization
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.access.PermissionEvaluator
+import org.springframework.security.test.context.support.WithMockUser
+import strikt.api.expectThat
+import strikt.assertions.all
+import strikt.assertions.containsExactlyInAnyOrder
+import strikt.assertions.hasSize
+import strikt.assertions.isA
+import strikt.assertions.isContainedIn
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
+import strikt.assertions.isLessThan
+import strikt.assertions.isNotEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
+import strikt.assertions.isTrue
+import java.time.Instant
+
+@SpringBootTest(
+  properties = [
+    "sql.enabled=true",
+    "account.storage.enabled=true",
+    "spinnaker.test.database.host=\${SQL_HOST:localhost}",
+    "spinnaker.test.database.port=\${PG_PORT:5432}",
+    "spinnaker.test.database.username=postgres",
+    "spinnaker.test.database.change-log=classpath:/db/changelog/accounts.yml",
+  ],
+  classes = [SqlCredentialsAutoConfiguration::class, CredentialsAutoConfiguration::class]
+)
+@AutoConfigureDatabase("credentials_repository")
+@AutoConfigureJson
+@WithMockUser
+class SqlCredentialsDefinitionRepositoryTest {
+  @MockBean
+  lateinit var permissionEvaluator: PermissionEvaluator
+
+  @Autowired
+  lateinit var repository: CredentialsDefinitionRepository
+
+  private val accountName = "test-account"
+  private val accountType = "test"
+
+  @Test
+  fun smokeTest() {
+    val credentials =
+      TestCredentialsDefinition(
+        name = accountName,
+        attributes = mapOf("hello" to "world"),
+        permissions = mapOf(Authorization.READ to setOf("USER"), Authorization.WRITE to setOf("USER"))
+      )
+
+    val metadata = repository.create(credentials)
+
+    expectThat(metadata) {
+      get { type } isEqualTo accountType
+      get { name } isEqualTo accountName
+      get { source } isEqualTo CredentialsSource.STORAGE
+      get { lastModified }.isNotNull().isLessThan(Instant.now())
+      get { eTag }.isNotNull()
+    }
+
+    val result = repository.findByName(accountName)
+
+    expectThat(result) {
+      isNotNull()
+      isA<TestCredentialsDefinition>().get { attributes["hello"] } isEqualTo "world"
+    }
+
+    val eTag = metadata.eTag
+    val updatedCredentials = credentials.copy(attributes = mapOf("hello" to "brooklyn"))
+    val updatedMetadata = repository.updateIfMatch(updatedCredentials, listOf(eTag))
+
+    expectThat(updatedMetadata) {
+      get { this.eTag } isNotEqualTo eTag
+    }
+
+    val updatedResult = repository.findByName(accountName)
+
+    expectThat(updatedResult) {
+      isNotNull()
+      isA<TestCredentialsDefinition>().get { attributes["hello"] } isEqualTo "brooklyn"
+    }
+
+    repository.delete(accountName)
+
+    val deletedResult = repository.findByName(accountName)
+
+    expectThat(deletedResult) {
+      isNull()
+    }
+
+    val history = repository.revisionHistory(accountName)
+
+    expectThat(history) {
+      hasSize(3) // create, update, delete
+      all { get { user } isEqualTo "user" }
+    }
+  }
+
+  @Test
+  fun bulkSmokeTest() {
+    val credentialsList = (1..5).map {
+      TestCredentialsDefinition(
+        name = "test-account-$it",
+        attributes = mapOf("iteration" to it.toString()),
+        permissions = mapOf(Authorization.READ to setOf("USER"), Authorization.WRITE to setOf("USER"))
+      )
+    }
+
+    val views = repository.saveAll(credentialsList)
+    expectThat(views) {
+      hasSize(credentialsList.size)
+      all {
+        get { spec }.isA<TestCredentialsDefinition>() isContainedIn credentialsList
+        and { get { status.isValid }.isTrue() }
+      }
+    }
+
+    val saved = repository.listByType(accountType)
+    expectThat(saved) {
+      containsExactlyInAnyOrder(credentialsList)
+    }
+
+    val toDelete = credentialsList.map { it.name }
+    repository.deleteAll(toDelete)
+
+    val remaining = repository.listByType(accountType)
+    expectThat(remaining) {
+      isEmpty()
+    }
+  }
+}

--- a/kork-credentials-sql/src/test/kotlin/com/netflix/spinnaker/credentials/test/TestCredentialsDefinition.kt
+++ b/kork-credentials-sql/src/test/kotlin/com/netflix/spinnaker/credentials/test/TestCredentialsDefinition.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.test
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition
+import com.netflix.spinnaker.credentials.definition.CredentialsType
+import com.netflix.spinnaker.security.Authorization
+import com.netflix.spinnaker.security.AuthorizationMapControlled
+
+@CredentialsType("test")
+data class TestCredentialsDefinition(
+  private var name: String,
+  var attributes: Map<String, String>,
+  private var permissions: Map<Authorization, Set<String>>,
+) : CredentialsDefinition, AuthorizationMapControlled {
+  override fun getName(): String = name
+
+  override fun getPermissions(): Map<Authorization, Set<String>> = permissions
+}

--- a/kork-credentials/kork-credentials.gradle
+++ b/kork-credentials/kork-credentials.gradle
@@ -20,12 +20,16 @@ apply from: "$rootDir/gradle/lombok.gradle"
 dependencies {
   api project(":kork-credentials-api")
   api project(":kork-annotations")
+  api project(":kork-plugins-api")
+  api project(":kork-secrets")
   implementation(platform(project(":spinnaker-dependencies")))
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation "org.springframework.boot:spring-boot"
   implementation 'org.springframework.boot:spring-boot-starter-json'
+  implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'javax.annotation:javax.annotation-api'
   implementation 'org.slf4j:slf4j-api'
+  implementation project(":kork-plugins")
 
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
@@ -35,4 +39,8 @@ dependencies {
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
+  testImplementation "org.springframework.boot:spring-boot-test"
+  testImplementation "org.springframework.boot:spring-boot-starter-test"
+  testImplementation "org.springframework.security:spring-security-config"
+  testImplementation "org.springframework.security:spring-security-test"
 }

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/ConditionalOnSelfServiceEnabled.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/ConditionalOnSelfServiceEnabled.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/** Conditional that requires self-service account storage to be enabled. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@ConditionalOnProperty(prefix = "account.storage", name = "enabled", havingValue = "true")
+public @interface ConditionalOnSelfServiceEnabled {}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsAutoConfiguration.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsAutoConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.netflix.spinnaker.credentials.poller.PollerConfiguration;
+import com.netflix.spinnaker.credentials.poller.PollerConfigurationProperties;
+import com.netflix.spinnaker.credentials.secrets.SecretCredentialsConfiguration;
+import com.netflix.spinnaker.credentials.service.CredentialsServiceConfiguration;
+import com.netflix.spinnaker.credentials.types.CredentialsDefinitionTypesConfiguration;
+import com.netflix.spinnaker.credentials.validator.CredentialsDefinitionValidatorConfiguration;
+import com.netflix.spinnaker.kork.secrets.SecretConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@AutoConfigureAfter({
+  JacksonAutoConfiguration.class,
+  ValidationAutoConfiguration.class,
+  SecurityAutoConfiguration.class
+})
+@Import({
+  CredentialsDefinitionTypesConfiguration.class,
+  SecretConfiguration.class,
+  SecretCredentialsConfiguration.class,
+  CredentialsDefinitionValidatorConfiguration.class,
+  CredentialsServiceConfiguration.class,
+  CredentialsManager.class,
+  PollerConfiguration.class,
+})
+@EnableConfigurationProperties(PollerConfigurationProperties.class)
+public class CredentialsAutoConfiguration {
+  @Bean
+  public static CredentialsTypePropertiesBeanPostProcessor
+      credentialsTypePropertiesBeanPostProcessor() {
+    return new CredentialsTypePropertiesBeanPostProcessor();
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsManager.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsManager.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.netflix.spinnaker.credentials.constraint.CredentialsDefinitionValidator;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.credentials.service.CredentialsDefinitionService;
+import com.netflix.spinnaker.credentials.service.CredentialsInspector;
+import com.netflix.spinnaker.credentials.service.ValidateCredentialsMutation;
+import com.netflix.spinnaker.credentials.types.CredentialsDefinitionTypeMap;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import com.netflix.spinnaker.kork.web.exceptions.ValidationException;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/** Facade for managing credentials storage, inspection, and retrieval. */
+@Component
+@RequiredArgsConstructor
+public class CredentialsManager {
+  private final CredentialsDefinitionTypeMap typeMap;
+  private final ObjectProvider<CredentialsInspector> inspectorProvider;
+  private final ObjectProvider<CredentialsDefinitionService> serviceProvider;
+
+  /**
+   * Provides the list of supported type discriminators for credentials. These are dynamically
+   * loaded and may be provided by plugins, so this list must be checked at runtime.
+   */
+  public List<String> listSupportedTypes() {
+    return List.copyOf(typeMap.getSupportedTypeNames());
+  }
+
+  /**
+   * Lists credentials views for the authenticated user. These views are a superset of the
+   * credentials a user may use as it will also include potentially damaged credentials whose
+   * persisted structure does not match the underlying credentials definition class.
+   */
+  public List<CredentialsView> listCredentialsViews(Authentication auth) {
+    CredentialsInspector inspector = inspectorProvider.getIfAvailable();
+    return inspector != null ? inspector.listCredentialsViews(auth) : List.of();
+  }
+
+  /**
+   * Validates the given credential definition for the provided user for the given command.
+   *
+   * @param mutation credential mutation to validate
+   * @param auth user who is validating the account definition
+   * @throws ValidationException if validation finds any errors
+   * @see CredentialsDefinitionValidator
+   */
+  public void validate(ValidateCredentialsMutation mutation, Authentication auth) {
+    getService().validate(mutation, auth);
+  }
+
+  /**
+   * Creates a new credential definition. If credentials already exist for the same name, then this
+   * response may include the existing credentials with an HTTP error code, `E-Tag`,
+   * `Last-Modified`, and other headers.
+   */
+  public CredentialsView.Metadata create(CredentialsDefinition definition, Authentication auth) {
+    return getService().create(definition, auth);
+  }
+
+  /** Saves a credential definition by creating new credentials or updating existing credentials. */
+  public CredentialsView.Metadata save(CredentialsDefinition definition, Authentication auth) {
+    return getService().save(definition, auth);
+  }
+
+  /** Saves a batch of credentials definitions by creating or updating each one as appropriate. */
+  public List<CredentialsView> saveAll(
+      List<CredentialsDefinition> definitions, Authentication auth) {
+    return getService().saveAll(definitions, auth);
+  }
+
+  /**
+   * Updates existing credentials matching the same name. If no credentials exist with the same
+   * name, then this should return an HTTP error code.
+   */
+  public CredentialsView.Metadata update(
+      CredentialsDefinition definition, Authentication auth, List<String> ifMatch) {
+    return getService().update(definition, auth, ifMatch);
+  }
+
+  /** Deletes a credential definition by name. */
+  public void delete(String name, Authentication auth) {
+    getService().delete(name, auth);
+  }
+
+  /** Delete multiple credentials definitions by name. */
+  public void deleteAll(Collection<String> names, Authentication auth) {
+    getService().deleteAll(names, auth);
+  }
+
+  /** Lists the historical revisions of a credential definition by name. */
+  public List<CredentialsDefinitionRepository.Revision> revisionHistory(String name) {
+    return getService().revisionHistory(name);
+  }
+
+  private CredentialsDefinitionService getService() {
+    CredentialsDefinitionService service = serviceProvider.getIfAvailable();
+    if (service == null) {
+      throw new NotFoundException("Self-service account storage is not enabled");
+    }
+    return service;
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypeBaseConfiguration.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypeBaseConfiguration.java
@@ -17,175 +17,44 @@
 
 package com.netflix.spinnaker.credentials;
 
-import com.netflix.spinnaker.credentials.definition.*;
-import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
-import com.netflix.spinnaker.credentials.definition.BasicCredentialsLoader;
-import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
-import com.netflix.spinnaker.credentials.definition.CredentialsParser;
-import java.util.Optional;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import java.util.Objects;
 import javax.annotation.Nullable;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.BeanFactoryUtils;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.config.ConstructorArgumentValues;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.support.AbstractApplicationContext;
-import org.springframework.core.ResolvableType;
+import org.springframework.context.ApplicationContextAware;
 
 /**
- * CredentialsTypeBaseConfiguration is a convenient way to configure {@link CredentialsRepository}
- * and {@link AbstractCredentialsLoader} for all the {@link CredentialsTypeProperties} configured in
- * the system.
+ * Provides a backward compatible way to register a {@link CredentialsTypeProperties} bean and its
+ * associated credentials beans. It is recommended to directly use {@link CredentialsTypeProperties}
+ * and register it as a bean rather than creating beans of this class.
  *
- * <p>It will try to reuse any {@link CredentialsRepository}, {@link CredentialsDefinitionSource},
- * {@link CredentialsParser}, {@link CredentialsLifecycleHandler}, or {@link
- * AbstractCredentialsLoader} that may have been added as a bean and create default implementations
- * otherwise.
+ * @see CredentialsTypePropertiesBeanPostProcessor
+ * @deprecated use {@link CredentialsTypeProperties} directly
  */
 @RequiredArgsConstructor
+@Log4j2
+@Deprecated(since = "2023-10-13")
 public class CredentialsTypeBaseConfiguration<
         T extends Credentials, U extends CredentialsDefinition>
-    implements InitializingBean {
-  private final ApplicationContext applicationContext;
+    implements InitializingBean, ApplicationContextAware {
   private final CredentialsTypeProperties<T, U> properties;
-  @Nullable @Getter private CredentialsRepository<T> credentialsRepository;
-  @Nullable @Getter private AbstractCredentialsLoader<T> credentialsLoader;
+  @Nullable @Setter private ApplicationContext applicationContext;
+
+  public CredentialsTypeBaseConfiguration(
+      @Nullable ApplicationContext applicationContext, CredentialsTypeProperties<T, U> properties) {
+    this.properties = properties;
+    this.applicationContext = applicationContext;
+  }
 
   @Override
   public void afterPropertiesSet() {
-    registerCredentialsProperties();
-  }
-
-  @SuppressWarnings("unchecked")
-  private void registerCredentialsProperties() {
-    // Get or build lifecycle handler
-    CredentialsLifecycleHandler<?> lifecycleHandler =
-        getParameterizedBean(
-                applicationContext,
-                CredentialsLifecycleHandler.class,
-                properties.getCredentialsClass())
-            .orElseGet(NoopCredentialsLifecycleHandler::new);
-
-    // Get or build credentials repository
-    credentialsRepository =
-        getParameterizedBean(
-                applicationContext, CredentialsRepository.class, properties.getCredentialsClass())
-            .orElseGet(
-                () ->
-                    registerCredentialsRepository(
-                        applicationContext, properties, lifecycleHandler));
-
-    // Get or build credential source
-    CredentialsDefinitionSource<U> credentialsDefinitionSource =
-        getParameterizedBean(
-                applicationContext,
-                CredentialsDefinitionSource.class,
-                properties.getCredentialsDefinitionClass())
-            .orElse(properties.getDefaultCredentialsSource());
-
-    // Get or build credentials parser
-    CredentialsParser<U, T> credentialsParser =
-        getParameterizedBean(
-                applicationContext,
-                CredentialsParser.class,
-                properties.getCredentialsDefinitionClass(),
-                properties.getCredentialsClass())
-            .orElse(properties.getCredentialsParser());
-
-    // Get or build credentials loader
-    credentialsLoader =
-        getParameterizedBean(
-                applicationContext,
-                AbstractCredentialsLoader.class,
-                properties.getCredentialsClass())
-            .orElseGet(
-                () ->
-                    registerCredentialsLoader(
-                        applicationContext,
-                        properties,
-                        credentialsDefinitionSource,
-                        credentialsParser,
-                        credentialsRepository));
-  }
-
-  /**
-   * Registers a new MapBackedCredentialsRepository under the name "credentialsRepository.[type]"
-   *
-   * @param context
-   * @param properties
-   * @param lifecycleHandler
-   * @param <T>
-   * @return Credentials repository registered in Spring
-   */
-  @SuppressWarnings("unchecked")
-  protected CredentialsRepository<T> registerCredentialsRepository(
-      ApplicationContext context,
-      CredentialsTypeProperties<T, ?> properties,
-      CredentialsLifecycleHandler<?> lifecycleHandler) {
-
-    RootBeanDefinition bd = new RootBeanDefinition();
-    bd.setTargetType(
-        ResolvableType.forClassWithGenerics(
-            CredentialsRepository.class, properties.getCredentialsClass()));
-    bd.setBeanClass(MapBackedCredentialsRepository.class);
-    ConstructorArgumentValues values = new ConstructorArgumentValues();
-    values.addGenericArgumentValue(properties.getType());
-    values.addGenericArgumentValue(lifecycleHandler);
-    bd.setConstructorArgumentValues(values);
-
-    String beanName = "credentialsRepository." + properties.getType();
-    ((DefaultListableBeanFactory) ((AbstractApplicationContext) context).getBeanFactory())
-        .registerBeanDefinition(beanName, bd);
-    return context.getBean(beanName, MapBackedCredentialsRepository.class);
-  }
-
-  @SuppressWarnings("unchecked")
-  protected AbstractCredentialsLoader<T> registerCredentialsLoader(
-      ApplicationContext context,
-      CredentialsTypeProperties<T, U> properties,
-      CredentialsDefinitionSource<U> credentialsDefinitionSource,
-      CredentialsParser<U, T> credentialsParser,
-      CredentialsRepository<T> credentialsRepository) {
-
-    RootBeanDefinition bd = new RootBeanDefinition();
-    bd.setTargetType(
-        ResolvableType.forClassWithGenerics(
-            AbstractCredentialsLoader.class, properties.getCredentialsClass()));
-    bd.setBeanClass(BasicCredentialsLoader.class);
-    ConstructorArgumentValues values = new ConstructorArgumentValues();
-    values.addGenericArgumentValue(credentialsDefinitionSource);
-    values.addGenericArgumentValue(credentialsParser);
-    values.addGenericArgumentValue(credentialsRepository);
-    values.addGenericArgumentValue(properties.isParallel());
-    bd.setConstructorArgumentValues(values);
-
-    String beanName = "credentialsLoader." + properties.getType();
-    ((DefaultListableBeanFactory) ((AbstractApplicationContext) context).getBeanFactory())
-        .registerBeanDefinition(beanName, bd);
-    return context.getBean(beanName, AbstractCredentialsLoader.class);
-  }
-
-  @SuppressWarnings("unchecked")
-  protected <T> Optional<T> getParameterizedBean(
-      ApplicationContext applicationContext, Class<T> paramClass, Class<?>... generics) {
-    ResolvableType resolvableType = ResolvableType.forClassWithGenerics(paramClass, generics);
-    String[] beanNames =
-        BeanFactoryUtils.beanNamesForTypeIncludingAncestors(applicationContext, resolvableType);
-    if (beanNames.length == 1) {
-      return Optional.of((T) applicationContext.getBean(beanNames[0]));
-    }
-    if (beanNames.length == 0) {
-      return Optional.empty();
-    }
-    throw new IllegalArgumentException(
-        beanNames.length
-            + " beans found of class "
-            + paramClass
-            + " ("
-            + generics.length
-            + " generics)");
+    var context =
+        Objects.requireNonNull(applicationContext, "No ApplicationContext value was provided");
+    var loader = new CredentialsTypePropertiesBeanLoader<>(context, properties);
+    loader.initializeCredentialsLoader();
   }
 }

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypeProperties.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypeProperties.java
@@ -17,19 +17,117 @@
 
 package com.netflix.spinnaker.credentials;
 
+import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
 import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
 
-@Builder
+/**
+ * CredentialsTypeProperties is a convenient way to configure {@link CredentialsRepository}, {@link
+ * CredentialsDefinitionSource}, and {@link AbstractCredentialsLoader} for various credentials
+ * classes. It will try to reuse any {@link CredentialsRepository}, {@link
+ * CredentialsDefinitionSource}, {@link CredentialsParser}, {@link CredentialsLifecycleHandler}, or
+ * {@link AbstractCredentialsLoader} that may have been added as a bean and create default
+ * implementations otherwise.
+ *
+ * <h2>Example Usage</h2>
+ *
+ * Suppose we have credentials classes defined for some credentials type named {@code cake} with its
+ * {@link CredentialsDefinition} class named {@code CakeDefinition}, its {@link Credentials} class
+ * named {@code CakeCredentials}, and a Spring Boot {@link ConfigurationProperties} bean for the
+ * configuration properties class {@code BakeryProperties} containing a property defined as {@code
+ * List<CakeDefinition> accounts} (i.e., a {@link CredentialsDefinitionSource} of {@code
+ * BakeryProperties::getAccounts}), then the most basic way to configure this cake credential type
+ * would work like the following code snippet from a {@link Configuration} class:
+ *
+ * <pre>
+ * &#64;Bean
+ * CredentialsTypeProperties&lt;CakeCredentials, CakeDefinition&gt;
+ *     cakeCredentialsTypeProperties(
+ *         BakeryProperties properties,
+ *         ...) {
+ *   return CredentialsTypeProperties.builder(
+ *           CakeCredentials.class, CakeDefinition.class)
+ *       .type("cake")
+ *       .defaultCredentialsSource(properties::getAccounts)
+ *       .credentialsParser(
+ *           definition -> {
+ *               CakeCredentials credentials;
+ *               // ... logic to convert definition into credentials
+ *               // (includes any other injected beans)
+ *               return credentials;
+ *           })
+ *       .build();
+ * }
+ * </pre>
+ *
+ * If the property {@code credentials.storage.cake.enabled} is set to {@code true}, then the above
+ * example will handle the setup for credentials storage support for cake accounts.
+ */
 @Getter
+@ToString(of = {"type", "credentialsClass", "credentialsDefinitionClass"})
 public class CredentialsTypeProperties<T extends Credentials, U extends CredentialsDefinition> {
+  /** Specifies the credentials type name this is for. */
   private final String type;
+
+  /** Specifies the type of credentials being configured. */
   private final Class<T> credentialsClass;
+
+  /** Specifies the type of credential definitions being configured. */
   private final Class<U> credentialsDefinitionClass;
+
+  /**
+   * Specifies a default fallback source for credentials definitions if no {@link
+   * CredentialsDefinitionSource} bean is otherwise registered for this credentials definition type.
+   */
   private final CredentialsDefinitionSource<U> defaultCredentialsSource;
-  private final CredentialsParser<U, T> credentialsParser;
+
+  /**
+   * Specifies the parser to use to transform credentials definitions into credentials. If left
+   * null, this must be configured as a bean elsewhere.
+   */
+  @Nullable private final CredentialsParser<U, T> credentialsParser;
+
+  /** Enables parallel credentials parsing. */
   private final boolean parallel;
+
+  @Builder
+  public CredentialsTypeProperties(
+      @Nonnull String type,
+      @Nonnull Class<T> credentialsClass,
+      @Nonnull Class<U> credentialsDefinitionClass,
+      @Nullable CredentialsDefinitionSource<U> defaultCredentialsSource,
+      @Nullable CredentialsParser<U, T> credentialsParser,
+      boolean parallel) {
+    Assert.hasText(type, "No credential type provided");
+    this.type = type;
+    this.credentialsClass = credentialsClass;
+    this.credentialsDefinitionClass = credentialsDefinitionClass;
+    this.defaultCredentialsSource =
+        defaultCredentialsSource != null ? defaultCredentialsSource : List::of;
+    this.credentialsParser = credentialsParser;
+    this.parallel = parallel;
+  }
+
+  public static <T extends Credentials, U extends CredentialsDefinition>
+      CredentialsTypePropertiesBuilder<T, U> builder() {
+    return new CredentialsTypePropertiesBuilder<>();
+  }
+
+  public static <T extends Credentials, U extends CredentialsDefinition>
+      CredentialsTypePropertiesBuilder<T, U> builder(
+          Class<T> credentialsClass, Class<U> credentialsDefinitionClass) {
+    return new CredentialsTypePropertiesBuilder<T, U>()
+        .credentialsClass(credentialsClass)
+        .credentialsDefinitionClass(credentialsDefinitionClass);
+  }
 }

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypePropertiesBeanLoader.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypePropertiesBeanLoader.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.BasicCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+import com.netflix.spinnaker.credentials.service.CompositeCredentialsDefinitionSource;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanReference;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.env.Environment;
+
+/**
+ * Helper class for {@link CredentialsTypePropertiesBeanPostProcessor}. Handles registration and
+ * loading of default credentials beans for a {@link CredentialsTypeProperties} bean.
+ *
+ * @param <C> type of Credentials this manages
+ * @param <D> type of CredentialsDefinitions this uses
+ * @see CredentialsTypePropertiesBeanPostProcessor
+ */
+@Log4j2
+@SuppressWarnings("unchecked")
+class CredentialsTypePropertiesBeanLoader<C extends Credentials, D extends CredentialsDefinition> {
+  private final CredentialsTypeProperties<C, D> properties;
+  private final Environment environment;
+  private final ConfigurableListableBeanFactory beanFactory;
+  private final BeanDefinitionRegistry registry;
+
+  // CredentialsRepository<C>
+  private final ResolvableType credentialsRepositoryType;
+
+  // CredentialsDefinitionSource<D>
+  private final ResolvableType credentialsDefinitionSourceType;
+
+  // CredentialsParser<D, C>
+  private final ResolvableType credentialsParserType;
+
+  // AbstractCredentialsLoader<C>
+  private final ResolvableType credentialsLoaderType;
+
+  CredentialsTypePropertiesBeanLoader(
+      ApplicationContext context, CredentialsTypeProperties<C, D> properties) {
+    this.properties = properties;
+
+    environment = context.getEnvironment();
+    beanFactory = ((ConfigurableApplicationContext) context).getBeanFactory();
+    registry = (BeanDefinitionRegistry) beanFactory;
+
+    // cache some resolvable types for bean lookup and registration
+    credentialsRepositoryType =
+        ResolvableType.forClassWithGenerics(
+            CredentialsRepository.class, properties.getCredentialsClass());
+    credentialsDefinitionSourceType =
+        ResolvableType.forClassWithGenerics(
+            CredentialsDefinitionSource.class, properties.getCredentialsDefinitionClass());
+    credentialsParserType =
+        ResolvableType.forClassWithGenerics(
+            CredentialsParser.class,
+            properties.getCredentialsDefinitionClass(),
+            properties.getCredentialsClass());
+    credentialsLoaderType =
+        ResolvableType.forClassWithGenerics(
+            AbstractCredentialsLoader.class, properties.getCredentialsClass());
+  }
+
+  /** Loads and registers credentials beans for these properties. */
+  void initializeCredentialsLoader() {
+    String beanName =
+        findExistingBeanName(credentialsLoaderType)
+            .orElseGet(
+                () ->
+                    registerCredentialsLoader(
+                        getReferenceToCredentialsDefinitionSource(), getCredentialsRepository()));
+    // initialize the bean if it hasn't been already
+    beanFactory.getBean(beanName);
+  }
+
+  /**
+   * Gets a bean reference to the CredentialsDefinitionSource for these properties. This will use an
+   * existing bean if available or will handle registration of a default bean otherwise. Bean
+   * initialization is deferred until it is needed by a CredentialsLoader.
+   */
+  private BeanReference getReferenceToCredentialsDefinitionSource() {
+    return findExistingBeanName(credentialsDefinitionSourceType)
+        .map(RuntimeBeanReference::new)
+        .orElseGet(this::registerCredentialsDefinitionSource);
+  }
+
+  /**
+   * Registers a CredentialsDefinitionSource bean for these properties. If credentials storage is
+   * both enabled and opted in for this credential definition type, then this decorates the default
+   * credential definition source with a storage-aware version.
+   */
+  private RuntimeBeanReference registerCredentialsDefinitionSource() {
+    var bd = new RootBeanDefinition();
+    getCredentialsStorageRepositoryReferenceIfEnabled()
+        .ifPresentOrElse(
+            repositoryBeanReference -> {
+              log.debug("Credentials storage enabled for {}", properties);
+              bd.setBeanClass(CompositeCredentialsDefinitionSource.class);
+              Class<D> definitionClass = properties.getCredentialsDefinitionClass();
+              bd.setTargetType(
+                  ResolvableType.forClassWithGenerics(
+                      CompositeCredentialsDefinitionSource.class, definitionClass));
+              bd.getConstructorArgumentValues().addGenericArgumentValue(repositoryBeanReference);
+              bd.getConstructorArgumentValues().addGenericArgumentValue(definitionClass);
+              // TODO(jvz): consider supporting multiple CredentialsDefinitionSource beans here
+              bd.getConstructorArgumentValues()
+                  .addGenericArgumentValue(List.of(properties.getDefaultCredentialsSource()));
+            },
+            () -> {
+              log.debug("Credentials storage disabled for {}", properties);
+              bd.setBeanClass(CredentialsDefinitionSource.class);
+              bd.setTargetType(credentialsDefinitionSourceType);
+              bd.setInstanceSupplier(properties::getDefaultCredentialsSource);
+            });
+    return new RuntimeBeanReference(
+        BeanDefinitionReaderUtils.registerWithGeneratedName(bd, registry));
+  }
+
+  /**
+   * Gets the CredentialsRepository for these properties. This will try to use an existing bean if
+   * available or will otherwise register and initialize a default one.
+   */
+  private CredentialsRepository<C> getCredentialsRepository() {
+    return findExistingBeanName(credentialsRepositoryType)
+        .map(beanName -> beanFactory.getBean(beanName, CredentialsRepository.class))
+        .orElseGet(this::registerCredentialsRepository);
+  }
+
+  /**
+   * Registers a CredentialsRepository bean for these properties. This will use an existing
+   * CredentialsLifecycleHandler bean for this credential type if available.
+   */
+  private CredentialsRepository<C> registerCredentialsRepository() {
+    var bd = new RootBeanDefinition(MapBackedCredentialsRepository.class);
+    Class<C> credentialsClass = properties.getCredentialsClass();
+    String type = properties.getType();
+    bd.setTargetType(
+        ResolvableType.forClassWithGenerics(
+            MapBackedCredentialsRepository.class, credentialsClass));
+    bd.getConstructorArgumentValues().addGenericArgumentValue(type);
+    ResolvableType lifecycleHandlerType =
+        ResolvableType.forClassWithGenerics(CredentialsLifecycleHandler.class, credentialsClass);
+    findExistingBeanName(lifecycleHandlerType)
+        .ifPresentOrElse(
+            beanName ->
+                bd.getConstructorArgumentValues()
+                    .addGenericArgumentValue(new RuntimeBeanReference(beanName)),
+            () ->
+                bd.getConstructorArgumentValues()
+                    .addGenericArgumentValue(new NoopCredentialsLifecycleHandler<C>()));
+    String beanName = "credentialsRepository." + type;
+    registry.registerBeanDefinition(beanName, bd);
+    log.debug("Registered bean named '{}' with type {}", beanName, credentialsRepositoryType);
+    return beanFactory.getBean(beanName, CredentialsRepository.class);
+  }
+
+  /** Registers a BasicCredentialsLoader bean using the beans configured for these properties. */
+  private String registerCredentialsLoader(
+      BeanReference credentialsDefinitionSourceReference, CredentialsRepository<C> repository) {
+    var bd = new RootBeanDefinition(BasicCredentialsLoader.class);
+    bd.setTargetType(
+        ResolvableType.forClassWithGenerics(
+            BasicCredentialsLoader.class,
+            properties.getCredentialsDefinitionClass(),
+            properties.getCredentialsClass()));
+    bd.getConstructorArgumentValues().addGenericArgumentValue(credentialsDefinitionSourceReference);
+    findExistingBeanName(credentialsParserType)
+        .ifPresentOrElse(
+            beanName ->
+                bd.getConstructorArgumentValues()
+                    .addGenericArgumentValue(new RuntimeBeanReference(beanName)),
+            () ->
+                bd.getConstructorArgumentValues()
+                    .addGenericArgumentValue(
+                        Objects.requireNonNull(
+                            properties.getCredentialsParser(),
+                            () -> "No " + credentialsParserType + " found")));
+    bd.getConstructorArgumentValues().addGenericArgumentValue(repository);
+    bd.getConstructorArgumentValues().addGenericArgumentValue(properties.isParallel());
+    String beanName = "credentialsLoader." + properties.getType();
+    registry.registerBeanDefinition(beanName, bd);
+    log.debug("Registered bean named '{}' with type {}", beanName, bd.getResolvableType());
+    return beanName;
+  }
+
+  /**
+   * Finds an existing bean name matching the provided type. Returns empty when there are no
+   * matching beans or the bean name if there is a unique bean; otherwise, throws a {@link
+   * NoUniqueBeanDefinitionException} if more than one bean matches the given type.
+   */
+  private Optional<String> findExistingBeanName(ResolvableType type) {
+    String[] beanNames = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, type);
+    if (beanNames.length > 1) {
+      throw new NoUniqueBeanDefinitionException(type, beanNames);
+    }
+    return beanNames.length == 1 ? Optional.of(beanNames[0]) : Optional.empty();
+  }
+
+  /**
+   * Gets a bean reference for the CredentialsDefinitionRepository bean if credentials storage is
+   * enabled for this credential type and credentials storage is enabled in general.
+   */
+  private Optional<BeanReference> getCredentialsStorageRepositoryReferenceIfEnabled() {
+    if (isCredentialsStorageEnabled()) {
+      String[] beanNames =
+          BeanFactoryUtils.beanNamesForTypeIncludingAncestors(
+              beanFactory, CredentialsDefinitionRepository.class);
+      if (beanNames.length > 1) {
+        throw new NoUniqueBeanDefinitionException(CredentialsDefinitionRepository.class, beanNames);
+      }
+      return beanNames.length == 1
+          ? Optional.of(new RuntimeBeanReference(beanNames[0]))
+          : Optional.empty();
+    }
+    return Optional.empty();
+  }
+
+  private boolean isCredentialsStorageEnabled() {
+    String typeName =
+        CredentialsTypes.getCredentialsTypeName(properties.getCredentialsDefinitionClass());
+    if (typeName == null) {
+      return false;
+    }
+    String primaryProperty = "credentials.storage." + typeName + ".enabled";
+    if (environment.containsProperty(primaryProperty)) {
+      return environment.getRequiredProperty(primaryProperty, Boolean.class);
+    }
+    String legacyProperty = "account.storage." + typeName + ".enabled";
+    return environment.getProperty(legacyProperty, Boolean.class, false);
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypePropertiesBeanPostProcessor.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypePropertiesBeanPostProcessor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.BasicCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import com.netflix.spinnaker.credentials.service.CompositeCredentialsDefinitionSource;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+/**
+ * Handles registration of various credentials beans. For each registered {@code
+ * CredentialsTypeProperties<C, D>} bean, an existing bean of a certain type will be used if
+ * registered; otherwise, default beans are created in each of the following types. For these beans,
+ * the type {@code C} is the concrete {@link Credentials} type and {@code D} is the concrete {@link
+ * CredentialsDefinition} type. When {@linkplain CredentialsDefinitionRepository credentials
+ * storage} is enabled, if the property {@code credentials.storage.[definition-type].enabled} is set
+ * to {@code true} (where {@code [definition-type]} is the {@linkplain CredentialsType credential
+ * definition type name}), then a default {@link CredentialsDefinitionSource} bean may be registered
+ * which wraps the provided default credentials definition source with support for credentials
+ * storage. For backward compatibility purposes, this property may also be specified as {@code
+ * account.storage.[definition-name].enabled}.
+ *
+ * <table>
+ *     <tr>
+ *         <th>Bean Type</th>
+ *         <th>Default Bean</th>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link CredentialsLifecycleHandler CredentialsLifecycleHandler&lt;C&gt;}</td>
+ *         <td>{@link NoopCredentialsLifecycleHandler}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link CredentialsRepository CredentialsRepository&lt;C&gt;}</td>
+ *         <td>{@link MapBackedCredentialsRepository} using the provided credential {@code type} and optional
+ *         {@link CredentialsLifecycleHandler} bean from above</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link CredentialsDefinitionSource CredentialsDefinitionSource&lt;D&gt;}</td>
+ *         <td>The provided {@link CredentialsDefinitionSource} which may be wrapped into a
+ *         {@link CompositeCredentialsDefinitionSource} when automatic credentials storage is enabled
+ *         for this credential definition type</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link CredentialsParser CredentialsParser&lt;D, C&gt;}</td>
+ *         <td>The provided {@link CredentialsParser}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link AbstractCredentialsLoader AbstractCredentialsLoader&lt;C&gt;}</td>
+ *         <td>{@link BasicCredentialsLoader} using the {@link CredentialsDefinitionSource},
+ *         {@link CredentialsParser}, and {@link CredentialsRepository} beans from above, along with the
+ *         provided {@code parallel} boolean flag.</td>
+ *     </tr>
+ * </table>
+ */
+@Log4j2
+@Setter
+public class CredentialsTypePropertiesBeanPostProcessor
+    implements BeanPostProcessor, ApplicationContextAware {
+  private ApplicationContext applicationContext;
+
+  @Override
+  public Object postProcessBeforeInitialization(Object bean, String beanName)
+      throws BeansException {
+    if (bean instanceof CredentialsTypeProperties<?, ?>) {
+      var properties = (CredentialsTypeProperties<?, ?>) bean;
+      postProcessCredentialsTypeProperties(properties);
+    }
+    return bean;
+  }
+
+  private <C extends Credentials, D extends CredentialsDefinition>
+      void postProcessCredentialsTypeProperties(CredentialsTypeProperties<C, D> properties) {
+    var loader = new CredentialsTypePropertiesBeanLoader<>(applicationContext, properties);
+    log.debug("Processing CredentialsTypeProperties for type {}", properties.getType());
+    loader.initializeCredentialsLoader();
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypes.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/CredentialsTypes.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.exceptions.InvalidCredentialsTypeException;
+import javax.annotation.Nullable;
+import lombok.experimental.UtilityClass;
+import org.springframework.core.annotation.AnnotationUtils;
+
+@UtilityClass
+@NonnullByDefault
+public class CredentialsTypes {
+  @Nullable
+  public static String getCredentialsTypeName(
+      Class<? extends CredentialsDefinition> credentialsType) {
+    CredentialsType type = AnnotationUtils.findAnnotation(credentialsType, CredentialsType.class);
+    if (type != null) {
+      return type.value();
+    }
+    // legacy support
+    JsonTypeName annotation = AnnotationUtils.findAnnotation(credentialsType, JsonTypeName.class);
+    return annotation != null ? annotation.value() : null;
+  }
+
+  public static String getRequiredCredentialsTypeName(
+      Class<? extends CredentialsDefinition> credentialsType) {
+    String typeName = getCredentialsTypeName(credentialsType);
+    if (typeName == null) {
+      throw new InvalidCredentialsTypeException(
+          String.format("No @CredentialsType or @JsonTypeName defined for %s", credentialsType));
+    }
+    return typeName;
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/poller/Poller.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/poller/Poller.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.credentials.poller;
 
 import com.netflix.spinnaker.credentials.Credentials;
-import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.CredentialsLoader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class Poller<T extends Credentials> implements Runnable {
-  private final AbstractCredentialsLoader<T> credentialsLoader;
+  private final CredentialsLoader<T> credentialsLoader;
 
   public void run() {
     try {

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/poller/PollerConfiguration.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/poller/PollerConfiguration.java
@@ -16,22 +16,23 @@
 
 package com.netflix.spinnaker.credentials.poller;
 
-import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
-import java.util.List;
+import com.netflix.spinnaker.credentials.Credentials;
+import com.netflix.spinnaker.credentials.definition.CredentialsLoader;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.scheduling.support.PeriodicTrigger;
 
-@EnableConfigurationProperties(PollerConfigurationProperties.class)
+@Configuration(proxyBeanMethods = false)
 @RequiredArgsConstructor
-@Slf4j
+@NonnullByDefault
 public class PollerConfiguration implements SchedulingConfigurer {
   private final PollerConfigurationProperties config;
-  private final List<AbstractCredentialsLoader<?>> pollers;
+  private final ObjectProvider<CredentialsLoader<? extends Credentials>> pollers;
 
   @Override
   public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/secrets/CredentialsDefinitionMapper.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/secrets/CredentialsDefinitionMapper.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2021 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.secrets;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.netflix.spinnaker.credentials.CredentialsError;
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import com.netflix.spinnaker.credentials.validator.CredentialsDefinitionErrorCode;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.jackson.ObjectNodeErrors;
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretReference;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretService;
+import com.netflix.spinnaker.security.AccessControlled;
+import com.netflix.spinnaker.security.SpinnakerAuthorities;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.logging.log4j.ThreadContext;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+
+/**
+ * Maps credential definitions to and from strings. Only {@link CredentialsDefinition} classes
+ * annotated with a {@link CredentialsType} will be considered. {@link UserSecretReference} URIs may
+ * be used for credentials values which will be replaced with an appropriate string for the secret
+ * along with recording an associated account name for time of use permission checks on the user
+ * secret.
+ */
+@Log4j2
+@Component
+@NonnullByDefault
+@RequiredArgsConstructor
+public class CredentialsDefinitionMapper {
+
+  private final ObjectMapper objectMapper;
+  private final UserSecretService secretService;
+
+  /**
+   * Serializes the given {@link CredentialsDefinition} instance into a JSON string.
+   *
+   * @param definition the account to serialize
+   * @return the serialized account
+   * @throws JsonProcessingException if there are errors converting the account into JSON
+   */
+  public String serialize(CredentialsDefinition definition) throws JsonProcessingException {
+    return objectMapper.writeValueAsString(definition);
+  }
+
+  /**
+   * Attempts to deserialize the given JSON string into an appropriate {@link CredentialsDefinition}
+   * account object. This does not load or decrypt any secret URIs.
+   *
+   * @param string the JSON string to parse
+   * @return the parsed account
+   * @throws JsonProcessingException if the input string is invalid JSON or does not map to a known
+   *     CredentialsDefinition class
+   * @throws IllegalArgumentException if the JSON is missing a "type" or "name" field or if the JSON
+   *     is not an object
+   */
+  public CredentialsDefinition deserialize(String string) throws JsonProcessingException {
+    return objectMapper.readValue(string, CredentialsDefinition.class);
+  }
+
+  /**
+   * Attempts to both deserialize and decrypt referenced secrets in the given JSON string into an
+   * appropriate {@link CredentialsDefinition} account object.
+   *
+   * @param string the JSON string to parse
+   * @return the parsed account with loaded secrets
+   * @throws JsonProcessingException if the input string is invalid JSON or does not map to an
+   *     existing CredentialsDefinition class
+   * @throws com.netflix.spinnaker.kork.secrets.SecretException if there are errors while fetching
+   *     the secret
+   * @throws IllegalArgumentException if the JSON is missing a "name" field or if the JSON is not an
+   *     object
+   */
+  public CredentialsDefinition deserializeWithSecrets(String string)
+      throws JsonProcessingException {
+    ObjectNode account = parseJson(string);
+    String accountName = account.required("name").asText();
+    Iterator<Map.Entry<String, JsonNode>> it = account.fields();
+    while (it.hasNext()) {
+      Map.Entry<String, JsonNode> field = it.next();
+      JsonNode node = field.getValue();
+      if (node.isTextual()) {
+        String text = node.asText();
+        Optional<String> plaintext;
+        if (UserSecretReference.isUserSecret(text)) {
+          plaintext =
+              UserSecretReference.tryParse(text)
+                  .map(ref -> secretService.getUserSecretStringForResource(ref, accountName));
+        } else if (EncryptedSecret.isEncryptedSecret(text)) {
+          plaintext = EncryptedSecret.tryParse(text).map(secretService::getExternalSecretString);
+        } else {
+          plaintext = Optional.empty();
+        }
+
+        plaintext.map(account::textNode).ifPresent(field::setValue);
+      }
+    }
+    return objectMapper.convertValue(account, CredentialsDefinition.class);
+  }
+
+  private ObjectNode parseJson(String string) throws JsonProcessingException {
+    JsonNode jsonNode = objectMapper.readTree(string);
+    if (!jsonNode.isObject()) {
+      throw new IllegalArgumentException(
+          "Expected an object node but got " + jsonNode.getNodeType());
+    }
+    return (ObjectNode) jsonNode;
+  }
+
+  /**
+   * Attempts to deserialize the given JSON string into an appropriate {@link CredentialsDefinition}
+   * inside a {@link CredentialsView} along with any errors encountered during deserialization. This
+   * does not decrypt any secrets.
+   *
+   * @param string the JSON string to parse
+   * @return an initialized CredentialsView with the deserialized credentials or errors
+   */
+  public CredentialsView deserializeWithErrors(String string) {
+    CredentialsView view = new CredentialsView();
+
+    // ensure that the JSON string is both valid JSON and an object in particular
+    JsonNode jsonNode;
+    try {
+      jsonNode = objectMapper.readTree(string);
+    } catch (JsonProcessingException e) {
+      log.info("Cannot deserialize invalid JSON credentials data", e);
+      view.setSpec(Map.of("data", string));
+      view.getStatus()
+          .addError(
+              new CredentialsError(
+                  CredentialsDefinitionErrorCode.INVALID_SYNTAX.getErrorCode(), e.getMessage()));
+      return view;
+    }
+
+    view.setSpec(jsonNode);
+
+    if (!jsonNode.isObject()) {
+      JsonNodeType nodeType = jsonNode.getNodeType();
+      log.info(
+          "Encountered invalid structured JSON credentials data. Expected an object but got {}",
+          nodeType);
+      view.getStatus()
+          .addError(
+              new CredentialsError(
+                  CredentialsDefinitionErrorCode.INVALID_STRUCTURE.getErrorCode(),
+                  "Expected an object node but instead got " + nodeType));
+      return view;
+    }
+
+    // ensure we have a `name` and `type` field
+    ObjectNode account = (ObjectNode) jsonNode;
+    // allow for permission checking of invalid or unknown account types
+    view.setSpec(new UnknownAccount(account));
+    Errors errors = new ObjectNodeErrors(account, "result");
+    String name;
+    String type;
+    if (!account.hasNonNull("name")) {
+      log.info("Missing or empty 'name' field in credentials definition");
+      errors.rejectValue(
+          "name",
+          CredentialsDefinitionErrorCode.MISSING_NAME.getErrorCode(),
+          "No 'name' field in credentials definition");
+    } else {
+      name = account.get("name").asText();
+      ThreadContext.put("accountName", name);
+      view.getMetadata().setName(name);
+    }
+    if (!account.hasNonNull("type")) {
+      log.info("Missing or empty 'type' field in credentials definition");
+      errors.rejectValue(
+          "type",
+          CredentialsDefinitionErrorCode.MISSING_TYPE.getErrorCode(),
+          "No 'type' field in credentials definition");
+    } else {
+      type = account.get("type").asText();
+      ThreadContext.put("accountType", type);
+      log.debug("Validating account with type '{}'", type);
+      view.getMetadata().setType(type);
+    }
+
+    try {
+      CredentialsDefinition loaded =
+          objectMapper.convertValue(account, CredentialsDefinition.class);
+      view.setSpec(loaded);
+    } catch (IllegalArgumentException e) {
+      log.info("Invalid credentials JSON binding", e);
+      errors.reject(CredentialsDefinitionErrorCode.INVALID_BINDING.getErrorCode(), e.getMessage());
+    } finally {
+      ThreadContext.removeAll(List.of("accountName", "accountType"));
+    }
+
+    if (errors.hasErrors()) {
+      List<CredentialsError> errorList =
+          errors.getAllErrors().stream()
+              .map(
+                  error -> {
+                    String errorCode = error.getCode();
+                    assert errorCode != null;
+                    String message = error.getDefaultMessage();
+                    assert message != null;
+                    String field =
+                        error instanceof FieldError ? ((FieldError) error).getField() : null;
+                    return new CredentialsError(errorCode, message, field);
+                  })
+              .collect(Collectors.toList());
+      view.getStatus().addErrors(errorList);
+    }
+
+    return view;
+  }
+
+  // provides a view into unparsed credentials to support access controls if defined
+  @RequiredArgsConstructor
+  private static class UnknownAccount implements AccessControlled {
+    private final ObjectNode account;
+
+    @Override
+    public boolean isAuthorized(Authentication authentication, Object authorization) {
+      JsonNode permittedRoles;
+      JsonNode permissions = account.get("permissions");
+      JsonNode artifactRoles = account.get("roles");
+      JsonNode requiredGroupMembership = account.get("requiredGroupMembership");
+      if (permissions != null) {
+        JsonNode roles = permissions.get(authorization.toString().toUpperCase(Locale.ROOT));
+        if (roles == null) {
+          return true;
+        }
+        permittedRoles = roles;
+      } else if (artifactRoles != null) {
+        permittedRoles = artifactRoles;
+      } else if (requiredGroupMembership != null) {
+        permittedRoles = requiredGroupMembership;
+      } else {
+        // doesn't seem to be an access-controlled object
+        return true;
+      }
+      if (permittedRoles.isEmpty() || !permittedRoles.isArray()) {
+        // no roles defined for an authorization -> open access
+        return true;
+      }
+      Set<String> roles = new HashSet<>();
+      for (JsonNode permittedRole : permittedRoles) {
+        roles.add(permittedRole.asText());
+      }
+      return SpinnakerAuthorities.hasAnyRole(authentication, roles);
+    }
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/secrets/SecretCredentialsConfiguration.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/secrets/SecretCredentialsConfiguration.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.secrets;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/** Configures integration with secrets. */
+@Configuration
+@ComponentScan
+public class SecretCredentialsConfiguration {}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CompositeCredentialsDefinitionSource.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CompositeCredentialsDefinitionSource.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.service;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.netflix.spinnaker.credentials.CredentialsTypes;
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.credentials.definition.CompositeCredentialsNavigator;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsNavigator;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Navigates all CredentialsDefinition account instances for a given credentials type. Given an
+ * {@link CredentialsDefinitionRepository} bean and an optional list of {@link
+ * CredentialsDefinitionSource} beans for a given account type {@code T}, this class combines the
+ * lists from all the given credentials definition sources. When no {@link
+ * CredentialsDefinitionSource} beans are available for a given account type, then a default source
+ * should be specified to wrap any existing Spring configuration beans that provide the same.
+ *
+ * @param <T> account credentials definition type
+ */
+@Log4j2
+public class CompositeCredentialsDefinitionSource<T extends CredentialsDefinition>
+    implements CredentialsNavigator<T> {
+
+  private final CredentialsDefinitionRepository repository;
+  @Getter private final Class<T> type;
+  @Getter private final String typeName;
+  private final List<CredentialsDefinitionSource<T>> configSources;
+  private final CredentialsNavigator<T> configNavigator;
+
+  // used to report duplicate accounts only once, instead of spamming the logs
+  private final Set<String> duplicateAccountNames = ConcurrentHashMap.newKeySet();
+
+  /**
+   * Constructs composite {@code CredentialsDefinitionSource<T>} using the provided repository,
+   * credential type, and additional sources for credentials of the same type.
+   *
+   * @param repository the backing repository for managing credential definitions at runtime
+   * @param type the credential type supported by this source (must be annotated with {@link
+   *     JsonTypeName} or {@link com.netflix.spinnaker.credentials.definition.CredentialsType})
+   * @param configSources the list of other credential definition sources to list accounts from
+   */
+  public CompositeCredentialsDefinitionSource(
+      CredentialsDefinitionRepository repository,
+      Class<T> type,
+      List<CredentialsDefinitionSource<T>> configSources) {
+    this.repository = repository;
+    this.type = type;
+    this.typeName = CredentialsTypes.getRequiredCredentialsTypeName(type);
+    this.configSources = configSources;
+    this.configNavigator = new CompositeCredentialsNavigator<>(configSources, type, typeName);
+  }
+
+  @Override
+  public List<T> getCredentialsDefinitions() {
+    Set<String> seen = new HashSet<>();
+    return Stream.concat(
+            repository.listByType(typeName).stream().map(type::cast),
+            configSources.stream().flatMap(source -> source.getCredentialsDefinitions().stream()))
+        .filter(
+            definition -> {
+              String name = definition.getName();
+              if (seen.add(name)) {
+                // haven't seen yet
+                return true;
+              }
+              if (duplicateAccountNames.add(name)) {
+                // first time we've seen this dupe
+                log.warn("Duplicate account name detected ({}). Skipping this definition.", name);
+              }
+              return false;
+            })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Lists all views into credentials accessible to the current user of the type tracked by this
+   * instance.
+   */
+  @Override
+  public List<CredentialsView> listCredentialsViews() {
+    List<CredentialsView> views = new ArrayList<>(repository.listCredentialsViews(typeName));
+    views.addAll(configNavigator.listCredentialsViews());
+    return views;
+  }
+
+  @Override
+  public Optional<T> findByName(String accountName) {
+    CredentialsDefinition storedCredentials = repository.findByName(accountName);
+    if (type.isInstance(storedCredentials)) {
+      return Optional.of(type.cast(storedCredentials));
+    }
+    return configNavigator.findByName(accountName);
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CredentialsDefinitionAdvice.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CredentialsDefinitionAdvice.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.service;
+
+import com.netflix.spinnaker.credentials.definition.error.CredentialsDefinitionRepositoryException;
+import com.netflix.spinnaker.credentials.definition.error.DuplicateCredentialsDefinitionException;
+import com.netflix.spinnaker.credentials.definition.error.InvalidCredentialsDefinitionException;
+import com.netflix.spinnaker.credentials.definition.error.NoMatchingCredentialsException;
+import com.netflix.spinnaker.credentials.definition.error.NoSuchCredentialsDefinitionException;
+import com.netflix.spinnaker.kork.exceptions.InvalidCredentialsTypeException;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import java.time.Instant;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/** Provides exception handlers for {@link CredentialsDefinitionRepositoryException} exceptions. */
+@RestControllerAdvice
+public class CredentialsDefinitionAdvice {
+  @ExceptionHandler(NoSuchCredentialsDefinitionException.class)
+  public ResponseEntity<ModelMap> handleNoSuchCredentials(NoSuchCredentialsDefinitionException ex) {
+    var map = convertExceptionToErrorAttributes(ex);
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(map);
+  }
+
+  @ExceptionHandler(DuplicateCredentialsDefinitionException.class)
+  public ResponseEntity<Object> handleDuplicateCredentials(
+      DuplicateCredentialsDefinitionException e) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .eTag(e.getETag())
+        .lastModified(e.getLastModified())
+        .body(e.getExisting());
+  }
+
+  @ExceptionHandler(NoMatchingCredentialsException.class)
+  public ResponseEntity<Object> handleNoMatchingCredentials(NoMatchingCredentialsException e) {
+    return ResponseEntity.status(HttpStatus.PRECONDITION_FAILED)
+        .eTag(e.getETag())
+        .lastModified(e.getLastModified())
+        .body(e.getExisting());
+  }
+
+  @ExceptionHandler({
+    InvalidCredentialsDefinitionException.class,
+    InvalidCredentialsTypeException.class
+  })
+  public ResponseEntity<ModelMap> handleInvalidCredentials(SpinnakerException ex) {
+    var map = convertExceptionToErrorAttributes(ex);
+    return ResponseEntity.badRequest().body(map);
+  }
+
+  private static ModelMap convertExceptionToErrorAttributes(SpinnakerException ex) {
+    ModelMap map = new ModelMap();
+    map.addAttribute("timestamp", Instant.now());
+    map.addAttribute("exception", ex.getClass().getName());
+    map.addAttribute("message", ex.getMessage());
+    map.addAllAttributes(ex.getAdditionalAttributes());
+    return map;
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CredentialsDefinitionService.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CredentialsDefinitionService.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2023 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.service;
+
+import com.netflix.spinnaker.credentials.Credentials;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.credentials.constraint.CredentialsDefinitionValidator;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.credentials.validator.CredentialsDefinitionErrorCode;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
+import com.netflix.spinnaker.kork.web.exceptions.ValidationException;
+import com.netflix.spinnaker.security.AccessControlled;
+import com.netflix.spinnaker.security.Authorization;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Service wrapper for an {@link CredentialsDefinitionRepository} which enforces permissions and
+ * other validations.
+ *
+ * @see com.netflix.spinnaker.credentials.constraint.ValidatedCredentials
+ */
+@Log4j2
+@RequiredArgsConstructor
+@Service
+@Validated
+public class CredentialsDefinitionService {
+  private final CredentialsDefinitionRepository repository;
+  private final PermissionEvaluator permissionEvaluator;
+  private final ObjectProvider<CredentialsRepository<? extends Credentials>>
+      credentialsRepositories;
+
+  private boolean isNameInUse(String name) {
+    return repository.findByName(name) != null
+        || credentialsRepositories.stream().anyMatch(repo -> repo.has(name));
+  }
+
+  private boolean shouldDenyWritePermission(Authentication auth, String name) {
+    CredentialsDefinition storedCredentials = repository.findByName(name);
+    if (storedCredentials instanceof AccessControlled) {
+      return !permissionEvaluator.hasPermission(auth, storedCredentials, Authorization.WRITE);
+    }
+    return credentialsRepositories
+        .orderedStream()
+        .filter(repo -> repo.has(name))
+        .map(repo -> repo.getOne(name))
+        .filter(Objects::nonNull)
+        .filter(AccessControlled.class::isInstance)
+        .map(AccessControlled.class::cast)
+        .findFirst()
+        .map(existing -> !permissionEvaluator.hasPermission(auth, existing, Authorization.WRITE))
+        .orElse(false);
+  }
+
+  /**
+   * Validates the given credential definition for the provided user for the given command.
+   *
+   * @param mutation credential mutation to validate
+   * @param auth user who is validating the account definition
+   * @throws ValidationException if validation finds any errors
+   * @see CredentialsDefinitionValidator
+   */
+  public void validate(@Valid ValidateCredentialsMutation mutation, Authentication auth) {
+    Errors errors;
+    if (mutation instanceof ValidateCredentialsMutation.Create) {
+      var credentials = ((ValidateCredentialsMutation.Create) mutation).getCredentials();
+      errors = new BeanPropertyBindingResult(credentials, "credentials");
+      var name = credentials.getName();
+      if (StringUtils.hasText(name)) {
+        validateCreate(errors, name);
+      }
+    } else if (mutation instanceof ValidateCredentialsMutation.Update) {
+      var credentials = ((ValidateCredentialsMutation.Update) mutation).getCredentials();
+      errors = new BeanPropertyBindingResult(credentials, "credentials");
+      var name = credentials.getName();
+      if (StringUtils.hasText(name)) {
+        validateUpdate(errors, name, auth);
+      }
+    } else if (mutation instanceof ValidateCredentialsMutation.Save) {
+      var credentials = ((ValidateCredentialsMutation.Save) mutation).getCredentials();
+      errors = new BeanPropertyBindingResult(credentials, "credentials");
+      for (int i = 0; i < credentials.size(); i++) {
+        errors.pushNestedPath(String.format("[%d]", i));
+        var name = credentials.get(i).getName();
+        validateSave(errors, name, auth);
+        errors.popNestedPath();
+      }
+    } else if (mutation instanceof ValidateCredentialsMutation.Delete) {
+      var credentials = ((ValidateCredentialsMutation.Delete) mutation).getCredentials();
+      errors = new BeanPropertyBindingResult(credentials, "credentials");
+      Set<String> unknownNames = repository.getUnknownNames(credentials);
+      for (int i = 0; i < credentials.size(); i++) {
+        errors.pushNestedPath(String.format("[%d]", i));
+        var name = credentials.get(i);
+        if (unknownNames.contains(name)) {
+          errors.reject(
+              CredentialsDefinitionErrorCode.NOT_FOUND.getErrorCode(), "No credentials found");
+        } else if (shouldDenyWritePermission(auth, name)) {
+          errors.reject(
+              CredentialsDefinitionErrorCode.UNAUTHORIZED.getErrorCode(),
+              "Missing write permissions for credentials");
+        }
+        errors.popNestedPath();
+      }
+    } else {
+      throw new InvalidRequestException(
+          "Unrecognized validate credentials mutation class: " + mutation.getClass());
+    }
+    if (errors.hasErrors()) {
+      throw new ValidationException(errors.getAllErrors());
+    }
+  }
+
+  public CredentialsView.Metadata create(
+      @Valid CredentialsDefinition definition, Authentication auth) {
+    validate(new ValidateCredentialsMutation.Create(definition), auth);
+    return repository.create(definition);
+  }
+
+  private void validateCreate(Errors errors, String name) {
+    if (isNameInUse(name)) {
+      errors.rejectValue(
+          "name",
+          CredentialsDefinitionErrorCode.DUPLICATE_NAME.getErrorCode(),
+          "Cannot create a new account with the same name as an existing one");
+    }
+  }
+
+  public CredentialsView.Metadata update(
+      @Valid CredentialsDefinition definition,
+      Authentication auth,
+      @Nullable List<String> ifMatches) {
+    validate(new ValidateCredentialsMutation.Update(definition), auth);
+    return CollectionUtils.isEmpty(ifMatches) || ifMatches.get(0).equals("*")
+        ? repository.update(definition)
+        : repository.updateIfMatch(definition, ifMatches);
+  }
+
+  private void validateUpdate(Errors errors, String name, Authentication auth) {
+    if (!isNameInUse(name)) {
+      errors.rejectValue(
+          "name",
+          CredentialsDefinitionErrorCode.NOT_FOUND.getErrorCode(),
+          "Cannot update an account which does not exist");
+    } else if (shouldDenyWritePermission(auth, name)) {
+      errors.reject(
+          CredentialsDefinitionErrorCode.UNAUTHORIZED.getErrorCode(),
+          "Unauthorized to overwrite existing account");
+    }
+  }
+
+  public CredentialsView.Metadata save(
+      @Valid CredentialsDefinition definition, Authentication auth) {
+    validate(new ValidateCredentialsMutation.Save(List.of(definition)), auth);
+    return repository.save(definition);
+  }
+
+  public List<CredentialsView> saveAll(
+      List<@Valid CredentialsDefinition> definitions, Authentication auth) {
+    validate(new ValidateCredentialsMutation.Save(definitions), auth);
+    return repository.saveAll(definitions);
+  }
+
+  private void validateSave(Errors errors, String name, Authentication auth) {
+    if (isNameInUse(name) && shouldDenyWritePermission(auth, name)) {
+      errors.reject(
+          CredentialsDefinitionErrorCode.UNAUTHORIZED.getErrorCode(),
+          "Unauthorized to overwrite existing account");
+    }
+  }
+
+  public void delete(@NotBlank String accountName, Authentication auth) {
+    if (shouldDenyWritePermission(auth, accountName)) {
+      throw new AccessDeniedException(
+          String.format("Unauthorized to delete account '%s'", accountName));
+    }
+    repository.delete(accountName);
+  }
+
+  public void deleteAll(Collection<@NotBlank String> accountNames, Authentication auth) {
+    Set<String> unauthorizedAccountNamesToDelete =
+        accountNames.stream()
+            .filter(name -> shouldDenyWritePermission(auth, name))
+            .collect(Collectors.toSet());
+    if (!unauthorizedAccountNamesToDelete.isEmpty()) {
+      throw new AccessDeniedException(
+          "Unauthorized to delete account(s): " + unauthorizedAccountNamesToDelete);
+    }
+    repository.deleteAll(accountNames);
+  }
+
+  public List<CredentialsDefinitionRepository.Revision> revisionHistory(
+      @NotBlank String accountName) {
+    return repository.revisionHistory(accountName);
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CredentialsInspector.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CredentialsInspector.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.service;
+
+import com.netflix.spinnaker.credentials.CredentialsError;
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsNavigator;
+import com.netflix.spinnaker.credentials.validator.CredentialsDefinitionErrorCode;
+import com.netflix.spinnaker.security.AccessControlled;
+import com.netflix.spinnaker.security.Authorization;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+@Log4j2
+public class CredentialsInspector {
+  private final List<CredentialsNavigator<? extends CredentialsDefinition>> navigators;
+  private final PermissionEvaluator permissionEvaluator;
+
+  public CredentialsInspector(
+      ObjectProvider<CredentialsDefinitionSource<? extends CredentialsDefinition>> sources,
+      PermissionEvaluator permissionEvaluator) {
+    List<CredentialsNavigator<? extends CredentialsDefinition>> navigators = new ArrayList<>();
+    for (CredentialsDefinitionSource<? extends CredentialsDefinition> source : sources) {
+      if (source instanceof CredentialsNavigator<?>) {
+        CredentialsNavigator<? extends CredentialsDefinition> navigator =
+            (CredentialsNavigator<? extends CredentialsDefinition>) source;
+        navigators.add(navigator);
+      } else {
+        log.warn("Unable to navigate credentials source {}", source.getClass());
+      }
+    }
+    this.navigators = Collections.unmodifiableList(navigators);
+    this.permissionEvaluator = permissionEvaluator;
+  }
+
+  /**
+   * Enumerates and inspects all credential definitions the given authenticated user has access to.
+   * This combines all {@link CredentialsDefinitionRepository} and {@link
+   * CredentialsDefinitionSource} definitions. The resulting list of credentials should be checked
+   * for duplicate account names. Credentials with permissions defined should be filtered in or out
+   * of the resulting list depending on whether the user has {@link Authorization#READ} permission.
+   *
+   * @param auth the authenticated user to inspect credentials for
+   * @return a list of views into the inspected credentials
+   */
+  public List<CredentialsView> listCredentialsViews(Authentication auth) {
+    Set<String> validNames = new HashSet<>();
+    return navigators.stream()
+        .flatMap(navigator -> navigator.listCredentialsViews().stream())
+        .map(
+            view -> {
+              var status = view.getStatus();
+              var spec = view.getSpec();
+              if (spec instanceof AccessControlled
+                  && !permissionEvaluator.hasPermission(auth, spec, Authorization.READ)) {
+                // remove unauthorized accounts from results
+                return null;
+              }
+              if (status.isValid() && !validNames.add(view.getMetadata().getName())) {
+                status.setValid(false);
+                status.setErrors(
+                    List.of(
+                        new CredentialsError(
+                            CredentialsDefinitionErrorCode.DUPLICATE_NAME.getErrorCode(),
+                            "Duplicate account name",
+                            "name")));
+              }
+              return view;
+            })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CredentialsInspector.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CredentialsInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,19 +19,16 @@ package com.netflix.spinnaker.credentials.service;
 import com.netflix.spinnaker.credentials.CredentialsError;
 import com.netflix.spinnaker.credentials.CredentialsView;
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
-import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
-import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
 import com.netflix.spinnaker.credentials.definition.CredentialsNavigator;
 import com.netflix.spinnaker.credentials.validator.CredentialsDefinitionErrorCode;
 import com.netflix.spinnaker.security.AccessControlled;
 import com.netflix.spinnaker.security.Authorization;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.security.access.PermissionEvaluator;
@@ -40,33 +37,19 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Log4j2
+@RequiredArgsConstructor
 public class CredentialsInspector {
-  private final List<CredentialsNavigator<? extends CredentialsDefinition>> navigators;
+  // as this class is instantiated before all credentials-related beans have been defined, this must
+  // use lazy loading of beans via ObjectProvider instead of a List or similar collection
+  private final ObjectProvider<CredentialsNavigator<? extends CredentialsDefinition>> navigators;
   private final PermissionEvaluator permissionEvaluator;
-
-  public CredentialsInspector(
-      ObjectProvider<CredentialsDefinitionSource<? extends CredentialsDefinition>> sources,
-      PermissionEvaluator permissionEvaluator) {
-    List<CredentialsNavigator<? extends CredentialsDefinition>> navigators = new ArrayList<>();
-    for (CredentialsDefinitionSource<? extends CredentialsDefinition> source : sources) {
-      if (source instanceof CredentialsNavigator<?>) {
-        CredentialsNavigator<? extends CredentialsDefinition> navigator =
-            (CredentialsNavigator<? extends CredentialsDefinition>) source;
-        navigators.add(navigator);
-      } else {
-        log.warn("Unable to navigate credentials source {}", source.getClass());
-      }
-    }
-    this.navigators = Collections.unmodifiableList(navigators);
-    this.permissionEvaluator = permissionEvaluator;
-  }
 
   /**
    * Enumerates and inspects all credential definitions the given authenticated user has access to.
-   * This combines all {@link CredentialsDefinitionRepository} and {@link
-   * CredentialsDefinitionSource} definitions. The resulting list of credentials should be checked
-   * for duplicate account names. Credentials with permissions defined should be filtered in or out
-   * of the resulting list depending on whether the user has {@link Authorization#READ} permission.
+   * This combines all {@link CredentialsNavigator} beans to iterate over credentials definitions.
+   * The resulting list of credentials is checked for duplicate account names. Credentials with
+   * permissions defined are filtered in or out of the resulting list depending on whether the user
+   * has {@link Authorization#READ} permission.
    *
    * @param auth the authenticated user to inspect credentials for
    * @return a list of views into the inspected credentials

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CredentialsServiceConfiguration.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/CredentialsServiceConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.service;
+
+import com.netflix.spinnaker.credentials.ConditionalOnSelfServiceEnabled;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/** Configures the service layer beans for credentials. */
+@Configuration
+@ComponentScan
+@ConditionalOnSelfServiceEnabled
+public class CredentialsServiceConfiguration {}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/ValidateCredentialsMutation.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/ValidateCredentialsMutation.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials.service;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(ValidateCredentialsMutation.Create.class),
+  @JsonSubTypes.Type(ValidateCredentialsMutation.Update.class),
+  @JsonSubTypes.Type(ValidateCredentialsMutation.Save.class),
+  @JsonSubTypes.Type(ValidateCredentialsMutation.Delete.class)
+})
+public interface ValidateCredentialsMutation {
+  @Value
+  @Builder
+  @Jacksonized
+  @JsonTypeName("create")
+  class Create implements ValidateCredentialsMutation {
+    @Valid @NotNull CredentialsDefinition credentials;
+  }
+
+  @Value
+  @Builder
+  @Jacksonized
+  @JsonTypeName("update")
+  class Update implements ValidateCredentialsMutation {
+    @Valid @NotNull CredentialsDefinition credentials;
+  }
+
+  @Value
+  @Builder
+  @Jacksonized
+  @JsonTypeName("save")
+  class Save implements ValidateCredentialsMutation {
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    @Singular
+    @NotEmpty
+    List<@Valid @NotNull CredentialsDefinition> credentials;
+  }
+
+  @Value
+  @Builder
+  @Jacksonized
+  @JsonTypeName("delete")
+  class Delete implements ValidateCredentialsMutation {
+    @Singular @NotEmpty List<@NotBlank String> credentials;
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/package-info.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/service/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+@NonnullByDefault
+package com.netflix.spinnaker.credentials.service;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/CredentialsDefinitionMixin.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/CredentialsDefinitionMixin.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+
+/**
+ * Jackson mixin to add a polymorphic type name value. When a {@link CredentialsDefinition}
+ * implementation class is annotated with {@link JsonTypeName}, then the value of that annotation is
+ * used as the {@code type} property value when marshalling and unmarshalling CredentialsDefinition
+ * classes. It is recommended that the corresponding cloud provider name for the credentials be used
+ * here.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+public interface CredentialsDefinitionMixin {}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/CredentialsDefinitionModule.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/CredentialsDefinitionModule.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.credentials.types;
+
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionTypeProvider;
+import org.springframework.stereotype.Component;
+
+/**
+ * Jackson module to register {@link CredentialsDefinition} type discriminators for the provided
+ * account definition types. Type discriminators are determined by the presence of a {@link
+ * com.netflix.spinnaker.credentials.definition.CredentialsType} annotation. Plugins should export
+ * their account definition types via {@link CredentialsDefinitionTypeProvider} beans.
+ */
+@Component
+public class CredentialsDefinitionModule extends SimpleModule {
+
+  private final NamedType[] accountDefinitionTypes;
+
+  public CredentialsDefinitionModule(CredentialsDefinitionTypeMap typeMap) {
+    super("Credentials Definition API");
+    accountDefinitionTypes = typeMap.asNamedTypes();
+  }
+
+  @Override
+  public void setupModule(SetupContext context) {
+    super.setupModule(context);
+    context.setMixInAnnotations(CredentialsDefinition.class, CredentialsDefinitionMixin.class);
+    context.registerSubtypes(accountDefinitionTypes);
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/CredentialsDefinitionTypeMap.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/CredentialsDefinitionTypeMap.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.credentials.types;
+
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionTypeProvider;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/**
+ * Holds credential type discriminator mappings to corresponding {@link CredentialsDefinition}
+ * classes.
+ */
+@Component
+@NonnullByDefault
+public class CredentialsDefinitionTypeMap {
+  private final Map<String, Class<? extends CredentialsDefinition>> discoveredTypes;
+
+  public CredentialsDefinitionTypeMap(
+      ObjectProvider<CredentialsDefinitionTypeProvider> typeProviders) {
+    Map<String, Class<? extends CredentialsDefinition>> types = new HashMap<>();
+    typeProviders.forEach(provider -> types.putAll(provider.getCredentialsTypes()));
+    discoveredTypes = Map.copyOf(types);
+  }
+
+  /** Returns all known credential type discriminator names. */
+  public Collection<String> getSupportedTypeNames() {
+    return discoveredTypes.keySet();
+  }
+
+  /** Returns all known credential types adapted into Jackson {@link NamedType} objects. */
+  NamedType[] asNamedTypes() {
+    return discoveredTypes.entrySet().stream()
+        .map(e -> new NamedType(e.getValue(), e.getKey()))
+        .distinct()
+        .toArray(NamedType[]::new);
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/CredentialsDefinitionTypeProperties.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/CredentialsDefinitionTypeProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.types;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionTypeProvider;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class CredentialsDefinitionTypeProperties {
+  /**
+   * Additional packages to scan for {@link
+   * com.netflix.spinnaker.credentials.definition.CredentialsDefinition} implementation classes that
+   * may be annotated with {@link CredentialsType} to participate in the account management system.
+   * These packages are in addition to the default scan package from within Clouddriver. Note that
+   * this configuration option only works for account types that are compiled in Spinnaker; plugin
+   * account types must register a {@link CredentialsDefinitionTypeProvider} bean for additional
+   * types.
+   */
+  private List<String> additionalScanPackages = List.of();
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/CredentialsDefinitionTypesConfiguration.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/CredentialsDefinitionTypesConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.types;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides configuration settings related to managing credential definitions at runtime.
+ *
+ * @see CredentialsDefinitionTypeProperties
+ */
+@Configuration
+@EnableConfigurationProperties
+@Log4j2
+@ComponentScan
+public class CredentialsDefinitionTypesConfiguration {
+  @Bean
+  @ConfigurationProperties("credentials.types")
+  public CredentialsDefinitionTypeProperties credentialsDefinitionTypeProperties() {
+    return new CredentialsDefinitionTypeProperties();
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/DefaultCredentialsDefinitionTypeExtractor.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/DefaultCredentialsDefinitionTypeExtractor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.types;
+
+import com.netflix.spinnaker.credentials.CredentialsTypes;
+import com.netflix.spinnaker.credentials.constraint.CredentialsDefinitionTypeExtractor;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provides a default implementation for {@link CredentialsDefinitionTypeExtractor} which checks for
+ * a {@link com.netflix.spinnaker.credentials.definition.CredentialsType} annotation.
+ *
+ * @see CredentialsTypes
+ */
+@Component
+public class DefaultCredentialsDefinitionTypeExtractor
+    implements CredentialsDefinitionTypeExtractor {
+  @Nullable
+  @Override
+  public String getCredentialsType(@Nonnull CredentialsDefinition definition) {
+    return CredentialsTypes.getCredentialsTypeName(definition.getClass());
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/DefaultCredentialsDefinitionTypeProvider.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/types/DefaultCredentialsDefinitionTypeProvider.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.types;
+
+import com.netflix.spinnaker.credentials.CredentialsTypes;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionTypeProvider;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.plugins.SpinnakerPluginManager;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Exports all discovered account definition types from scanning the classpath. Plugins may register
+ * additional provider beans to register additional account types to support in {@link
+ * CredentialsDefinitionRepository}.
+ */
+@Component
+@NonnullByDefault
+@Log4j2
+public class DefaultCredentialsDefinitionTypeProvider implements CredentialsDefinitionTypeProvider {
+  private final ResourceLoader resourceLoader;
+  private final ObjectProvider<SpinnakerPluginManager> pluginManagerProvider;
+  private final List<String> scanPackages;
+
+  private final Counter credentialsDefinitionClassLoadFailures =
+      Metrics.counter("credentials.types.classLoadError");
+
+  public DefaultCredentialsDefinitionTypeProvider(
+      ResourceLoader resourceLoader,
+      ObjectProvider<SpinnakerPluginManager> pluginManagerProvider,
+      CredentialsDefinitionTypeProperties properties) {
+    this.resourceLoader = resourceLoader;
+    this.pluginManagerProvider = pluginManagerProvider;
+    scanPackages = new ArrayList<>();
+    // most classes in spinnaker are packaged under com.netflix.spinnaker;
+    // however, kayenta is packaged under com.netflix.kayenta
+    scanPackages.add("com.netflix");
+    scanPackages.addAll(properties.getAdditionalScanPackages());
+  }
+
+  @Override
+  public Map<String, Class<? extends CredentialsDefinition>> getCredentialsTypes() {
+    var allScannables = new HashMap<String, ResourceLoader>();
+
+    // Load all type providers from main app classes and configuration
+    scanPackages.forEach(sp -> allScannables.put(sp, resourceLoader));
+
+    // Load all defined type providers from plugins
+    SpinnakerPluginManager pluginManager = pluginManagerProvider.getIfAvailable();
+    if (pluginManager != null) {
+      pluginManager
+          .getStartedPlugins()
+          .forEach(
+              p -> {
+                var pluginLoader = p.getPluginClassLoader();
+                for (var pkg : p.getPluginClassLoader().getDefinedPackages()) {
+                  allScannables.put(pkg.getName(), new DefaultResourceLoader(pluginLoader));
+                }
+              });
+    }
+
+    return allScannables.entrySet().stream()
+        .flatMap(
+            e -> {
+              var provider = new ClassPathScanningCandidateComponentProvider(false);
+              provider.setResourceLoader(e.getValue());
+              provider.addIncludeFilter(new AssignableTypeFilter(CredentialsDefinition.class));
+              return provider.findCandidateComponents(e.getKey()).stream()
+                  .map(
+                      beanDefinition ->
+                          tryLoadAccountDefinitionClassName(
+                              beanDefinition, e.getValue().getClassLoader()));
+            })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a));
+  }
+
+  @Nullable
+  private Map.Entry<String, Class<? extends CredentialsDefinition>>
+      tryLoadAccountDefinitionClassName(
+          BeanDefinition beanDefinition, @Nullable ClassLoader classLoader) {
+    var className = beanDefinition.getBeanClassName();
+    if (className == null) {
+      return null;
+    }
+
+    try {
+      Class<? extends CredentialsDefinition> subtype =
+          ClassUtils.forName(className, classLoader).asSubclass(CredentialsDefinition.class);
+      String typeName = CredentialsTypes.getCredentialsTypeName(subtype);
+      if (typeName != null) {
+        log.info("Discovered credentials definition type '{}' from class '{}'", typeName, subtype);
+        return Map.entry(typeName, subtype);
+      } else {
+        log.info(
+            "Skipping CredentialsDefinition class '{}' as it does not define a @CredentialsType annotation",
+            subtype);
+      }
+    } catch (ClassNotFoundException e) {
+      log.warn(
+          "Unable to load CredentialsDefinition class '{}'. Credentials with this type will not be loaded.",
+          className,
+          e);
+      credentialsDefinitionClassLoadFailures.increment();
+    }
+    return null;
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/AbstractCredentialsDefinitionValidator.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/AbstractCredentialsDefinitionValidator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import com.netflix.spinnaker.credentials.constraint.CredentialsDefinitionValidator;
+import java.net.URL;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * A base class for {@link CredentialsDefinitionValidator} implementations. Provides common methods
+ * used by the validators.
+ */
+@Log4j2
+public abstract class AbstractCredentialsDefinitionValidator
+    implements CredentialsDefinitionValidator {
+
+  protected boolean emptyOptionalAndValue(final Optional<String> optValue) {
+    return optValue.isEmpty() || (optValue.get() == null || optValue.get().isEmpty());
+  }
+
+  protected boolean isValidUrl(final String endpoint) {
+    if (endpoint == null || endpoint.isEmpty()) {
+      return false;
+    }
+    try {
+      new URL(endpoint).toURI();
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  protected boolean logAndReturnValidationFailure(
+      final ConstraintValidatorContext context, String fieldName, String message) {
+    log.info("Account validation error for field '{}': {}", fieldName, message);
+    context
+        .buildConstraintViolationWithTemplate(message)
+        .addPropertyNode(fieldName)
+        .addConstraintViolation();
+    return false;
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/AccessControlledCredentialsDefinitionValidator.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/AccessControlledCredentialsDefinitionValidator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import com.netflix.spinnaker.credentials.constraint.CredentialsDefinitionValidator;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.security.AccessControlled;
+import com.netflix.spinnaker.security.Authorization;
+import com.netflix.spinnaker.security.SpinnakerAuthorities;
+import javax.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.PropertyAccessorFactory;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validates that an authenticated user has authorization to write with credentials. This helps to
+ * prevent users from inadvertently locking themselves out from their own credentials.
+ */
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class AccessControlledCredentialsDefinitionValidator
+    implements CredentialsDefinitionValidator {
+  private final PermissionEvaluator permissionEvaluator;
+
+  @Override
+  public boolean isValid(CredentialsDefinition value, ConstraintValidatorContext context) {
+    if (!(value instanceof AccessControlled)) {
+      // not our problem
+      return true;
+    }
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    // when authentication is an admin user, they can't lock themselves out
+    if (SpinnakerAuthorities.isAdmin(authentication)) {
+      return true;
+    }
+    if (authentication == null) {
+      context
+          .buildConstraintViolationWithTemplate("no authenticated user found")
+          .addConstraintViolation();
+      return false;
+    }
+    if (!permissionEvaluator.hasPermission(authentication, value, Authorization.WRITE)) {
+      BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(value);
+      String property = wrapper.isReadableProperty("permissions") ? "permissions" : "roles";
+      log.debug(
+          "No write permission granted to account {} in {} to {}",
+          value.getName(),
+          wrapper.getPropertyValue(property),
+          authentication);
+      context
+          .buildConstraintViolationWithTemplate("no write permission granted to current user")
+          .addPropertyNode(property)
+          .addConstraintViolation();
+      return false;
+    }
+    return true;
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/CredentialsDefinitionErrorCode.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/CredentialsDefinitionErrorCode.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import lombok.Getter;
+
+public enum CredentialsDefinitionErrorCode {
+  DUPLICATE_NAME("name.duplicate"),
+  MISSING_NAME("name.missing"),
+  MISSING_TYPE("type.missing"),
+  NOT_FOUND("missing"),
+  UNAUTHORIZED("unauthorized"),
+  INVALID_NAME("name.invalid"),
+  INVALID_SYNTAX("syntax.invalid"),
+  INVALID_STRUCTURE("structure.invalid"),
+  INVALID_BINDING("binding.invalid"),
+  INVALID_PERMISSIONS("permissions.invalid"),
+  ;
+
+  @Getter private final String errorCode;
+
+  CredentialsDefinitionErrorCode(String errorCode) {
+    this.errorCode = "credentials." + errorCode;
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/CredentialsDefinitionValidatorConfiguration.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/CredentialsDefinitionValidatorConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import com.netflix.spinnaker.credentials.constraint.CredentialsDefinitionValidator;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBindHandlerAdvisor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/** Configures integration with {@link CredentialsDefinitionValidator}. */
+@Configuration
+@ComponentScan
+@EnableConfigurationProperties(CredentialsDefinitionValidatorProperties.class)
+public class CredentialsDefinitionValidatorConfiguration {
+  @Bean
+  public ConfigurationPropertiesBindHandlerAdvisor systemContextBindHandlerAdvisor() {
+    return SystemContextBindHandler::new;
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/CredentialsDefinitionValidatorProperties.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/CredentialsDefinitionValidatorProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("credentials.validator")
+public class CredentialsDefinitionValidatorProperties {
+  private static final Pattern DEFAULT_VALID_ACCOUNT_NAME_PATTERN =
+      Pattern.compile("[a-zA-Z][-_a-zA-Z0-9]+[a-zA-Z0-9]");
+
+  /**
+   * Specifies the pattern to validate allowed account names by account type. Account types without
+   * a pattern defined here will use the default validation pattern that checks for a letter at the
+   * beginning, an alphanumeric character at the end, and alphanumeric characters, hyphens, and
+   * underscores in-between.
+   */
+  private Map<String, Pattern> validAccountNamePatterns = Map.of();
+
+  public Pattern getValidAccountNamePattern(String accountType) {
+    return validAccountNamePatterns.getOrDefault(accountType, DEFAULT_VALID_ACCOUNT_NAME_PATTERN);
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/DefaultCredentialsDefinitionNamePatternProvider.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/DefaultCredentialsDefinitionNamePatternProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import com.netflix.spinnaker.credentials.constraint.CredentialsDefinitionNamePatternProvider;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default implementation for {@link CredentialsDefinitionNamePatternProvider} using the configured
+ * {@link CredentialsDefinitionValidatorProperties#getValidAccountNamePatterns()}.
+ */
+@Component
+@RequiredArgsConstructor
+public class DefaultCredentialsDefinitionNamePatternProvider
+    implements CredentialsDefinitionNamePatternProvider {
+  private final CredentialsDefinitionValidatorProperties properties;
+
+  @Override
+  public Pattern getPatternForType(String type) {
+    return properties.getValidAccountNamePattern(type);
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/DefaultSecretReferenceValidator.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/DefaultSecretReferenceValidator.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes;
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
+import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
+import com.netflix.spinnaker.kork.secrets.SecretError;
+import com.netflix.spinnaker.kork.secrets.SecretErrorCode;
+import com.netflix.spinnaker.kork.secrets.SecretException;
+import com.netflix.spinnaker.kork.secrets.SecretReferenceValidator;
+import com.netflix.spinnaker.kork.secrets.StandardSecretParameter;
+import com.netflix.spinnaker.kork.secrets.user.UserSecret;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretReference;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretService;
+import com.netflix.spinnaker.security.SpinnakerAuthorities;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class DefaultSecretReferenceValidator implements SecretReferenceValidator {
+  private final UserSecretService secretService;
+
+  @Override
+  public Optional<SecretError> validateUserSecretReference(String uri) {
+    log.debug("Validating user secret reference '{}'", uri);
+    try {
+      UserSecretReference ref = UserSecretReference.parse(uri);
+      UserSecret secret = secretService.getUserSecret(ref);
+      String key = ref.getParameters().get(StandardSecretParameter.KEY.getParameterName());
+      if (key != null) {
+        try {
+          secret.getSecretString(key);
+        } catch (NoSuchElementException e) {
+          return Optional.of(SecretErrorCode.MISSING_USER_SECRET_DATA_KEY);
+        }
+      }
+    } catch (AccessDeniedException e) {
+      log.info("Access denied to user secret reference {}", uri);
+      return Optional.of(SecretErrorCode.DENIED_ACCESS_TO_USER_SECRET);
+    } catch (RuntimeException e) {
+      String message = e.getMessage();
+      if (e instanceof SecretError) {
+        SecretError error = (SecretError) e;
+        log.info("Secret validation error for string '{}': {}", uri, message, e);
+        return Optional.of(error);
+      }
+      log.info("Unable to decrypt secret '{}'", uri, e);
+      return Optional.of(translateException(e, SecretErrorCode.USER_SECRET_DECRYPTION_FAILURE));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<SecretError> validateExternalSecretReference(String uri) {
+    log.debug("Validating external secret reference '{}'", uri);
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (!SpinnakerAuthorities.isAdmin(authentication)) {
+      return Optional.of(SecretErrorCode.DENIED_ACCESS_TO_EXTERNAL_SECRET);
+    }
+    try {
+      EncryptedSecret ref = EncryptedSecret.parse(uri);
+      if (ref == null) {
+        log.info("Unable to parse external secret URI string '{}'", uri);
+        return Optional.of(SecretErrorCode.INVALID_EXTERNAL_SECRET_URI);
+      }
+      secretService.checkExternalSecret(ref);
+    } catch (InvalidSecretFormatException e) {
+      log.info("Invalid external secret URI format for string '{}'", uri, e);
+      return Optional.of(translateException(e, SecretErrorCode.INVALID_EXTERNAL_SECRET_URI));
+    } catch (SecretException e) {
+      log.info("Unable to decrypt external secret reference '{}'", uri, e);
+      return Optional.of(translateException(e, SecretErrorCode.EXTERNAL_SECRET_DECRYPTION_FAILURE));
+    }
+    return Optional.empty();
+  }
+
+  private static GenericSecretError translateException(
+      Throwable throwable, SecretErrorCode errorCode) {
+    String message = throwable.getMessage();
+    if (!StringUtils.hasText(message)) {
+      message = errorCode.getMessage();
+    }
+    var builder = GenericSecretError.builder().message(message).errorCode(errorCode.getErrorCode());
+    if (throwable instanceof HasAdditionalAttributes) {
+      builder.additionalAttributes(((HasAdditionalAttributes) throwable).getAdditionalAttributes());
+    }
+    return builder.build();
+  }
+
+  @Getter
+  @Builder
+  private static class GenericSecretError implements SecretError {
+    private final String errorCode;
+    private final String message;
+    @Builder.Default private final Map<String, Object> additionalAttributes = Map.of();
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/SystemContextBindHandler.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/SystemContextBindHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.security.SystemUser;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBindHandlerAdvisor;
+import org.springframework.boot.context.properties.bind.AbstractBindHandler;
+import org.springframework.boot.context.properties.bind.BindContext;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.core.ResolvableType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Provides a synthetic authenticated {@link SystemUser} when validating configuration property
+ * bindings. This needs to be registered in a {@link ConfigurationPropertiesBindHandlerAdvisor} bean
+ * to be used by Spring Boot when binding {@link ConfigurationProperties} classes.
+ */
+@Log4j2
+public class SystemContextBindHandler extends AbstractBindHandler {
+  private static final ResolvableType CREDENTIALS_DEFINITION_TYPE =
+      ResolvableType.forClass(CredentialsDefinition.class);
+
+  public SystemContextBindHandler(BindHandler parent) {
+    super(parent);
+  }
+
+  @Override
+  public void onFinish(
+      ConfigurationPropertyName name, Bindable<?> target, BindContext context, Object result)
+      throws Exception {
+    if (CREDENTIALS_DEFINITION_TYPE.isAssignableFrom(target.getType())) {
+      SecurityContext securityContext = SecurityContextHolder.getContext();
+      Authentication previousAuthentication = securityContext.getAuthentication();
+      securityContext.setAuthentication(SystemUser.getInstance());
+      try {
+        super.onFinish(name, target, context, result);
+      } finally {
+        securityContext.setAuthentication(previousAuthentication);
+      }
+    }
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/UserSecretsValidator.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/UserSecretsValidator.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.netflix.spinnaker.credentials.constraint.CredentialsDefinitionValidator;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.kork.api.exceptions.ConstraintViolation;
+import com.netflix.spinnaker.kork.api.exceptions.ConstraintViolationContext;
+import com.netflix.spinnaker.kork.secrets.SecretErrorCode;
+import com.netflix.spinnaker.kork.secrets.SecretReferenceValidator;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretReference;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import javax.annotation.Nullable;
+import javax.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.PropertyAccessorFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+/**
+ * Validates that {@link UserSecretReference} strings point to valid user secrets that the current
+ * user is authorized to use.
+ */
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class UserSecretsValidator implements CredentialsDefinitionValidator, Validator {
+
+  private final SecretReferenceValidator secretReferenceValidator;
+  private final ObjectProvider<ConstraintViolationContext> constraintViolationContextProvider;
+
+  @Override
+  public boolean supports(Class<?> clazz) {
+    return CredentialsDefinition.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public void validate(Object target, Errors errors) {
+    log.debug("Validating user secrets in account");
+    BeanWrapper bean = PropertyAccessorFactory.forBeanPropertyAccess(target);
+    forEachNonNullStringProperty(
+        bean,
+        (name, value) ->
+            secretReferenceValidator
+                .validate(value)
+                .ifPresent(
+                    error -> {
+                      if (error != SecretErrorCode.DENIED_ACCESS_TO_EXTERNAL_SECRET) {
+                        errors.rejectValue(name, error.getErrorCode(), error.getMessage());
+                        constraintViolationContextProvider.ifAvailable(
+                            details ->
+                                details.addViolation(
+                                    ConstraintViolation.builder()
+                                        .message(error.getMessage())
+                                        .errorCode(error.getErrorCode())
+                                        .path(name)
+                                        .validatedObject(target)
+                                        .invalidValue(value)
+                                        .additionalAttributes(error.getAdditionalAttributes())
+                                        .build()));
+                      }
+                    }));
+  }
+
+  @Override
+  public boolean isValid(CredentialsDefinition value, ConstraintValidatorContext context) {
+    log.debug("Validating user secrets in account");
+    BeanWrapper bean = PropertyAccessorFactory.forBeanPropertyAccess(value);
+    AtomicBoolean invalid = new AtomicBoolean();
+    forEachNonNullStringProperty(
+        bean,
+        (propertyName, propertyValue) ->
+            secretReferenceValidator
+                .validate(propertyValue)
+                .ifPresent(
+                    error -> {
+                      invalid.set(true);
+                      context
+                          .buildConstraintViolationWithTemplate(error.getErrorCode())
+                          .addPropertyNode(propertyName)
+                          .addConstraintViolation();
+                      constraintViolationContextProvider.ifAvailable(
+                          details ->
+                              details.addViolation(
+                                  ConstraintViolation.builder()
+                                      .message(error.getMessage())
+                                      .errorCode(error.getErrorCode())
+                                      .path(propertyName)
+                                      .validatedObject(value)
+                                      .invalidValue(propertyValue)
+                                      .additionalAttributes(error.getAdditionalAttributes())
+                                      .build()));
+                    }));
+    return !invalid.get();
+  }
+
+  private void forEachNonNullStringProperty(BeanWrapper bean, BiConsumer<String, String> consumer) {
+    // as CredentialsDefinitionMapper only considers top-level string properties for injecting
+    // secrets, we only need to consider the top-level bean properties that are string-like along
+    // with the special case for @JsonAnyGetter-annotated properties returning a Map as those may
+    // also have entries whose values are string-like and can have secrets injected
+    for (PropertyDescriptor descriptor : bean.getPropertyDescriptors()) {
+      String propertyName = descriptor.getName();
+      Object propertyValue = bean.getPropertyValue(propertyName);
+      if (propertyValue == null) {
+        continue;
+      }
+      Method readMethod = descriptor.getReadMethod();
+      if (AnnotationUtils.findAnnotation(readMethod, JsonAnyGetter.class) != null
+          && Map.class.isAssignableFrom(readMethod.getReturnType())) {
+        ((Map<?, ?>) propertyValue)
+            .forEach(
+                (key, mapValue) -> {
+                  String value = getStringLikeValue(mapValue);
+                  if (value != null) {
+                    String fullKey = propertyName + '.' + key;
+                    consumer.accept(fullKey, value);
+                  }
+                });
+      } else {
+        String value = getStringLikeValue(propertyValue);
+        if (value != null) {
+          consumer.accept(propertyName, value);
+        }
+      }
+    }
+  }
+
+  @Nullable
+  private static String getStringLikeValue(@Nullable Object value) {
+    if (value instanceof CharSequence) {
+      return ((CharSequence) value).toString();
+    }
+    if (value instanceof Optional<?>) {
+      Object containedValue = ((Optional<?>) value).orElse(null);
+      if (containedValue instanceof CharSequence) {
+        return ((CharSequence) containedValue).toString();
+      }
+    }
+    return null;
+  }
+}

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/package-info.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/validator/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonnullByDefault
+package com.netflix.spinnaker.credentials.validator;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;

--- a/kork-credentials/src/main/resources/META-INF/spring.factories
+++ b/kork-credentials/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.credentials.jackson.SensitiveAutoConfiguration
+  com.netflix.spinnaker.credentials.jackson.SensitiveAutoConfiguration,\
+  com.netflix.spinnaker.credentials.CredentialsAutoConfiguration

--- a/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/secrets/CredentialsDefinitionMapperTest.java
+++ b/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/secrets/CredentialsDefinitionMapperTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.secrets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.credentials.CredentialsAutoConfiguration;
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.security.AccessControlled;
+import com.netflix.spinnaker.security.Authorization;
+import com.netflix.spinnaker.security.SpinnakerAuthorities;
+import io.spinnaker.test.security.TestAccount;
+import io.spinnaker.test.security.ValueAccount;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(
+    properties = "credentials.types.additional-scan-packages=io.spinnaker.test.security")
+class CredentialsDefinitionMapperTest {
+
+  @Autowired ObjectMapper objectMapper;
+  @Autowired CredentialsDefinitionMapper mapper;
+  @MockBean PermissionEvaluator fiatPermissionEvaluator;
+
+  @Test
+  void canConvertAdditionalAccountTypes() throws JsonProcessingException {
+    var account = new TestAccount();
+    account.setData("name", "foo");
+    account.setData("password", "hunter2");
+    Assertions.assertEquals(account, mapper.deserializeWithSecrets(mapper.serialize(account)));
+  }
+
+  @Test
+  void canConvertJacksonizedAccountTypes() throws JsonProcessingException {
+    var account = ValueAccount.builder().name("james").value("meowth").build();
+    assertEquals(account, mapper.deserializeWithSecrets(mapper.serialize(account)));
+  }
+
+  @Test
+  void canDecryptSecretUris() {
+    var data = "{\"type\":\"test\",\"name\":\"bar\",\"password\":\"secret://noop?v=hunter2&k=v\"}";
+    CredentialsDefinition account = assertDoesNotThrow(() -> mapper.deserializeWithSecrets(data));
+    assertThat(account).isInstanceOf(TestAccount.class);
+    assertThat(account.getName()).isEqualTo("bar");
+    TestAccount testAccount = (TestAccount) account;
+    // due to how noop secret engine works, it returns the key's, "k", value, when
+    // getSecretString is called. So we expect the returned value to be "v".
+    org.assertj.core.api.Assertions.assertThat(testAccount.getData().get("password"))
+        .isEqualTo("v");
+  }
+
+  @Test
+  void canDecryptEncryptedUris() {
+    var data = "{\"type\":\"test\",\"name\":\"bar\",\"password\":\"encrypted:noop!v:hunter2\"}";
+    CredentialsDefinition account = assertDoesNotThrow(() -> mapper.deserializeWithSecrets(data));
+    assertThat(account).isInstanceOf(TestAccount.class);
+    assertThat(account.getName()).isEqualTo("bar");
+    TestAccount testAccount = (TestAccount) account;
+    org.assertj.core.api.Assertions.assertThat(testAccount.getData().get("password"))
+        .isEqualTo("hunter2");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "{\"permissions\":{\"READ\":[1,2,3,4,5]}}",
+        "{\"name\":\"foo\",\"permissions\":{\"READ\":[\"0\"]}}",
+        "{\"roles\":[1,2,3,4,5]}",
+        "{\"requiredGroupMembership\":[1,2,3,4,5]}"
+      })
+  void canParseAccessControlledButUnknownAccount(String data) {
+    CredentialsView view = assertDoesNotThrow(() -> mapper.deserializeWithErrors(data));
+    assertThat(view.getStatus().isValid()).isFalse();
+    Object spec = view.getSpec();
+    assertThat(spec)
+        .isNotNull()
+        .isNotInstanceOf(CredentialsDefinition.class)
+        .isInstanceOf(AccessControlled.class);
+    AccessControlled accessControlled = (AccessControlled) spec;
+
+    Authentication authorizedUser =
+        new TestingAuthenticationToken(
+            "test", "test", AuthorityUtils.createAuthorityList("ROLE_0", "ROLE_1"));
+    assertThat(accessControlled.isAuthorized(authorizedUser, Authorization.READ)).isTrue();
+
+    Authentication anonymous =
+        new AnonymousAuthenticationToken(
+            "anonymous", "N/A", Set.of(SpinnakerAuthorities.ANONYMOUS_AUTHORITY));
+    assertThat(accessControlled.isAuthorized(anonymous, Authorization.READ)).isFalse();
+  }
+
+  @Configuration
+  @AutoConfigureJson
+  @ImportAutoConfiguration(CredentialsAutoConfiguration.class)
+  static class TestConfig {}
+}

--- a/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/service/ValidateCredentialsMutationTest.java
+++ b/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/service/ValidateCredentialsMutationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.types.CredentialsDefinitionTypesConfiguration;
+import io.spinnaker.test.security.ValueAccount;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+
+@SpringBootTest(
+    properties = "credentials.types.additional-scan-packages=io.spinnaker.test.security")
+@AutoConfigureJson
+class ValidateCredentialsMutationTest {
+  @Autowired ObjectMapper mapper;
+
+  @Test
+  void ensureSerializationAndDeserializationWorkAsExpected() throws Exception {
+    var credentials = ValueAccount.builder().name("account").value("value").build();
+    assertThat(
+            mapper.readValue(mapper.writeValueAsString(credentials), CredentialsDefinition.class))
+        .isInstanceOf(ValueAccount.class)
+        .isEqualTo(credentials);
+
+    var create = new ValidateCredentialsMutation.Create(credentials);
+    var deserialized =
+        mapper.readValue(mapper.writeValueAsString(create), ValidateCredentialsMutation.class);
+    assertThat(deserialized)
+        .isInstanceOf(ValidateCredentialsMutation.Create.class)
+        .returns(
+            credentials,
+            mutation -> ((ValidateCredentialsMutation.Create) mutation).getCredentials());
+
+    var manualSerialization =
+        "{\"type\":\"save\",\"credentials\":{\"type\":\"value\",\"name\":\"account\",\"value\":\"value\"}}";
+    deserialized = mapper.readValue(manualSerialization, ValidateCredentialsMutation.class);
+    assertThat(deserialized)
+        .isInstanceOf(ValidateCredentialsMutation.Save.class)
+        .returns(
+            credentials,
+            mutation -> ((ValidateCredentialsMutation.Save) mutation).getCredentials().get(0));
+  }
+
+  @Configuration
+  @ImportAutoConfiguration(CredentialsDefinitionTypesConfiguration.class)
+  static class Config {}
+}

--- a/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/validator/CredentialsDefinitionNameValidatorTest.java
+++ b/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/validator/CredentialsDefinitionNameValidatorTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spinnaker.test.security.OverlyFlexibleAccount;
+import io.spinnaker.test.security.ValidatedAccount;
+import io.spinnaker.test.security.ValueAccount;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest(
+    properties = {"credentials.validator.valid-account-name-patterns.validated = f.+bar"})
+class CredentialsDefinitionNameValidatorTest {
+  @MockBean PermissionEvaluator permissionEvaluator;
+  @Autowired Validator validator;
+
+  @BeforeEach
+  void setUp() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new TestingAuthenticationToken("test", "test"));
+  }
+
+  @Test
+  void passesDefaultValidation() {
+    var account = ValueAccount.builder().name("Foo-Bar_Account01").value("hello").build();
+
+    Set<ConstraintViolation<ValueAccount>> violations = validator.validate(account);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void passesExplicitValidation() {
+    var account = new ValidatedAccount();
+    account.setName("foobar");
+    account.setLabel("2000");
+
+    Set<ConstraintViolation<ValidatedAccount>> violations = validator.validate(account);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void failsDefaultValidation() {
+    var account = ValueAccount.builder().name("---illegal-name---").value("hello").build();
+
+    Set<ConstraintViolation<ValueAccount>> violations = validator.validate(account);
+
+    assertThat(violations)
+        .hasSize(1)
+        .first()
+        .extracting(ConstraintViolation::getMessage)
+        .asString()
+        .contains("account name does not match pattern");
+  }
+
+  @Test
+  void failsExplicitValidation() {
+    var account = new ValidatedAccount();
+    account.setName("bar_foo");
+    account.setLabel("2000");
+
+    Set<ConstraintViolation<ValidatedAccount>> violations = validator.validate(account);
+
+    assertThat(violations)
+        .hasSize(1)
+        .first()
+        .extracting(ConstraintViolation::getMessage)
+        .asString()
+        .contains("account name does not match pattern f.+bar");
+  }
+
+  @Test
+  void failsWithNameTooShort() {
+    var account = ValueAccount.builder().name("no").value("yes").build();
+
+    Set<ConstraintViolation<ValueAccount>> violations = validator.validate(account);
+
+    assertThat(violations)
+        .hasSize(1)
+        .first()
+        .extracting(ConstraintViolation::getMessage)
+        .asString()
+        .contains("account name does not match pattern");
+  }
+
+  @Test
+  void failsWithNullName() {
+    var account = new OverlyFlexibleAccount();
+
+    Set<ConstraintViolation<OverlyFlexibleAccount>> violations = validator.validate(account);
+
+    assertThat(violations).hasSize(1);
+  }
+
+  @Test
+  void failsWithEmptyName() {
+    var account = new OverlyFlexibleAccount();
+    account.setName("");
+
+    Set<ConstraintViolation<OverlyFlexibleAccount>> violations = validator.validate(account);
+
+    assertThat(violations).hasSize(1);
+  }
+
+  @Test
+  void failsWithBlankName() {
+    var account = new OverlyFlexibleAccount();
+    account.setName(" \t\r\n");
+
+    Set<ConstraintViolation<OverlyFlexibleAccount>> violations = validator.validate(account);
+
+    assertThat(violations).hasSize(1);
+  }
+
+  @Configuration
+  @EnableAutoConfiguration
+  static class Config {}
+}

--- a/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/validator/DefaultSecretReferenceValidatorTest.java
+++ b/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/validator/DefaultSecretReferenceValidatorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.netflix.spinnaker.kork.secrets.SecretEngine;
+import com.netflix.spinnaker.kork.secrets.SecretErrorCode;
+import com.netflix.spinnaker.kork.secrets.SecretReferenceValidator;
+import com.netflix.spinnaker.kork.secrets.user.StringUserSecretData;
+import com.netflix.spinnaker.kork.secrets.user.UserSecret;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretMetadata;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretReference;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(SecurityTestConfig.class)
+class DefaultSecretReferenceValidatorTest {
+  @MockBean SecretEngine engine;
+  @Autowired SecretReferenceValidator validator;
+
+  String secretUri = "secret://mock?k=v";
+  UserSecretReference secretReference = UserSecretReference.parse(secretUri);
+  UserSecret userSecret =
+      UserSecret.builder()
+          .data(new StringUserSecretData("hunter2"))
+          .metadata(
+              UserSecretMetadata.builder().type("string").roles(List.of("secret-role")).build())
+          .build();
+
+  @BeforeEach
+  void setUp() {
+    given(engine.identifier()).willReturn("mock");
+  }
+
+  @Test
+  @WithMockUser
+  void unauthorizedUserIsDeniedAccessToUserSecret() {
+    given(engine.decrypt(secretReference)).willReturn(userSecret);
+
+    assertThat(validator.validate(secretUri))
+        .isPresent()
+        .hasValue(SecretErrorCode.DENIED_ACCESS_TO_USER_SECRET);
+  }
+
+  @Test
+  @WithMockUser(roles = "secret-role")
+  void authorizedUserCanAccessUserSecret() {
+    given(engine.decrypt(secretReference)).willReturn(userSecret);
+
+    assertThat(validator.validate(secretUri)).isEmpty();
+  }
+}

--- a/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/validator/SecurityTestConfig.java
+++ b/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/validator/SecurityTestConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import com.netflix.spinnaker.security.AbstractPermissionEvaluator;
+import java.io.Serializable;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+
+@Configuration(proxyBeanMethods = false)
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableAutoConfiguration
+public class SecurityTestConfig {
+  @Bean
+  PermissionEvaluator permissionEvaluator() {
+    return new AbstractPermissionEvaluator() {
+      @Override
+      public boolean hasPermission(
+          String username, Serializable targetId, String targetType, Object permission) {
+        return false;
+      }
+    };
+  }
+}

--- a/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/validator/UserSecretsValidatorTest.java
+++ b/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/validator/UserSecretsValidatorTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
+import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
+import com.netflix.spinnaker.kork.secrets.SecretEngine;
+import com.netflix.spinnaker.kork.secrets.SecretException;
+import com.netflix.spinnaker.kork.secrets.user.OpaqueUserSecretData;
+import com.netflix.spinnaker.kork.secrets.user.StringUserSecretData;
+import com.netflix.spinnaker.kork.secrets.user.UserSecret;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretData;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretMetadata;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretReference;
+import com.netflix.spinnaker.security.SpinnakerAuthorities;
+import io.spinnaker.test.security.OptionalFieldAccount;
+import io.spinnaker.test.security.TestAccount;
+import io.spinnaker.test.security.ValueAccount;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.bind.BindException;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.bind.validation.ValidationBindHandler;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
+
+@SpringJUnitConfig(SecurityTestConfig.class)
+class UserSecretsValidatorTest {
+
+  @MockBean SecretEngine mockSecretEngine;
+  @Autowired Validator validator;
+
+  UserSecret userSecret =
+      UserSecret.builder()
+          .data(new StringUserSecretData("hunter2"))
+          .metadata(
+              UserSecretMetadata.builder().type("string").roles(List.of("secret-role")).build())
+          .build();
+  String secretUri = "secret://mock?k=v";
+  UserSecretReference ref = UserSecretReference.parse(secretUri);
+
+  @BeforeEach
+  void setUp() {
+    given(mockSecretEngine.identifier()).willReturn("mock");
+  }
+
+  @Test
+  @WithMockUser(roles = "secret-role")
+  void canUseAuthorizedUserSecret() {
+    given(mockSecretEngine.decrypt(eq(ref))).willReturn(userSecret);
+    ValueAccount account = ValueAccount.builder().name("elmer").value(secretUri).build();
+
+    Set<ConstraintViolation<ValueAccount>> violations = validator.validate(account);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @WithMockUser
+  void cannotUseUnauthorizedUserSecret() {
+    given(mockSecretEngine.decrypt(eq(ref))).willReturn(userSecret);
+    ValueAccount account = ValueAccount.builder().name("daffy").value(secretUri).build();
+
+    Set<ConstraintViolation<ValueAccount>> violations = validator.validate(account);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @WithMockUser
+  void cannotUseUnauthorizedUserSecretInOptionalFields() {
+    given(mockSecretEngine.decrypt(eq(ref))).willReturn(userSecret);
+    OptionalFieldAccount account =
+        OptionalFieldAccount.builder().name("opt").secret(Optional.of(secretUri)).build();
+
+    var violations = validator.validate(account);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @WithMockUser
+  void cannotUseUnauthorizedUserSecretInJsonAnyGetterMapValues() {
+    given(mockSecretEngine.decrypt(eq(ref))).willReturn(userSecret);
+    TestAccount account = new TestAccount();
+    account.setData("name", "opt");
+    account.setData("client-secret", secretUri);
+
+    var violations = validator.validate(account);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @WithMockUser
+  void cannotUseUnauthorizedUserSecretInJsonAnyGetterMapOptionalValues() {
+    given(mockSecretEngine.decrypt(eq(ref))).willReturn(userSecret);
+    TestAccount account = new TestAccount();
+    account.setData("name", "opt");
+    account.setData("client-secret", Optional.of(secretUri));
+
+    var violations = validator.validate(account);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @WithMockUser
+  void cannotUseEncryptedSecretWithoutAdmin() {
+    given(mockSecretEngine.decrypt(eq(ref))).willReturn(userSecret);
+    ValueAccount account =
+        ValueAccount.builder().name("donald").value("encrypted:mock!fake:yes").build();
+
+    Set<ConstraintViolation<ValueAccount>> violations = validator.validate(account);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @WithMockUser(authorities = SpinnakerAuthorities.ADMIN)
+  void canUseEncryptedSecretWhenAdmin() {
+    given(mockSecretEngine.decrypt(eq(ref))).willReturn(userSecret);
+    ValueAccount account =
+        ValueAccount.builder().name("donald").value("encrypted:mock!fake:yes").build();
+
+    Set<ConstraintViolation<ValueAccount>> violations = validator.validate(account);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @WithMockUser
+  void canUseEncryptedSecretWhenSystemContextBindHandlerUsed() {
+    Map<String, String> properties =
+        Map.of("account.name", "donald", "account.value", "encrypted:mock!fake:yes");
+    Binder binder = new Binder(new MapConfigurationPropertySource(properties));
+    Bindable<ValueAccount> bindable = Bindable.of(ValueAccount.class);
+
+    assertThrows(
+        BindException.class, () -> binder.bindOrCreate("account", bindable, getBindHandler()));
+
+    assertDoesNotThrow(
+        () ->
+            binder.bindOrCreate(
+                "account", bindable, new SystemContextBindHandler(getBindHandler())));
+  }
+
+  private BindHandler getBindHandler() {
+    return new ValidationBindHandler(new SpringValidatorAdapter(validator));
+  }
+
+  @Test
+  @WithMockUser
+  void cannotUseEncryptedSecretWithDecryptError() {
+    String secretUri = "encrypted:mock!fake:yes";
+    EncryptedSecret ref = EncryptedSecret.parse(secretUri);
+    assertNotNull(ref);
+    ValueAccount account = ValueAccount.builder().name("donald").value(secretUri).build();
+    given(mockSecretEngine.decrypt(eq(ref))).willThrow(SecretDecryptionException.class);
+
+    Set<ConstraintViolation<ValueAccount>> violations = validator.validate(account);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @WithMockUser
+  void doesNotBreakWhenSecretExceptionIsThrown() {
+    given(mockSecretEngine.decrypt(eq(ref))).willThrow(SecretException.class);
+
+    ValueAccount account = ValueAccount.builder().name("error").value(secretUri).build();
+
+    Set<ConstraintViolation<ValueAccount>> violations = validator.validate(account);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @WithMockUser
+  void verifiesKeyExistsInSecret() {
+    String secretUri = "secret://mock?k=foo";
+    UserSecretReference ref = UserSecretReference.parse(secretUri);
+    assertNotNull(ref);
+    UserSecretMetadata metadata =
+        UserSecretMetadata.builder().type("opaque").encoding("json").roles(List.of("user")).build();
+    UserSecretData data = new OpaqueUserSecretData(Map.of());
+    UserSecret secret = UserSecret.builder().metadata(metadata).data(data).build();
+    given(mockSecretEngine.decrypt(eq(ref))).willReturn(secret);
+
+    ValueAccount account = ValueAccount.builder().name("missing-key").value(secretUri).build();
+
+    Set<ConstraintViolation<ValueAccount>> violations = validator.validate(account);
+    assertThat(violations).isNotEmpty();
+  }
+}

--- a/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/validator/ValidatedAccountNameConstraintValidatorTest.java
+++ b/kork-credentials/src/test/java/com/netflix/spinnaker/credentials/validator/ValidatedAccountNameConstraintValidatorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spinnaker.test.security.ValidatedAccount;
+import javax.validation.Validator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.PermissionEvaluator;
+
+@SpringBootTest
+class ValidatedAccountNameConstraintValidatorTest {
+  @Autowired Validator validator;
+  @MockBean PermissionEvaluator permissionEvaluator;
+
+  @Test
+  void nullValuesValidated() {
+    var account = new ValidatedAccount();
+    assertThat(validator.validate(account)).hasSize(2);
+  }
+
+  @Test
+  void emptyValuesValidated() {
+    var account = new ValidatedAccount();
+    account.setName("");
+    account.setLabel("");
+    assertThat(validator.validate(account)).hasSize(2);
+  }
+
+  @Test
+  void invalidNameValidation() {
+    var account = new ValidatedAccount();
+    account.setName("/etc/passwd");
+    account.setLabel("/etc/shadow");
+    assertThat(validator.validate(account)).hasSize(1);
+  }
+
+  @Configuration
+  @EnableAutoConfiguration
+  static class Config {}
+}

--- a/kork-credentials/src/test/java/io/spinnaker/test/security/OptionalFieldAccount.java
+++ b/kork-credentials/src/test/java/io/spinnaker/test/security/OptionalFieldAccount.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.spinnaker.test.security;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+@CredentialsType("optional")
+public class OptionalFieldAccount implements CredentialsDefinition {
+  String name;
+  Optional<String> secret;
+}

--- a/kork-credentials/src/test/java/io/spinnaker/test/security/OverlyFlexibleAccount.java
+++ b/kork-credentials/src/test/java/io/spinnaker/test/security/OverlyFlexibleAccount.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spinnaker.test.security;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import lombok.Data;
+
+@Data
+@CredentialsType("flex")
+public class OverlyFlexibleAccount implements CredentialsDefinition {
+  private String name;
+}

--- a/kork-credentials/src/test/java/io/spinnaker/test/security/TestAccount.java
+++ b/kork-credentials/src/test/java/io/spinnaker/test/security/TestAccount.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spinnaker.test.security;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+@CredentialsType("test")
+@NonnullByDefault
+@JsonIgnoreProperties("type")
+public class TestAccount implements CredentialsDefinition {
+  private final Map<String, Object> data = new HashMap<>();
+
+  @Override
+  @JsonIgnore
+  public String getName() {
+    return (String) data.get("name");
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getData() {
+    return data;
+  }
+
+  @JsonAnySetter
+  public void setData(String key, Object value) {
+    data.put(key, value);
+  }
+}

--- a/kork-credentials/src/test/java/io/spinnaker/test/security/ValidatedAccount.java
+++ b/kork-credentials/src/test/java/io/spinnaker/test/security/ValidatedAccount.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spinnaker.test.security;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import javax.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+@CredentialsType("validated")
+public class ValidatedAccount implements CredentialsDefinition {
+  private String name;
+  @NotBlank private String label;
+}

--- a/kork-credentials/src/test/java/io/spinnaker/test/security/ValueAccount.java
+++ b/kork-credentials/src/test/java/io/spinnaker/test/security/ValueAccount.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spinnaker.test.security;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@CredentialsType("value")
+@NonnullByDefault
+@Value
+@Builder
+@Jacksonized
+public class ValueAccount implements CredentialsDefinition {
+  String name;
+  String value;
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretEngineRegistry.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretEngineRegistry.java
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.kork.secrets;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SecretEngineRegistry {
   private final ObjectProvider<SecretEngine> secretEngines;
+
+  // This is used by the Armory kubesvc plugin
+  public Map<String, SecretEngine> getRegisteredEngines() {
+    return secretEngines
+        .orderedStream()
+        .collect(Collectors.toMap(SecretEngine::identifier, Function.identity()));
+  }
 
   public List<SecretEngine> getSecretEngineList() {
     return secretEngines.orderedStream().collect(Collectors.toList());

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretError.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Apple Inc.
+ * Copyright 2023 Apple Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,15 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.secrets.user;
+package com.netflix.spinnaker.kork.secrets;
 
-import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
-import lombok.RequiredArgsConstructor;
+import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes;
 
-@NonnullByDefault
-@RequiredArgsConstructor
-// not using @UserSecretType as this is an unstructured type
-// see StringUserSecretSerde
-public class StringUserSecretData implements UserSecretData {
-  private final String data;
+/** Common interface for exceptions that have a corresponding {@link SecretErrorCode}. */
+public interface SecretError extends HasAdditionalAttributes {
+  /** Returns the error code constant for this error. */
+  String getErrorCode();
 
-  @Override
-  public String getSecretString(String key) {
-    return data;
-  }
-
-  @Override
-  public String getSecretString() {
-    return data;
-  }
+  /** Returns the exception message provided by this error. */
+  String getMessage();
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretErrorCode.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretErrorCode.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets;
+
+import lombok.Getter;
+
+/** Standard error codes and messages for various secret errors. */
+public enum SecretErrorCode implements SecretError {
+  /** @see com.netflix.spinnaker.kork.secrets.user.InvalidUserSecretReferenceException */
+  INVALID_USER_SECRET_URI("user.format.invalid", "Invalid user secret URI format"),
+  /** @see com.netflix.spinnaker.kork.secrets.user.MissingUserSecretMetadataException */
+  MISSING_USER_SECRET_METADATA("user.metadata.missing", "Missing user secret metadata"),
+  /** @see com.netflix.spinnaker.kork.secrets.user.InvalidUserSecretMetadataException */
+  INVALID_USER_SECRET_METADATA("user.metadata.invalid", "Invalid user secret metadata"),
+  /** @see com.netflix.spinnaker.kork.secrets.user.UnsupportedUserSecretEngineException */
+  UNSUPPORTED_USER_SECRET_ENGINE(
+      "user.engine.unsupported", "SecretEngine does not support user secrets"),
+  /** @see com.netflix.spinnaker.kork.secrets.user.UnsupportedUserSecretEncodingException */
+  UNSUPPORTED_USER_SECRET_ENCODING(
+      "user.encoding.unsupported", "Unsupported user secret 'encoding'"),
+  /** @see com.netflix.spinnaker.kork.secrets.user.UnsupportedUserSecretTypeException */
+  UNSUPPORTED_USER_SECRET_TYPE("user.type.unsupported", "Unsupported user secret 'type'"),
+  /** @see com.netflix.spinnaker.kork.secrets.user.InvalidUserSecretDataException */
+  INVALID_USER_SECRET_DATA("user.data.invalid", "Invalid user secret data"),
+  /** @see SecretDecryptionException */
+  USER_SECRET_DECRYPTION_FAILURE("user.decrypt.failure", "Unable to decrypt user secret"),
+  DENIED_ACCESS_TO_USER_SECRET("user.access.deny", "Denied access to user secret"),
+  MISSING_USER_SECRET_DATA_KEY("user.data.missing", "Missing user secret data for requested key"),
+  INVALID_EXTERNAL_SECRET_URI("external.format.invalid", "Invalid external secret URI format"),
+  /** @see SecretDecryptionException */
+  EXTERNAL_SECRET_DECRYPTION_FAILURE(
+      "external.decrypt.failure", "Unable to decrypt external secret"),
+  DENIED_ACCESS_TO_EXTERNAL_SECRET("external.access.deny", "Denied access to external secret"),
+  /** @see UnsupportedSecretEngineException */
+  UNSUPPORTED_SECRET_ENGINE("engine.unsupported", "Unsupported secret engine identifier"),
+  ;
+
+  @Getter private final String errorCode;
+  @Getter private final String message;
+
+  SecretErrorCode(String errorCode, String message) {
+    this.errorCode = "secrets." + errorCode;
+    this.message = message;
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretReferenceValidator.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/SecretReferenceValidator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.secrets.user.UserSecret;
+import com.netflix.spinnaker.kork.secrets.user.UserSecretReference;
+import java.util.Optional;
+
+/**
+ * Validation strategy for checking strings for possible secret references and validating that the
+ * current authenticated user (if available) is allowed to use it.
+ */
+@NonnullByDefault
+public interface SecretReferenceValidator {
+  /**
+   * Checks the given string to see if it is a valid {@link UserSecretReference} or {@link
+   * EncryptedSecret} URI and performs validation on the referenced secret. If the given string does
+   * not match {@link UserSecretReference#isUserSecret(String)} or {@link
+   * EncryptedSecret#isEncryptedSecret(String)}, then this will not validate the string any further.
+   *
+   * @param secretReference string possibly containing a secret reference URI
+   * @return an optional containing the {@link SecretError} if invalid or an empty optional
+   *     otherwise
+   */
+  default Optional<SecretError> validate(String secretReference) {
+    if (UserSecretReference.isUserSecret(secretReference)) {
+      return validateUserSecretReference(secretReference);
+    }
+    if (EncryptedSecret.isEncryptedSecret(secretReference)) {
+      return validateExternalSecretReference(secretReference);
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Checks the given string to see if it is a valid {@link UserSecretReference} and that its
+   * referenced {@link UserSecret} is valid.
+   *
+   * @param uri secret URI to validate
+   * @return a specific error code for a validation error or empty
+   */
+  Optional<SecretError> validateUserSecretReference(String uri);
+
+  /**
+   * Checks the given string to see if it is a valid {@link EncryptedSecret} and that its referenced
+   * secret data can be fetched.
+   *
+   * @param uri external secret URI to validate
+   * @return a specific error code for a validation error or empty
+   */
+  Optional<SecretError> validateExternalSecretReference(String uri);
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/UnsupportedSecretEngineException.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/UnsupportedSecretEngineException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Apple Inc.
+ * Copyright 2023 Apple Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,17 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.kork.secrets.user;
+package com.netflix.spinnaker.kork.secrets;
 
-import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
-import lombok.RequiredArgsConstructor;
-
-@NonnullByDefault
-@RequiredArgsConstructor
-// not using @UserSecretType as this is an unstructured type
-// see StringUserSecretSerde
-public class StringUserSecretData implements UserSecretData {
-  private final String data;
-
-  @Override
-  public String getSecretString(String key) {
-    return data;
+/** Exception thrown when an unsupported secret engine is called upon for decrypting a secret. */
+public class UnsupportedSecretEngineException extends SecretDecryptionException
+    implements SecretError {
+  public UnsupportedSecretEngineException(String engine) {
+    super(String.format("Unsupported secret engine identifier '%s'", engine));
   }
 
   @Override
-  public String getSecretString() {
-    return data;
+  public String getErrorCode() {
+    return SecretErrorCode.UNSUPPORTED_SECRET_ENGINE.getErrorCode();
   }
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/DefaultUserSecretSerde.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/DefaultUserSecretSerde.java
@@ -20,12 +20,9 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
-import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
-import com.netflix.spinnaker.kork.secrets.SecretException;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 
 /**
@@ -62,22 +59,33 @@ public class DefaultUserSecretSerde implements UserSecretSerde {
 
   @Override
   public UserSecret deserialize(byte[] encoded, UserSecretMetadata metadata) {
-    var type = Objects.requireNonNull(userSecretTypes.get(metadata.getType()));
-    var mapper = Objects.requireNonNull(mappersByEncodingFormat.get(metadata.getEncoding()));
-    try {
-      return UserSecret.builder().metadata(metadata).data(mapper.readValue(encoded, type)).build();
-    } catch (IOException e) {
-      throw new SecretDecryptionException(e);
+    var type = userSecretTypes.get(metadata.getType());
+    if (type == null) {
+      throw new UnsupportedUserSecretTypeException(metadata.getType());
     }
+    var mapper = mappersByEncodingFormat.get(metadata.getEncoding());
+    if (mapper == null) {
+      throw new UnsupportedUserSecretEncodingException(metadata.getEncoding());
+    }
+    UserSecretData data;
+    try {
+      data = mapper.readValue(encoded, type);
+    } catch (IOException e) {
+      throw new InvalidUserSecretDataException("cannot parse user secret data", e);
+    }
+    return UserSecret.builder().metadata(metadata).data(data).build();
   }
 
   @Override
   public byte[] serialize(UserSecretData secret, UserSecretMetadata metadata) {
-    var mapper = Objects.requireNonNull(mappersByEncodingFormat.get(metadata.getEncoding()));
+    var mapper = mappersByEncodingFormat.get(metadata.getEncoding());
+    if (mapper == null) {
+      throw new UnsupportedUserSecretEncodingException(metadata.getEncoding());
+    }
     try {
       return mapper.writeValueAsBytes(secret);
     } catch (JsonProcessingException e) {
-      throw new SecretException(e);
+      throw new InvalidUserSecretDataException(e.getMessage(), e);
     }
   }
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/InvalidUserSecretDataException.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/InvalidUserSecretDataException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
+import com.netflix.spinnaker.kork.secrets.SecretError;
+import com.netflix.spinnaker.kork.secrets.SecretErrorCode;
+
+/**
+ * Exception thrown when a {@link UserSecretSerde} is unable to deserialize data into {@link
+ * UserSecretData}.
+ */
+public class InvalidUserSecretDataException extends SecretDecryptionException
+    implements SecretError {
+  public InvalidUserSecretDataException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  @Override
+  public String getErrorCode() {
+    return SecretErrorCode.INVALID_USER_SECRET_DATA.getErrorCode();
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/InvalidUserSecretMetadataException.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/InvalidUserSecretMetadataException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes;
+import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
+import com.netflix.spinnaker.kork.secrets.SecretError;
+import com.netflix.spinnaker.kork.secrets.SecretErrorCode;
+import lombok.Getter;
+
+/**
+ * Exception thrown when a decrypted {@link UserSecret} has invalid {@link UserSecretMetadata}
+ * defined.
+ */
+public class InvalidUserSecretMetadataException extends InvalidSecretFormatException
+    implements HasAdditionalAttributes, SecretError {
+  @Getter private final UserSecretReference userSecretReference;
+
+  public InvalidUserSecretMetadataException(
+      UserSecretReference userSecretReference, Throwable cause) {
+    super(String.format("User secret %s has invalid metadata", userSecretReference), cause);
+    this.userSecretReference = userSecretReference;
+  }
+
+  @Override
+  public String getErrorCode() {
+    return SecretErrorCode.INVALID_USER_SECRET_METADATA.getErrorCode();
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/InvalidUserSecretReferenceException.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/InvalidUserSecretReferenceException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes;
+import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
+import com.netflix.spinnaker.kork.secrets.SecretError;
+import com.netflix.spinnaker.kork.secrets.SecretErrorCode;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+
+/** Exception thrown when an invalid {@link UserSecretReference} is attempted to be parsed. */
+@Getter
+public class InvalidUserSecretReferenceException extends InvalidSecretFormatException
+    implements HasAdditionalAttributes, SecretError {
+  private final Map<String, Object> additionalAttributes = new HashMap<>();
+
+  public InvalidUserSecretReferenceException(String input, Throwable cause) {
+    super("Unable to parse input into a URI", cause);
+    additionalAttributes.put("input", input);
+  }
+
+  public InvalidUserSecretReferenceException(String message, URI uri) {
+    super(message);
+    additionalAttributes.put("input", uri);
+  }
+
+  @Override
+  public String getErrorCode() {
+    return SecretErrorCode.INVALID_USER_SECRET_URI.getErrorCode();
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/MissingUserSecretMetadataException.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/MissingUserSecretMetadataException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes;
+import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
+import com.netflix.spinnaker.kork.secrets.SecretError;
+import com.netflix.spinnaker.kork.secrets.SecretErrorCode;
+import java.util.Map;
+import lombok.Getter;
+
+/**
+ * Exception thrown when a decrypted {@link UserSecret} does not have any {@link UserSecretMetadata}
+ * defined.
+ */
+public class MissingUserSecretMetadataException extends InvalidSecretFormatException
+    implements HasAdditionalAttributes, SecretError {
+  @Getter private final UserSecretReference userSecretReference;
+
+  public MissingUserSecretMetadataException(UserSecretReference userSecretReference) {
+    super(String.format("User secret %s has no metadata defined", userSecretReference));
+    this.userSecretReference = userSecretReference;
+  }
+
+  @Override
+  public Map<String, Object> getAdditionalAttributes() {
+    return Map.of("userSecretReference", userSecretReference);
+  }
+
+  @Override
+  public String getErrorCode() {
+    return SecretErrorCode.MISSING_USER_SECRET_METADATA.getErrorCode();
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/StringUserSecretSerde.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/StringUserSecretSerde.java
@@ -36,6 +36,6 @@ public class StringUserSecretSerde implements UserSecretSerde {
 
   @Override
   public byte[] serialize(UserSecretData secret, UserSecretMetadata metadata) {
-    return secret.getSecretString("").getBytes(StandardCharsets.UTF_8);
+    return secret.getSecretString().getBytes(StandardCharsets.UTF_8);
   }
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UnsupportedUserSecretEncodingException.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UnsupportedUserSecretEncodingException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
+import com.netflix.spinnaker.kork.secrets.SecretError;
+import com.netflix.spinnaker.kork.secrets.SecretErrorCode;
+
+/**
+ * Exception thrown when a {@link UserSecretSerde} encounters an unsupported {@linkplain
+ * UserSecretMetadata#getEncoding() encoding type}.
+ */
+public class UnsupportedUserSecretEncodingException extends SecretDecryptionException
+    implements SecretError {
+  public UnsupportedUserSecretEncodingException(String encoding) {
+    super(String.format("Unsupported user secret encoding '%s'", encoding));
+  }
+
+  @Override
+  public String getErrorCode() {
+    return SecretErrorCode.UNSUPPORTED_USER_SECRET_ENCODING.getErrorCode();
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UnsupportedUserSecretEngineException.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UnsupportedUserSecretEngineException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.secrets.SecretError;
+import com.netflix.spinnaker.kork.secrets.SecretErrorCode;
+
+/**
+ * Exception thrown by a {@link com.netflix.spinnaker.kork.secrets.SecretEngine} when an attempt is
+ * made to get a {@link UserSecret} while said engine does not support user secrets.
+ */
+public class UnsupportedUserSecretEngineException extends UnsupportedOperationException
+    implements SecretError {
+  public UnsupportedUserSecretEngineException(String engine) {
+    super(String.format("Unsupported secret engine identifier '%s' for user secrets", engine));
+  }
+
+  @Override
+  public String getErrorCode() {
+    return SecretErrorCode.UNSUPPORTED_USER_SECRET_ENGINE.getErrorCode();
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UnsupportedUserSecretTypeException.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UnsupportedUserSecretTypeException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
+import com.netflix.spinnaker.kork.secrets.SecretError;
+import com.netflix.spinnaker.kork.secrets.SecretErrorCode;
+
+/**
+ * Exception thrown when a {@link UserSecretSerde} is unable to serialize or deserialize a secret.
+ */
+public class UnsupportedUserSecretTypeException extends SecretDecryptionException
+    implements SecretError {
+  public UnsupportedUserSecretTypeException(String type) {
+    super(String.format("Unsupported user secret type '%s'", type));
+  }
+
+  @Override
+  public String getErrorCode() {
+    return SecretErrorCode.UNSUPPORTED_USER_SECRET_TYPE.getErrorCode();
+  }
+}

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecret.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecret.java
@@ -19,14 +19,12 @@ package com.netflix.spinnaker.kork.secrets.user;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.secrets.SecretEngine;
 import com.netflix.spinnaker.security.AccessControlled;
-import java.util.Collections;
-import java.util.Set;
-import java.util.stream.Collectors;
+import com.netflix.spinnaker.security.SpinnakerAuthorities;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.Delegate;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.AuthorityUtils;
 
 /**
  * User secrets are externally stored secrets with additional user-provided metadata regarding who
@@ -51,11 +49,7 @@ public class UserSecret implements AccessControlled {
 
   @Override
   public boolean isAuthorized(Authentication authentication, Object authorization) {
-    Set<String> userAuthorities =
-        AuthorityUtils.authorityListToSet(authentication.getAuthorities());
-    Set<String> permittedAuthorities =
-        getRoles().stream().map(role -> "ROLE_" + role).collect(Collectors.toSet());
-    return permittedAuthorities.isEmpty()
-        || !Collections.disjoint(userAuthorities, permittedAuthorities);
+    List<String> roles = getRoles();
+    return roles.isEmpty() || SpinnakerAuthorities.hasAnyRole(authentication, roles);
   }
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretData.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretData.java
@@ -17,9 +17,27 @@
 package com.netflix.spinnaker.kork.secrets.user;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.NoSuchElementException;
 
 @NonnullByDefault
 public interface UserSecretData {
-  /** Gets the value of this secret with the provided key and returns a string encoding of it. */
+  /**
+   * Gets the value of this secret with the provided key and returns a string encoding of it.
+   *
+   * @param key the key to look up the secret value for in this data; can be an empty string for
+   *     flat secrets
+   * @return the secret value encoded as a string
+   * @throws NoSuchElementException if no secret value exists for the given key
+   */
   String getSecretString(String key);
+
+  /**
+   * Gets the value of this secret as a single string if the underlying secret data supports it.
+   *
+   * @return the secret payload as a string
+   * @throws UnsupportedOperationException if this secret doesn't support scalar strings
+   */
+  default String getSecretString() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManager.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretManager.java
@@ -18,9 +18,11 @@ package com.netflix.spinnaker.kork.secrets.user;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
+import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
 import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
 import com.netflix.spinnaker.kork.secrets.SecretEngine;
 import com.netflix.spinnaker.kork.secrets.SecretEngineRegistry;
+import com.netflix.spinnaker.kork.secrets.UnsupportedSecretEngineException;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -42,15 +44,27 @@ public class UserSecretManager {
    *
    * @param reference parsed user secret reference to fetch
    * @return the decrypted user secret
+   * @throws UnsupportedSecretEngineException if the secret reference does not have a corresponding
+   *     secret engine
+   * @throws UnsupportedUserSecretEngineException if the secret engine does not support user secrets
+   * @throws MissingUserSecretMetadataException if the secret is missing its {@link
+   *     UserSecretMetadata}
+   * @throws InvalidUserSecretMetadataException if the secret has metadata that cannot be parsed
+   * @throws InvalidSecretFormatException if the secret reference has other validation errors
+   * @throws SecretDecryptionException if the secret reference cannot be fetched
    */
   public UserSecret getUserSecret(UserSecretReference reference) {
     String engineIdentifier = reference.getEngineIdentifier();
     SecretEngine engine = registry.getEngine(engineIdentifier);
     if (engine == null) {
-      throw new SecretDecryptionException("Unknown secret engine identifier: " + engineIdentifier);
+      throw new UnsupportedSecretEngineException(engineIdentifier);
     }
     engine.validate(reference);
-    return engine.decrypt(reference);
+    try {
+      return engine.decrypt(reference);
+    } catch (UnsupportedOperationException e) {
+      throw new UnsupportedSecretEngineException(engineIdentifier);
+    }
   }
 
   /**
@@ -59,12 +73,15 @@ public class UserSecretManager {
    *
    * @param reference parsed external secret reference to fetch
    * @return the decrypted external secret
+   * @throws SecretDecryptionException if the external secret does not have a corresponding secret
+   *     engine or cannot be fetched
+   * @throws InvalidSecretFormatException if the external secret reference is invalid
    */
   public byte[] getExternalSecret(EncryptedSecret reference) {
     String engineIdentifier = reference.getEngineIdentifier();
     SecretEngine engine = registry.getEngine(engineIdentifier);
     if (engine == null) {
-      throw new SecretDecryptionException("Unknown secret engine identifier: " + engineIdentifier);
+      throw new UnsupportedSecretEngineException(engineIdentifier);
     }
     engine.validate(reference);
     return engine.decrypt(reference);
@@ -76,6 +93,9 @@ public class UserSecretManager {
    *
    * @param reference parsed external secret reference to fetch
    * @return the decrypted external secret string
+   * @throws SecretDecryptionException if the external secret does not have a corresponding secret
+   *     engine or cannot be fetched
+   * @throws InvalidSecretFormatException if the external secret reference is invalid
    */
   public String getExternalSecretString(EncryptedSecret reference) {
     return new String(getExternalSecret(reference), StandardCharsets.UTF_8);

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretMetadata.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretMetadata.java
@@ -31,8 +31,10 @@ import lombok.extern.jackson.Jacksonized;
 public class UserSecretMetadata {
   /** Returns the type of the user secret. */
   @Nonnull private final String type;
+
   /** Returns the encoding of the user secret. */
-  @Nullable private final String encoding;
+  @Nullable @Builder.Default private final String encoding = null;
+
   /** Returns the authorized roles that can use the user secret. */
-  @Nonnull private final List<String> roles;
+  @Nonnull @Builder.Default private final List<String> roles = List.of();
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretSerde.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretSerde.java
@@ -17,12 +17,38 @@
 package com.netflix.spinnaker.kork.secrets.user;
 
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
+import com.netflix.spinnaker.kork.secrets.SecretException;
 
 @NonnullByDefault
 public interface UserSecretSerde {
+
+  /**
+   * Checks if this serde supports user secrets with the given metadata.
+   *
+   * @param metadata the user secret metadata to check for support
+   * @return true if this serde can serialize and deserialize user secrets with the given metadata
+   */
   boolean supports(UserSecretMetadata metadata);
 
+  /**
+   * Deserializes a raw user secret payload with its parsed metadata.
+   *
+   * @param encoded the raw user secret data
+   * @param metadata the parsed user secret metadata corresponding to the given raw secret
+   * @return the parsed user secret
+   * @throws SecretDecryptionException if the user secret data cannot be parsed as configured by the
+   *     metadata
+   */
   UserSecret deserialize(byte[] encoded, UserSecretMetadata metadata);
 
+  /**
+   * Serializes a raw user secret to the specified encoding in the given metadata.
+   *
+   * @param secret the user secret data
+   * @param metadata the metadata describing the user secret
+   * @return the serialized user secret
+   * @throws SecretException if the user secret cannot be serialized
+   */
   byte[] serialize(UserSecretData secret, UserSecretMetadata metadata);
 }

--- a/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretService.java
+++ b/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/user/UserSecretService.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.secrets.user;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
+import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
+import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
+import com.netflix.spinnaker.kork.secrets.StandardSecretParameter;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@NonnullByDefault
+public class UserSecretService {
+  private final UserSecretManager secretManager;
+  private final Map<String, Set<UserSecretReference>> resourceIdsWithUserSecrets =
+      new ConcurrentHashMap<>();
+
+  @PostAuthorize("hasPermission(returnObject, 'READ')")
+  public UserSecret getUserSecret(UserSecretReference ref) {
+    return secretManager.getUserSecret(ref);
+  }
+
+  /**
+   * Gets a user secret string value for the given resource id. User secret references are tracked
+   * through this method to support time-of-use access control checks for resources after they've
+   * been loaded by the system.
+   *
+   * @param ref parsed user secret reference to decrypt
+   * @param resourceId id of resource referencing the user secret
+   * @return the contents of the requested user secret string
+   */
+  public String getUserSecretStringForResource(UserSecretReference ref, String resourceId) {
+    var secret = secretManager.getUserSecret(ref);
+    resourceIdsWithUserSecrets
+        .computeIfAbsent(resourceId, ignored -> ConcurrentHashMap.newKeySet())
+        .add(ref);
+    var params = ref.getParameters();
+    String key = params.getOrDefault(StandardSecretParameter.KEY.getParameterName(), "");
+    try {
+      return secret.getSecretString(key);
+    } catch (NoSuchElementException e) {
+      throw new SecretDecryptionException(e);
+    }
+  }
+
+  /**
+   * Checks whether the provided resource id is being tracked for user secrets. Resources with no
+   * user secrets or that do not exist should return {@code false}.
+   */
+  public boolean isTrackingUserSecretsForResource(String resourceId) {
+    return resourceIdsWithUserSecrets.containsKey(resourceId);
+  }
+
+  /** Performs an action for all tracked user secrets of the provided resource id. */
+  public void forEachUserSecretOfResource(
+      String resourceId, BiConsumer<UserSecretReference, UserSecret> action) {
+    resourceIdsWithUserSecrets
+        .getOrDefault(resourceId, Set.of())
+        .forEach(ref -> action.accept(ref, secretManager.getUserSecret(ref)));
+  }
+
+  /**
+   * Attempts to fetch and decrypt the given parsed external secret reference. If this is unable to
+   * fetch the secret, then this will throw an exception.
+   *
+   * @param reference parsed external secret reference to fetch
+   * @throws SecretDecryptionException if the external secret does not have a corresponding secret
+   *     engine or cannot be fetched
+   * @throws InvalidSecretFormatException if the external secret reference is invalid
+   */
+  public void checkExternalSecret(EncryptedSecret reference) {
+    secretManager.getExternalSecret(reference);
+  }
+
+  /**
+   * Fetches and decrypts the given parsed external secret reference encoded as a string. External
+   * secrets are secrets available through {@link EncryptedSecret} URIs.
+   *
+   * @param reference parsed external secret reference to fetch
+   * @return the decrypted external secret string
+   * @throws SecretDecryptionException if the external secret does not have a corresponding secret
+   *     engine or cannot be fetched
+   * @throws InvalidSecretFormatException if the external secret reference is invalid
+   */
+  public String getExternalSecretString(EncryptedSecret reference) {
+    return secretManager.getExternalSecretString(reference);
+  }
+}

--- a/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretServiceTest.java
+++ b/kork-secrets/src/test/java/com/netflix/spinnaker/kork/secrets/user/UserSecretServiceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.kork.secrets.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+import com.netflix.spinnaker.kork.secrets.SecretEngine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig
+class UserSecretServiceTest {
+  @MockBean SecretEngine mockSecretEngine;
+  @Autowired UserSecretService userSecretService;
+
+  UserSecret secret =
+      UserSecret.builder()
+          .data(new StringUserSecretData("super-secret"))
+          .metadata(UserSecretMetadata.builder().type("string").build())
+          .build();
+
+  @BeforeEach
+  void setUp() {
+    given(mockSecretEngine.identifier()).willReturn("mock");
+  }
+
+  @Test
+  void tracksUserSecret() {
+    UserSecretReference ref = UserSecretReference.parse("secret://mock?k=v");
+    given(mockSecretEngine.decrypt(ref)).willReturn(secret);
+
+    String resourceId = "some-resource-id";
+    assertFalse(userSecretService.isTrackingUserSecretsForResource(resourceId));
+    String secretString = userSecretService.getUserSecretStringForResource(ref, resourceId);
+    assertEquals("super-secret", secretString);
+    assertTrue(userSecretService.isTrackingUserSecretsForResource(resourceId));
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  @EnableAutoConfiguration
+  static class TestConfig {}
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AbstractPermissionEvaluator.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AbstractPermissionEvaluator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import java.io.Serializable;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Base implementation for permission evaluators that support {@link AccessControlled} domain
+ * objects.
+ */
+public abstract class AbstractPermissionEvaluator implements PermissionEvaluator {
+
+  @Override
+  public boolean hasPermission(
+      Authentication authentication, Object targetDomainObject, Object permission) {
+    if (isDisabled()) {
+      return true;
+    }
+    if (authentication == null || targetDomainObject == null) {
+      return false;
+    }
+    if (SpinnakerAuthorities.isAdmin(authentication)) {
+      return true;
+    }
+    if (targetDomainObject instanceof AccessControlled) {
+      return ((AccessControlled) targetDomainObject).isAuthorized(authentication, permission);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean hasPermission(
+      Authentication authentication, Serializable targetId, String targetType, Object permission) {
+    if (isDisabled()) {
+      return true;
+    }
+    return hasPermission(
+        SpinnakerUsers.getUserId(authentication), targetId, targetType, permission);
+  }
+
+  /**
+   * Indicates whether permission evaluation is disabled. When this is true, {@code hasPermission}
+   * calls should return true. This should be overridden to allow for toggling this evaluator at
+   * runtime.
+   */
+  protected boolean isDisabled() {
+    return false;
+  }
+
+  /**
+   * Alternative method for evaluating a permission where only the identifier of the user and target
+   * object is available, rather than the authenticated user and target objects themselves.
+   *
+   * @param username identifier for user to check permissions for
+   * @param targetId identifier of the target resource to check permissions
+   * @param targetType the type of the target resource being checked
+   * @param permission the permission being validated
+   * @return true if the permission is granted
+   */
+  public abstract boolean hasPermission(
+      String username, Serializable targetId, String targetType, Object permission);
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AccessControlled.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AccessControlled.java
@@ -16,18 +16,26 @@
 
 package com.netflix.spinnaker.security;
 
+import java.util.Collection;
 import org.springframework.security.core.Authentication;
 
 /**
  * An AccessControlled object is an object that knows its own permissions and can check them against
  * a given user and authorization. This allows resources to support access control checks via Spring
  * Security against the resource object directly.
+ *
+ * @see AbstractPermissionEvaluator
  */
 public interface AccessControlled {
   /**
    * Checks if the authenticated user has a particular authorization on this object. Note that
    * checking if the user is an admin should be performed by a {@link
-   * org.springframework.security.access.PermissionEvaluator} rather than in these domain objects.
+   * org.springframework.security.access.PermissionEvaluator} or by checking {@link
+   * SpinnakerAuthorities#isAdmin(Authentication)} rather than via this method as the admin role is
+   * a Spinnaker-specific role.
+   *
+   * @see Authorization
+   * @see SpinnakerAuthorities#hasAnyRole(Authentication, Collection)
    */
   boolean isAuthorized(Authentication authentication, Object authorization);
 }

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AllowedAccountAuthority.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AllowedAccountAuthority.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.io.InvalidObjectException;
+import java.io.Serializable;
+import java.util.Locale;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * Represents an authorization to use an account. Allowed account authorities are based on an older
+ * security mechanism used by Spinnaker before other account types besides cloud providers and
+ * permissions were added.
+ */
+@Getter
+@EqualsAndHashCode(of = "account")
+@NonnullByDefault
+public class AllowedAccountAuthority implements GrantedAuthority, Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final String account;
+  private final String authority;
+
+  public AllowedAccountAuthority(String account) {
+    this.account = account.toLowerCase(Locale.ROOT);
+    authority = AllowedAccountsAuthorities.PREFIX + this.account;
+  }
+
+  private Object writeReplace() {
+    return new SerializationProxy(this);
+  }
+
+  private Object readObject() throws InvalidObjectException {
+    throw new InvalidObjectException("Proxy required");
+  }
+
+  private static class SerializationProxy implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final String account;
+
+    private SerializationProxy(AllowedAccountAuthority authority) {
+      account = authority.account;
+    }
+
+    private Object readResolve() {
+      return new AllowedAccountAuthority(account);
+    }
+  }
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/Authorization.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/Authorization.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import org.springframework.security.core.Authentication;
+
+/**
+ * Defines types of authorizations supported by {@link AccessControlled#isAuthorized(Authentication,
+ * Object)}.
+ */
+public enum Authorization {
+  READ,
+  WRITE,
+  EXECUTE,
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AuthorizationMapControlled.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AuthorizationMapControlled.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import java.util.Locale;
+import javax.annotation.Nullable;
+
+/**
+ * Common interface for access-controlled classes which use a permission map of {@link
+ * Authorization} enums.
+ */
+public interface AuthorizationMapControlled extends PermissionMapControlled<Authorization> {
+  @Nullable
+  @Override
+  default Authorization valueOf(@Nullable Object authorization) {
+    return authorization != null
+        ? Enum.valueOf(Authorization.class, authorization.toString().toUpperCase(Locale.ROOT))
+        : null;
+  }
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/PermissionMapControlled.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/PermissionMapControlled.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Common interface for access-controlled classes which use a permission map.
+ *
+ * @param <Authorization> Authorization enum type
+ */
+@Alpha
+public interface PermissionMapControlled<Authorization extends Enum<Authorization>>
+    extends AccessControlled {
+  @Nullable
+  Authorization valueOf(@Nullable Object authorization);
+
+  @Nonnull
+  default Map<Authorization, Set<String>> getPermissions() {
+    return Map.of();
+  }
+
+  @Override
+  default boolean isAuthorized(Authentication authentication, Object authorization) {
+    Authorization auth = valueOf(authorization);
+    if (auth == null) {
+      return false;
+    }
+    Set<String> permittedRoles = getPermissions().getOrDefault(auth, Set.of());
+    return permittedRoles.isEmpty()
+        || SpinnakerAuthorities.hasAnyRole(authentication, permittedRoles);
+  }
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/SpinnakerAuthorities.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/SpinnakerAuthorities.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+/**
+ * Constants and utilities for working with Spring Security GrantedAuthority objects specific to
+ * Spinnaker and Fiat. Spinnaker-specific roles are represented here as granted authorities with the
+ * {@code SPINNAKER_} prefix.
+ */
+public class SpinnakerAuthorities {
+  private static final String ROLE_PREFIX = "ROLE_";
+
+  public static final String ADMIN = "SPINNAKER_ADMIN";
+  /** Granted authority for Spinnaker administrators. */
+  public static final GrantedAuthority ADMIN_AUTHORITY = new SimpleGrantedAuthority(ADMIN);
+
+  /** Granted authority for anonymous users. */
+  public static final GrantedAuthority ANONYMOUS_AUTHORITY = forRoleName("ANONYMOUS");
+
+  /** Creates a granted authority corresponding to the provided name of a role. */
+  @Nonnull
+  public static GrantedAuthority forRoleName(@Nonnull String role) {
+    return new SimpleGrantedAuthority(ROLE_PREFIX + role);
+  }
+
+  /** Checks if the given user is a Spinnaker admin. */
+  public static boolean isAdmin(@Nullable Authentication authentication) {
+    return authentication != null
+        && authentication.getAuthorities().contains(SpinnakerAuthorities.ADMIN_AUTHORITY);
+  }
+
+  /** Checks if the given user has the provided role. */
+  public static boolean hasRole(@Nullable Authentication authentication, @Nonnull String role) {
+    return authentication != null && streamRoles(authentication).anyMatch(role::equals);
+  }
+
+  /** Checks if the given user has any of the provided roles. */
+  public static boolean hasAnyRole(
+      @Nullable Authentication authentication, @Nonnull Collection<String> roles) {
+    return authentication != null && streamRoles(authentication).anyMatch(roles::contains);
+  }
+
+  /** Gets the list of roles assigned to the given user. */
+  @Nonnull
+  public static List<String> getRoles(@Nullable Authentication authentication) {
+    if (authentication == null) {
+      return List.of();
+    }
+    return streamRoles(authentication).distinct().collect(Collectors.toList());
+  }
+
+  @Nonnull
+  private static Stream<String> streamRoles(@Nonnull Authentication authentication) {
+    return authentication.getAuthorities().stream()
+        .filter(SpinnakerAuthorities::isRole)
+        .map(SpinnakerAuthorities::getRole);
+  }
+
+  private static boolean isRole(@Nonnull GrantedAuthority authority) {
+    return authority.getAuthority().startsWith(ROLE_PREFIX);
+  }
+
+  private static String getRole(@Nonnull GrantedAuthority authority) {
+    return authority.getAuthority().substring(ROLE_PREFIX.length());
+  }
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/SpinnakerUsers.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/SpinnakerUsers.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.security;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import javax.annotation.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/** Constants and utilities related to Spinnaker users (AKA principals). */
+@NonnullByDefault
+public class SpinnakerUsers {
+  /** String constant for the anonymous userid. */
+  public static final String ANONYMOUS = "anonymous";
+
+  /** Gets the userid of the provided authentication token. */
+  public static String getUserId(@Nullable Authentication authentication) {
+    return authentication != null ? authentication.getName() : ANONYMOUS;
+  }
+
+  /** Gets the current Spinnaker userid. */
+  public static String getCurrentUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null) {
+      return getUserId(authentication);
+    }
+    // fall back to request header context if relevant (AuthenticatedRequestFilter)
+    return AuthenticatedRequest.getSpinnakerUser().orElse(ANONYMOUS);
+  }
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/SystemUser.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/SystemUser.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.security;
+
+import java.util.List;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+/** Synthetic system user for use in service bootstrapping contexts. */
+public class SystemUser extends AbstractAuthenticationToken {
+  public static final String NAME = "SYSTEM";
+
+  private static final SystemUser INSTANCE = new SystemUser();
+
+  private SystemUser() {
+    super(List.of(SpinnakerAuthorities.ADMIN_AUTHORITY, SpinnakerAuthorities.ANONYMOUS_AUTHORITY));
+    setAuthenticated(true);
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return NAME;
+  }
+
+  @Override
+  public Object getCredentials() {
+    return NAME;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  public static SystemUser getInstance() {
+    return INSTANCE;
+  }
+}

--- a/kork-security/src/test/groovy/com/netflix/spinnaker/security/AllowedAccountsAuthoritiesSpec.groovy
+++ b/kork-security/src/test/groovy/com/netflix/spinnaker/security/AllowedAccountsAuthoritiesSpec.groovy
@@ -18,10 +18,8 @@ package com.netflix.spinnaker.security
 
 import org.hamcrest.Matchers
 import org.springframework.security.core.GrantedAuthority
-import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.User
 import spock.lang.Specification
-
-import static com.netflix.spinnaker.security.AllowedAccountsAuthorities.PREFIX
 
 class AllowedAccountsAuthoritiesSpec extends Specification {
   def "extracts allowed accounts from granted authorities"() {
@@ -41,14 +39,14 @@ class AllowedAccountsAuthoritiesSpec extends Specification {
 
     where:
     accounts                       || expected
-    ["A", null, "", "b", "b", "C"] || [a(PREFIX + "a"), a(PREFIX + "b"), a(PREFIX + "c")]
+    ['A', null, '', 'b', 'b', 'C'] || [a('a'), a('b'), a('c')]
   }
 
   private static GrantedAuthority a(String name) {
-    return new SimpleGrantedAuthority(name)
+    return new AllowedAccountAuthority(name)
   }
 
-  private static org.springframework.security.core.userdetails.User u(String name, Collection<String> accounts = []) {
-    new org.springframework.security.core.userdetails.User(name, "", accounts.collect { a(PREFIX + it) })
+  private static User u(String name, Collection<String> accounts = []) {
+    new User(name, "", accounts.collect { a(it) })
   }
 }

--- a/kork-sql-test/kork-sql-test.gradle
+++ b/kork-sql-test/kork-sql-test.gradle
@@ -6,6 +6,7 @@ dependencies {
 
   api("org.testcontainers:mysql")
   api("org.testcontainers:postgresql")
+  api("org.springframework.boot:spring-boot-starter-test")
 
   testImplementation "org.junit.jupiter:junit-jupiter-api"
 

--- a/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/AutoConfigureDatabase.java
+++ b/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/AutoConfigureDatabase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.sql.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.jdbc.DatabaseDriver;
+import org.springframework.boot.test.autoconfigure.properties.PropertyMapping;
+import org.springframework.boot.test.autoconfigure.properties.SkipPropertyMapping;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * Autoconfiguration for setting up an external database with a Liquibase change log to initialize a
+ * fresh database.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ImportAutoConfiguration
+@PropertyMapping("spinnaker.test.database")
+public @interface AutoConfigureDatabase {
+  @AliasFor("databaseName")
+  @PropertyMapping(skip = SkipPropertyMapping.ON_DEFAULT_VALUE)
+  String value() default "";
+
+  /** Defines the SQL dialect to use for this test. */
+  DatabaseDriver driver() default DatabaseDriver.POSTGRESQL;
+
+  /** Specifies the hostname to connect to. */
+  @PropertyMapping(skip = SkipPropertyMapping.ON_DEFAULT_VALUE)
+  String host() default "";
+
+  /** Specifies the port number to connect to. */
+  @PropertyMapping(skip = SkipPropertyMapping.ON_DEFAULT_VALUE)
+  int port() default -1;
+
+  /** Defines the name of the database to create for the test. */
+  @PropertyMapping(skip = SkipPropertyMapping.ON_DEFAULT_VALUE)
+  String databaseName() default "";
+
+  /** Specifies the username to connect as. */
+  @PropertyMapping(skip = SkipPropertyMapping.ON_DEFAULT_VALUE)
+  String username() default "";
+
+  /** Specifies the Liquibase change log file to use to initialize the database. */
+  @PropertyMapping(skip = SkipPropertyMapping.ON_DEFAULT_VALUE)
+  String changeLog() default "";
+}

--- a/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/DatabaseInitializer.java
+++ b/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/DatabaseInitializer.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.sql.test;
+
+import javax.sql.DataSource;
+import liquibase.integration.spring.SpringLiquibase;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DefaultDSLContext;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration;
+import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.jdbc.DatabaseDriver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
+import org.springframework.jdbc.datasource.init.DataSourceInitializer;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureBefore({TransactionAutoConfiguration.class, JooqAutoConfiguration.class})
+@ConditionalOnProperty(prefix = "spinnaker.test.database", name = "database-name")
+@EnableConfigurationProperties(DatabaseProperties.class)
+public class DatabaseInitializer {
+  private final DatabaseProperties properties;
+
+  public DatabaseInitializer(DatabaseProperties properties) {
+    this.properties = properties;
+  }
+
+  @Bean
+  public DataSourceInitializer testDatabaseInitializer() {
+    var driver = properties.getDriver();
+    // use the default database for the connecting user to bootstrap a fresh database
+    var url =
+        String.format(
+            "jdbc:%s://%s:%d/", driver.getId(), properties.getHost(), properties.getPort());
+    var bootstrapDataSource = new SingleConnectionDataSource();
+    bootstrapDataSource.setUrl(url);
+    bootstrapDataSource.setUsername(properties.getUsername());
+    bootstrapDataSource.setDriverClassName(driver.getDriverClassName());
+    var initializer = new DataSourceInitializer();
+    initializer.setDataSource(bootstrapDataSource);
+    String databaseName = properties.getDatabaseName();
+    initializer.setDatabasePopulator(
+        connection -> connection.createStatement().execute("create database " + databaseName));
+    initializer.setDatabaseCleaner(
+        connection -> connection.createStatement().execute("drop database " + databaseName));
+    return initializer;
+  }
+
+  @Bean
+  @DependsOn("testDatabaseInitializer")
+  public DataSource dataSource() {
+    var driver = properties.getDriver();
+    var url =
+        String.format(
+            "jdbc:%s://%s:%d/%s",
+            driver.getId(),
+            properties.getHost(),
+            properties.getPort(),
+            properties.getDatabaseName());
+    return DataSourceBuilder.create()
+        .url(url)
+        .driverClassName(driver.getDriverClassName())
+        .username(properties.getUsername())
+        .build();
+  }
+
+  @Bean
+  public SpringLiquibase liquibase(DataSource dataSource) {
+    var liquibase = new SpringLiquibase();
+    liquibase.setDataSource(dataSource);
+    liquibase.setChangeLog(properties.getChangeLog());
+    return liquibase;
+  }
+
+  @Bean
+  public PlatformTransactionManager transactionManager(DataSource dataSource) {
+    return new DataSourceTransactionManager(dataSource);
+  }
+
+  @Bean
+  public DSLContext dslContext(DataSource dataSource) {
+    return new DefaultDSLContext(
+        new TransactionAwareDataSourceProxy(dataSource), convertToDialect(properties.getDriver()));
+  }
+
+  private static SQLDialect convertToDialect(DatabaseDriver driver) {
+    switch (driver) {
+      case MYSQL:
+        return SQLDialect.MYSQL;
+      case MARIADB:
+        return SQLDialect.MARIADB;
+      case POSTGRESQL:
+        return SQLDialect.POSTGRES;
+      case H2:
+        return SQLDialect.H2;
+      case DERBY:
+        return SQLDialect.DERBY;
+      case HSQLDB:
+        return SQLDialect.HSQLDB;
+      case SQLITE:
+        return SQLDialect.SQLITE;
+      default:
+        throw new UnsupportedOperationException("Cannot map driver to jOOQ dialect: " + driver);
+    }
+  }
+}

--- a/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/DatabaseProperties.java
+++ b/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/DatabaseProperties.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.sql.test;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.jdbc.DatabaseDriver;
+
+@ConstructorBinding
+@ConfigurationProperties("spinnaker.test.database")
+public class DatabaseProperties {
+  private final DatabaseDriver driver;
+  private final String host;
+  private final int port;
+  private final String databaseName;
+  private final String username;
+  private final String changeLog;
+
+  public DatabaseProperties(
+      DatabaseDriver driver,
+      String host,
+      int port,
+      String databaseName,
+      String username,
+      String changeLog) {
+    this.driver = driver;
+    this.host = host;
+    this.port = port;
+    this.databaseName = databaseName;
+    this.username = username;
+    this.changeLog = changeLog;
+  }
+
+  public DatabaseDriver getDriver() {
+    return driver;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getDatabaseName() {
+    return databaseName;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getChangeLog() {
+    return changeLog;
+  }
+}

--- a/kork-sql-test/src/main/resources/META-INF/spring.factories
+++ b/kork-sql-test/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+com.netflix.spinnaker.kork.sql.test.AutoConfigureDatabase=\
+  com.netflix.spinnaker.kork.sql.test.DatabaseInitializer

--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -17,6 +17,7 @@ dependencies {
   api project(":kork-security")
   api project(":kork-exceptions")
   api "org.codehaus.groovy:groovy"
+  api "org.springframework.boot:spring-boot-starter-validation"
   api "org.springframework.boot:spring-boot-starter-web"
   api "org.springframework.boot:spring-boot-starter-webflux"
   api "org.springframework.boot:spring-boot-starter-security"

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/ErrorConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/ErrorConfiguration.groovy
@@ -16,8 +16,11 @@
 
 package com.netflix.spinnaker.config
 
+import com.netflix.spinnaker.kork.api.exceptions.ConstraintViolationContext
+import com.netflix.spinnaker.kork.api.exceptions.DefaultConstraintViolationContext
 import com.netflix.spinnaker.kork.api.exceptions.ExceptionMessage
 import com.netflix.spinnaker.kork.web.controllers.GenericErrorController
+import com.netflix.spinnaker.kork.web.exceptions.ConstraintViolationAdvice
 import com.netflix.spinnaker.kork.web.exceptions.ExceptionMessageDecorator
 import com.netflix.spinnaker.kork.web.exceptions.ExceptionSummaryService
 import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers
@@ -27,10 +30,22 @@ import org.springframework.boot.web.servlet.error.DefaultErrorAttributes
 import org.springframework.boot.web.servlet.error.ErrorAttributes
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.context.annotation.RequestScope
 import org.springframework.web.context.request.WebRequest
 
 @Configuration
 class ErrorConfiguration {
+  @Bean
+  @RequestScope
+  ConstraintViolationContext constraintViolationContext() {
+    new DefaultConstraintViolationContext()
+  }
+
+  @Bean
+  ConstraintViolationAdvice constraintViolationAdvice(ConstraintViolationContext contextProvider) {
+    new ConstraintViolationAdvice(contextProvider)
+  }
+
   @Bean
   ErrorAttributes errorAttributes() {
     final DefaultErrorAttributes defaultErrorAttributes = new DefaultErrorAttributes()

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/BaseExceptionHandlers.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/BaseExceptionHandlers.java
@@ -16,11 +16,25 @@
 
 package com.netflix.spinnaker.kork.web.exceptions;
 
+import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes;
+import java.time.Instant;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.ui.ModelMap;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+@Log4j2
 public class BaseExceptionHandlers extends ResponseEntityExceptionHandler {
   private final DefaultErrorAttributes defaultErrorAttributes = new DefaultErrorAttributes();
 
@@ -35,5 +49,57 @@ public class BaseExceptionHandlers extends ResponseEntityExceptionHandler {
     // store exception as an attribute of HttpServletRequest such that it can be referenced by
     // GenericErrorController
     defaultErrorAttributes.resolveException(request, response, null, ex);
+  }
+
+  /**
+   * Generic exception handler for Spring exceptions. This transforms the exception details in a
+   * similar fashion to {@link DefaultErrorAttributes} combined with {@link
+   * com.netflix.spinnaker.kork.web.controllers.GenericErrorController}. Many standard Spring
+   * exceptions have default handlers in {@link ResponseEntityExceptionHandler} which mostly choose
+   * an appropriate HTTP response status while providing no other useful information outside of
+   * debug logs.
+   *
+   * @param ex the exception
+   * @param body the body for the response
+   * @param headers the headers for the response
+   * @param status the response status
+   * @param request the current request
+   * @return the error response
+   */
+  @Override
+  @Nonnull
+  @ParametersAreNonnullByDefault
+  protected ResponseEntity<Object> handleExceptionInternal(
+      Exception ex,
+      @Nullable Object body,
+      HttpHeaders headers,
+      HttpStatus status,
+      WebRequest request) {
+    log.info("Handling generic exception with response status {}", status, ex);
+    ModelMap map = new ModelMap();
+    map.addAttribute("timestamp", Instant.now());
+    map.addAttribute("exception", ex.getClass().getName());
+    map.addAttribute("error", status.getReasonPhrase());
+    map.addAttribute("status", status.value());
+    if (ex instanceof HasAdditionalAttributes) {
+      map.addAllAttributes(((HasAdditionalAttributes) ex).getAdditionalAttributes());
+    }
+    if (ex instanceof Errors) {
+      // like BindException
+      Errors errors = (Errors) ex;
+      String message =
+          "Validation failed for object '"
+              + errors.getObjectName()
+              + "' with error count "
+              + errors.getErrorCount();
+      map.addAttribute("message", message);
+      map.addAttribute("errors", errors.getAllErrors());
+    } else {
+      String message = ex.getMessage();
+      if (StringUtils.hasText(message)) {
+        map.addAttribute("message", message);
+      }
+    }
+    return ResponseEntity.status(status).headers(headers).body(map);
   }
 }

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/ConstraintViolationAdvice.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/ConstraintViolationAdvice.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.web.exceptions;
+
+import com.netflix.spinnaker.kork.api.exceptions.ConstraintViolationContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@RequiredArgsConstructor
+public class ConstraintViolationAdvice {
+  private final ConstraintViolationContext context;
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ConstraintViolationResponse> handleConstraintViolationException(
+      ConstraintViolationException e) {
+    ConstraintViolationResponse response = new ConstraintViolationResponse();
+    List<ConstraintViolationError> errors = combine(e.getConstraintViolations(), context);
+    response.setErrors(errors);
+    return ResponseEntity.badRequest().body(response);
+  }
+
+  private static List<ConstraintViolationError> combine(
+      Set<ConstraintViolation<?>> constraintViolations, ConstraintViolationContext context) {
+    var errors =
+        constraintViolations.stream()
+            .map(
+                constraintViolation ->
+                    context
+                        .removeMatchingViolation(
+                            violation -> violationsMatch(constraintViolation, violation))
+                        .map(
+                            violation ->
+                                ConstraintViolationError.builder()
+                                    .message(violation.getMessage())
+                                    .errorCode(violation.getErrorCode())
+                                    .path(constraintViolation.getPropertyPath().toString())
+                                    .additionalAttributes(violation.getAdditionalAttributes())
+                                    .build())
+                        .orElseGet(() -> translate(constraintViolation)))
+            .collect(Collectors.toCollection(ArrayList::new));
+    context.getConstraintViolations().stream()
+        .map(ConstraintViolationAdvice::translate)
+        .forEach(errors::add);
+    return errors;
+  }
+
+  private static boolean violationsMatch(
+      ConstraintViolation<?> constraintViolation,
+      com.netflix.spinnaker.kork.api.exceptions.ConstraintViolation violation) {
+    return constraintViolation.getLeafBean() == violation.getValidatedObject()
+        && constraintViolation.getMessageTemplate().equals(violation.getErrorCode());
+  }
+
+  private static ConstraintViolationError translate(ConstraintViolation<?> violation) {
+    return ConstraintViolationError.builder()
+        .message(violation.getMessage())
+        .errorCode(violation.getMessageTemplate())
+        .path(violation.getPropertyPath().toString())
+        .build();
+  }
+
+  private static ConstraintViolationError translate(
+      com.netflix.spinnaker.kork.api.exceptions.ConstraintViolation violation) {
+    return ConstraintViolationError.builder()
+        .message(violation.getMessage())
+        .errorCode(violation.getErrorCode())
+        .path(violation.getPath())
+        .additionalAttributes(violation.getAdditionalAttributes())
+        .build();
+  }
+}

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/ConstraintViolationError.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/ConstraintViolationError.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.web.exceptions;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+/** Summarizes a {@link javax.validation.ConstraintViolation}. */
+@Getter
+@ToString
+@Builder
+public class ConstraintViolationError {
+  private final String message;
+  private final String errorCode;
+  private final String path;
+  @Builder.Default private final Map<String, Object> additionalAttributes = Map.of();
+}

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/ConstraintViolationResponse.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/ConstraintViolationResponse.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.web.exceptions;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Summarizes a {@link javax.validation.ConstraintViolationException}. */
+@Getter
+@Setter
+public class ConstraintViolationResponse {
+  private Instant timestamp = Instant.now();
+  private List<ConstraintViolationError> errors;
+}

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/UpstreamRequestError.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/UpstreamRequestError.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.web.exceptions;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import java.net.URI;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpMethod;
+
+@Getter
+@Setter
+public class UpstreamRequestError {
+  private int status;
+  private String error;
+  private Instant timestamp = Instant.now();
+  private HttpMethod method;
+  private URI uri;
+  private String message;
+  @JsonRawValue private String body;
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,6 +37,7 @@ include(
   "kork-core-tck",
   "kork-credentials",
   "kork-credentials-api",
+  "kork-credentials-sql",
   "kork-crypto",
   "kork-eureka",
   "kork-exceptions",

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -139,6 +139,7 @@ dependencies {
     api("javax.xml.bind:jaxb-api:2.3.1")
     api("net.logstash.logback:logstash-logback-encoder:4.11")
     api("org.apache.commons:commons-exec:1.3")
+    api("org.apache.logging.log4j:log4j-api-kotlin:1.2.0")
     // TODO(jvz): beginning in BC 1.71, this should use the -jdk18on artifacts
     api("org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}")
     api("org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}")


### PR DESCRIPTION
This supersedes https://github.com/spinnaker/kork/pull/1013.

Broken up into logical commits, this extracts most of the credentials management functionality added to Clouddriver a while back. As I've worked on porting this functionality to Kayenta and Igor, I needed reusable APIs and SDKs for managing and inspecting credentials, and this PR includes all the changes I've been using in production so far in these services. As such, here's an overview of what's included:

* (web) Exception handling updates for both generic exceptions (where Spring otherwise hides relevant error information from the user) and exceptions raised by Spring's `WebClient` API (which offers much richer exceptions than the equivalent Retrofit ones)
* (api) New `ConstraintViolation` API for a generic model to expose constraint violations when validating various REST APIs
* (security) Introduces the `AccessControlled` interface along with some other abstractions above Fiat
* (secrets) Improved error handling for external and user secrets
* (credentials-api) Extracted some APIs from Clouddriver into Kork for credentials management
* (credentials) Several SDKs for implementing credentials management added including validation, secrets integration, and a much improved configuration DSL making `CredentialsTypeProperties` the go-to way of configuring credentials-related beans in most use cases
* (credentials-sql) Extracted and updated the SQL implementation of credentials storage

I'll annotate some classes in the diff to highlight interesting bits. There will be additional PRs following the merging of this to update Fiat, Clouddriver, Igor, Kayenta, and Gate.

Edit: the test failure was expected as I have some SQL integration tests that rely on a different CI setup that needs to be updated for how we run tests here.