### PR TITLE
feat(web): Improve error handling for WebClient

### DIFF
--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/UpstreamRequestError.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/UpstreamRequestError.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.web.exceptions;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import java.net.URI;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpMethod;
+
+@Getter
+@Setter
+public class UpstreamRequestError {
+  private int status;
+  private String error;
+  private Instant timestamp = Instant.now();
+  private HttpMethod method;
+  private URI uri;
+  private String message;
+  @JsonRawValue private String body;
+}


### PR DESCRIPTION
This ensures that errors in WebClient are treated similarly to Retrofit.