### PR TITLE
feat(security): Add access-controlled interfaces

### DIFF
--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AbstractPermissionEvaluator.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AbstractPermissionEvaluator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import java.io.Serializable;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Base implementation for permission evaluators that support {@link AccessControlled} domain
+ * objects.
+ */
+public abstract class AbstractPermissionEvaluator implements PermissionEvaluator {
+
+  @Override
+  public boolean hasPermission(
+      Authentication authentication, Object targetDomainObject, Object permission) {
+    if (isDisabled()) {
+      return true;
+    }
+    if (authentication == null || targetDomainObject == null) {
+      return false;
+    }
+    if (SpinnakerAuthorities.isAdmin(authentication)) {
+      return true;
+    }
+    if (targetDomainObject instanceof AccessControlled) {
+      return ((AccessControlled) targetDomainObject).isAuthorized(authentication, permission);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean hasPermission(
+      Authentication authentication, Serializable targetId, String targetType, Object permission) {
+    if (isDisabled()) {
+      return true;
+    }
+    return hasPermission(
+        SpinnakerUsers.getUserId(authentication), targetId, targetType, permission);
+  }
+
+  /**
+   * Indicates whether permission evaluation is disabled. When this is true, {@code hasPermission}
+   * calls should return true. This should be overridden to allow for toggling this evaluator at
+   * runtime.
+   */
+  protected boolean isDisabled() {
+    return false;
+  }
+
+  /**
+   * Alternative method for evaluating a permission where only the identifier of the user and target
+   * object is available, rather than the authenticated user and target objects themselves.
+   *
+   * @param username identifier for user to check permissions for
+   * @param targetId identifier of the target resource to check permissions
+   * @param targetType the type of the target resource being checked
+   * @param permission the permission being validated
+   * @return true if the permission is granted
+   */
+  public abstract boolean hasPermission(
+      String username, Serializable targetId, String targetType, Object permission);
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AccessControlled.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AccessControlled.java
@@ -16,18 +16,26 @@
 
 package com.netflix.spinnaker.security;
 
+import java.util.Collection;
 import org.springframework.security.core.Authentication;
 
 /**
  * An AccessControlled object is an object that knows its own permissions and can check them against
  * a given user and authorization. This allows resources to support access control checks via Spring
  * Security against the resource object directly.
+ *
+ * @see AbstractPermissionEvaluator
  */
 public interface AccessControlled {
   /**
    * Checks if the authenticated user has a particular authorization on this object. Note that
    * checking if the user is an admin should be performed by a {@link
-   * org.springframework.security.access.PermissionEvaluator} rather than in these domain objects.
+   * org.springframework.security.access.PermissionEvaluator} or by checking {@link
+   * SpinnakerAuthorities#isAdmin(Authentication)} rather than via this method as the admin role is
+   * a Spinnaker-specific role.
+   *
+   * @see Authorization
+   * @see SpinnakerAuthorities#hasAnyRole(Authentication, Collection)
    */
   boolean isAuthorized(Authentication authentication, Object authorization);
 }

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AllowedAccountAuthority.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AllowedAccountAuthority.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.io.InvalidObjectException;
+import java.io.Serializable;
+import java.util.Locale;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * Represents an authorization to use an account. Allowed account authorities are based on an older
+ * security mechanism used by Spinnaker before other account types besides cloud providers and
+ * permissions were added.
+ */
+@Getter
+@EqualsAndHashCode(of = "account")
+@NonnullByDefault
+public class AllowedAccountAuthority implements GrantedAuthority, Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final String account;
+  private final String authority;
+
+  public AllowedAccountAuthority(String account) {
+    this.account = account.toLowerCase(Locale.ROOT);
+    authority = AllowedAccountsAuthorities.PREFIX + this.account;
+  }
+
+  private Object writeReplace() {
+    return new SerializationProxy(this);
+  }
+
+  private Object readObject() throws InvalidObjectException {
+    throw new InvalidObjectException("Proxy required");
+  }
+
+  private static class SerializationProxy implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final String account;
+
+    private SerializationProxy(AllowedAccountAuthority authority) {
+      account = authority.account;
+    }
+
+    private Object readResolve() {
+      return new AllowedAccountAuthority(account);
+    }
+  }
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/Authorization.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/Authorization.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import org.springframework.security.core.Authentication;
+
+/**
+ * Defines types of authorizations supported by {@link AccessControlled#isAuthorized(Authentication,
+ * Object)}.
+ */
+public enum Authorization {
+  READ,
+  WRITE,
+  EXECUTE,
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/AuthorizationMapControlled.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/AuthorizationMapControlled.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import java.util.Locale;
+import javax.annotation.Nullable;
+
+/**
+ * Common interface for access-controlled classes which use a permission map of {@link
+ * Authorization} enums.
+ */
+public interface AuthorizationMapControlled extends PermissionMapControlled<Authorization> {
+  @Nullable
+  @Override
+  default Authorization valueOf(@Nullable Object authorization) {
+    return authorization != null
+        ? Enum.valueOf(Authorization.class, authorization.toString().toUpperCase(Locale.ROOT))
+        : null;
+  }
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/PermissionMapControlled.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/PermissionMapControlled.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Common interface for access-controlled classes which use a permission map.
+ *
+ * @param <Authorization> Authorization enum type
+ */
+@Alpha
+public interface PermissionMapControlled<Authorization extends Enum<Authorization>>
+    extends AccessControlled {
+  @Nullable
+  Authorization valueOf(@Nullable Object authorization);
+
+  @Nonnull
+  default Map<Authorization, Set<String>> getPermissions() {
+    return Map.of();
+  }
+
+  @Override
+  default boolean isAuthorized(Authentication authentication, Object authorization) {
+    Authorization auth = valueOf(authorization);
+    if (auth == null) {
+      return false;
+    }
+    Set<String> permittedRoles = getPermissions().getOrDefault(auth, Set.of());
+    return permittedRoles.isEmpty()
+        || SpinnakerAuthorities.hasAnyRole(authentication, permittedRoles);
+  }
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/SpinnakerAuthorities.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/SpinnakerAuthorities.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.security;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+/**
+ * Constants and utilities for working with Spring Security GrantedAuthority objects specific to
+ * Spinnaker and Fiat. Spinnaker-specific roles are represented here as granted authorities with the
+ * {@code SPINNAKER_} prefix.
+ */
+public class SpinnakerAuthorities {
+  private static final String ROLE_PREFIX = "ROLE_";
+
+  public static final String ADMIN = "SPINNAKER_ADMIN";
+  /** Granted authority for Spinnaker administrators. */
+  public static final GrantedAuthority ADMIN_AUTHORITY = new SimpleGrantedAuthority(ADMIN);
+
+  /** Granted authority for anonymous users. */
+  public static final GrantedAuthority ANONYMOUS_AUTHORITY = forRoleName("ANONYMOUS");
+
+  /** Creates a granted authority corresponding to the provided name of a role. */
+  @Nonnull
+  public static GrantedAuthority forRoleName(@Nonnull String role) {
+    return new SimpleGrantedAuthority(ROLE_PREFIX + role);
+  }
+
+  /** Checks if the given user is a Spinnaker admin. */
+  public static boolean isAdmin(@Nullable Authentication authentication) {
+    return authentication != null
+        && authentication.getAuthorities().contains(SpinnakerAuthorities.ADMIN_AUTHORITY);
+  }
+
+  /** Checks if the given user has the provided role. */
+  public static boolean hasRole(@Nullable Authentication authentication, @Nonnull String role) {
+    return authentication != null && streamRoles(authentication).anyMatch(role::equals);
+  }
+
+  /** Checks if the given user has any of the provided roles. */
+  public static boolean hasAnyRole(
+      @Nullable Authentication authentication, @Nonnull Collection<String> roles) {
+    return authentication != null && streamRoles(authentication).anyMatch(roles::contains);
+  }
+
+  /** Gets the list of roles assigned to the given user. */
+  @Nonnull
+  public static List<String> getRoles(@Nullable Authentication authentication) {
+    if (authentication == null) {
+      return List.of();
+    }
+    return streamRoles(authentication).distinct().collect(Collectors.toList());
+  }
+
+  @Nonnull
+  private static Stream<String> streamRoles(@Nonnull Authentication authentication) {
+    return authentication.getAuthorities().stream()
+        .filter(SpinnakerAuthorities::isRole)
+        .map(SpinnakerAuthorities::getRole);
+  }
+
+  private static boolean isRole(@Nonnull GrantedAuthority authority) {
+    return authority.getAuthority().startsWith(ROLE_PREFIX);
+  }
+
+  private static String getRole(@Nonnull GrantedAuthority authority) {
+    return authority.getAuthority().substring(ROLE_PREFIX.length());
+  }
+}

--- a/kork-security/src/main/java/com/netflix/spinnaker/security/SpinnakerUsers.java
+++ b/kork-security/src/main/java/com/netflix/spinnaker/security/SpinnakerUsers.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.security;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import javax.annotation.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/** Constants and utilities related to Spinnaker users (AKA principals). */
+@NonnullByDefault
+public class SpinnakerUsers {
+  /** String constant for the anonymous userid. */
+  public static final String ANONYMOUS = "anonymous";
+
+  /** Gets the userid of the provided authentication token. */
+  public static String getUserId(@Nullable Authentication authentication) {
+    return authentication != null ? authentication.getName() : ANONYMOUS;
+  }
+
+  /** Gets the current Spinnaker userid. */
+  public static String getCurrentUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null) {
+      return getUserId(authentication);
+    }
+    // fall back to request header context if relevant (AuthenticatedRequestFilter)
+    return AuthenticatedRequest.getSpinnakerUser().orElse(ANONYMOUS);
+  }
+}

--- a/kork-security/src/test/groovy/com/netflix/spinnaker/security/AllowedAccountsAuthoritiesSpec.groovy
+++ b/kork-security/src/test/groovy/com/netflix/spinnaker/security/AllowedAccountsAuthoritiesSpec.groovy
@@ -18,10 +18,8 @@ package com.netflix.spinnaker.security
 
 import org.hamcrest.Matchers
 import org.springframework.security.core.GrantedAuthority
-import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.User
 import spock.lang.Specification
-
-import static com.netflix.spinnaker.security.AllowedAccountsAuthorities.PREFIX
 
 class AllowedAccountsAuthoritiesSpec extends Specification {
   def "extracts allowed accounts from granted authorities"() {
@@ -41,14 +39,14 @@ class AllowedAccountsAuthoritiesSpec extends Specification {
 
     where:
     accounts                       || expected
-    ["A", null, "", "b", "b", "C"] || [a(PREFIX + "a"), a(PREFIX + "b"), a(PREFIX + "c")]
+    ['A', null, '', 'b', 'b', 'C'] || [a('a'), a('b'), a('c')]
   }
 
   private static GrantedAuthority a(String name) {
-    return new SimpleGrantedAuthority(name)
+    return new AllowedAccountAuthority(name)
   }
 
-  private static org.springframework.security.core.userdetails.User u(String name, Collection<String> accounts = []) {
-    new org.springframework.security.core.userdetails.User(name, "", accounts.collect { a(PREFIX + it) })
+  private static User u(String name, Collection<String> accounts = []) {
+    new User(name, "", accounts.collect { a(it) })
   }
 }


### PR DESCRIPTION
This adds more functionality to kork-security to help abstract Fiat functionality needed in Kork.