### PR TITLE
feat(credentials-api): Add CredentialsDefinitionRepository

### DIFF
--- a/kork-credentials-api/kork-credentials-api.gradle
+++ b/kork-credentials-api/kork-credentials-api.gradle
@@ -21,12 +21,19 @@ dependencies {
   implementation(platform(project(":spinnaker-dependencies")))
   implementation project(":kork-annotations")
   implementation project(":kork-exceptions")
+  implementation project(":kork-plugins-api")
   implementation 'javax.annotation:javax.annotation-api'
+  implementation 'jakarta.validation:jakarta.validation-api'
+  implementation "org.springframework:spring-beans"
+  implementation "org.apache.logging.log4j:log4j-api"
+  implementation "io.micrometer:micrometer-core"
 
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 
+  testImplementation 'org.springframework.boot:spring-boot-starter-test'
+  testImplementation 'org.springframework.boot:spring-boot-starter-validation'
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsError.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsError.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+/** Describes an error encountered loading or parsing credentials. */
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Data
+public class CredentialsError {
+  @Nonnull private String errorCode;
+  @Nonnull private String message;
+  @Nullable private String field;
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsSource.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsSource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+
+/** Describes where these credentials come from. */
+@Alpha
+public enum CredentialsSource {
+  /**
+   * Describes credentials stored in {@linkplain CredentialsDefinitionRepository account storage}.
+   */
+  STORAGE,
+  /** Describes credentials stored in configuration files. */
+  CONFIG,
+  /** Describes credentials provided by a plugin. */
+  PLUGIN,
+  /**
+   * Describes credentials provided from an external source such as a custom resource definition.
+   */
+  EXTERNAL,
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsView.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsView.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.credentials.definition.CredentialsType;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Provides a view into a credential definition for a user. */
+@Data
+@Alpha
+@NoArgsConstructor
+@AllArgsConstructor
+public class CredentialsView {
+  /**
+   * Provides metadata regarding a credential definition including the account name, the source from
+   * which it came, and the type of credentials (corresponding to its {@link CredentialsType} type
+   * discriminator value).
+   *
+   * @see CredentialsSource
+   */
+  private Metadata metadata = new Metadata();
+
+  /**
+   * Provides the current specification of the credentials. This may be an instance of a {@link
+   * Map}, a {@code JsonNode}, or a {@link CredentialsDefinition} depending on how far the parser
+   * gets before encountering an error. For a map result, this will contain a key named {@code data}
+   * pointing to a string containing the invalid JSON data. For a {@code JsonNode} result, this is
+   * valid JSON but not in the expected form of a {@link CredentialsDefinition}. For a {@link
+   * CredentialsDefinition}, this will not have any secrets decrypted. If more than one credential
+   * is available from multiple services, this will be a list of them.
+   */
+  private Object spec;
+
+  /** Describes the status of this credential definition. */
+  private final Status status = new Status();
+
+  @Data
+  public static class Metadata {
+    /** Provides the name of the account. May be null if unknown (and is not likely parseable). */
+    @Nullable private String name;
+    /** Provides the type discriminator of the credentials. May be null if unknown. */
+    @Nullable private String type;
+    /** Provides the entity tag of the credentials. If no history is tracked, this may be null. */
+    @Nullable private String eTag;
+    /**
+     * Provides the instant these credentials were last modified. If untracked, this may be null.
+     */
+    @Nullable private Instant lastModified;
+
+    /** Describes the source of this credential definition. */
+    private CredentialsSource source;
+  }
+
+  @Data
+  public static class Status {
+    /**
+     * Indicates if these credentials are valid. If false, then the errors list will be non-empty.
+     */
+    private boolean valid = true;
+    /** Lists the errors encountered if the account is invalid. */
+    private List<CredentialsError> errors = new ArrayList<>();
+
+    /** Adds an error to this status and resets the {@link #isValid()} flag to {@code false}. */
+    public void addError(CredentialsError error) {
+      valid = false;
+      errors.add(error);
+    }
+
+    /**
+     * Adds a collection of errors to this status and resets the {@link #isValid()} flag to {@code
+     * false}.
+     */
+    public void addErrors(Collection<CredentialsError> credentialsErrors) {
+      valid = false;
+      errors.addAll(credentialsErrors);
+    }
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionConstraintValidator.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionConstraintValidator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import java.util.regex.Pattern;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.util.StringUtils;
+
+/**
+ * Constraint validator implementation for the {@link ValidatedCredentials} annotation. Validation
+ * of credentials includes checking that its name matches the configured {@link
+ * CredentialsDefinitionNamePatternProvider} bean-provided regular expression using the credentials
+ * type name extracted by the configured {@link CredentialsDefinitionTypeExtractor} bean along with
+ * any other {@link CredentialsDefinitionValidator} beans found at runtime.
+ */
+@RequiredArgsConstructor
+public class CredentialsDefinitionConstraintValidator
+    implements ConstraintValidator<ValidatedCredentials, CredentialsDefinition> {
+  private final CredentialsDefinitionTypeExtractor typeExtractor;
+  private final CredentialsDefinitionNamePatternProvider namePatternProvider;
+  private final ObjectProvider<CredentialsDefinitionValidator> validators;
+
+  @Override
+  public boolean isValid(CredentialsDefinition value, ConstraintValidatorContext context) {
+    context.disableDefaultConstraintViolation();
+    String name = value.getName();
+    if (!StringUtils.hasText(name)) {
+      context
+          .buildConstraintViolationWithTemplate("missing account name")
+          .addPropertyNode("name")
+          .addConstraintViolation();
+      return false;
+    }
+    String type = typeExtractor.getCredentialsType(value);
+    if (type == null) {
+      context.buildConstraintViolationWithTemplate("missing account type").addConstraintViolation();
+      return false;
+    }
+    Pattern pattern = namePatternProvider.getPatternForType(type);
+    boolean valid = pattern.matcher(name).matches();
+    if (!valid) {
+      context
+          .buildConstraintViolationWithTemplate("account name does not match pattern " + pattern)
+          .addPropertyNode("name")
+          .addConstraintViolation();
+    }
+    for (CredentialsDefinitionValidator validator : validators) {
+      valid &= validator.isValid(value, context);
+    }
+    return valid;
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionNamePatternProvider.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionNamePatternProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import java.util.regex.Pattern;
+
+/**
+ * Provides validation patterns for {@linkplain CredentialsDefinition#getName() credentials names}.
+ * A bean of this type (along with {@link CredentialsDefinitionTypeExtractor}) must be registered in
+ * order to use the {@link ValidatedCredentials} constraint annotation on credentials.
+ *
+ * @see CredentialsDefinitionTypeExtractor
+ * @see ValidatedCredentials
+ */
+@FunctionalInterface
+public interface CredentialsDefinitionNamePatternProvider {
+  Pattern getPatternForType(String type);
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionTypeExtractor.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionTypeExtractor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import javax.annotation.Nullable;
+
+/**
+ * Strategy for extracting a credentials type name from a credential definition. A bean of this type
+ * must be registered (along with {@link CredentialsDefinitionNamePatternProvider}) to use the
+ * {@link ValidatedCredentials} constraint annotation on credentials.
+ *
+ * @see com.netflix.spinnaker.credentials.definition.CredentialsType
+ * @see CredentialsDefinitionNamePatternProvider
+ * @see ValidatedCredentials
+ */
+@FunctionalInterface
+public interface CredentialsDefinitionTypeExtractor {
+  @Nullable
+  String getCredentialsType(CredentialsDefinition definition);
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionValidator.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/CredentialsDefinitionValidator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
+import javax.validation.ConstraintValidator;
+
+/**
+ * Validates a {@link CredentialsDefinition} instance. Beans of this type are used when validating
+ * the {@link ValidatedCredentials} constraint annotation.
+ */
+public interface CredentialsDefinitionValidator
+    extends SpinnakerExtensionPoint,
+        ConstraintValidator<ValidatedCredentials, CredentialsDefinition> {}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/ValidatedCredentials.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/ValidatedCredentials.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Validation annotation to apply to {@link CredentialsDefinition} classes and parameters to ensure
+ * that the annotated credentials have been validated.
+ *
+ * @see CredentialsDefinitionValidator
+ * @see CredentialsDefinitionTypeExtractor
+ * @see CredentialsDefinitionNamePatternProvider
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.PARAMETER})
+@Constraint(validatedBy = CredentialsDefinitionConstraintValidator.class)
+public @interface ValidatedCredentials {
+  String message() default "";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/package-info.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/constraint/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonnullByDefault
+package com.netflix.spinnaker.credentials.constraint;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CompositeCredentialsNavigator.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CompositeCredentialsNavigator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Composite implementation of {@link CredentialsNavigator} for combining a collection of {@link
+ * CredentialsDefinitionSource} beans of the same credential type.
+ *
+ * @param <T> type of credentials
+ */
+@Alpha
+@RequiredArgsConstructor
+public class CompositeCredentialsNavigator<T extends CredentialsDefinition>
+    implements CredentialsNavigator<T> {
+  private final List<CredentialsDefinitionSource<T>> sources;
+  @Getter private final Class<T> type;
+  @Getter private final String typeName;
+
+  @Override
+  public List<T> getCredentialsDefinitions() {
+    return sources.stream()
+        .flatMap(source -> source.getCredentialsDefinitions().stream())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<CredentialsView> listCredentialsViews() {
+    return sources.stream()
+        .flatMap(
+            source -> {
+              if (source instanceof CredentialsNavigator<?>) {
+                // this source already knows how to list views
+                return ((CredentialsNavigator<T>) source).listCredentialsViews().stream();
+              }
+              // otherwise, create views just like super::listCredentialsViews
+              return source.getCredentialsDefinitions().stream()
+                  .map(
+                      definition -> {
+                        var metadata = new CredentialsView.Metadata();
+                        metadata.setType(getTypeName());
+                        metadata.setName(definition.getName());
+                        metadata.setSource(source.getSource());
+                        return new CredentialsView(metadata, definition);
+                      });
+            })
+        .collect(Collectors.toList());
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinition.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinition.java
@@ -17,14 +17,18 @@
 package com.netflix.spinnaker.credentials.definition;
 
 import com.netflix.spinnaker.credentials.Credentials;
+import com.netflix.spinnaker.credentials.constraint.ValidatedCredentials;
 
 /**
  * Contains properties that define {@link Credentials}. {@link CredentialsDefinition} can be POJOs
  * deserialized from configuration or an external system. These are optional but useful to use
- * built-in {@link CredentialsParser}.
+ * built-in {@link CredentialsParser}. Implementations that wish to support account storage must
+ * also be annotated with {@link CredentialsType} corresponding to the type discriminator to use for
+ * serialization and deserialization.
  *
  * <p>equals is checked to detect change in definitions
  */
+@ValidatedCredentials
 public interface CredentialsDefinition {
   String getName();
 }

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionRepository.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionRepository.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.credentials.definition.error.DuplicateCredentialsDefinitionException;
+import com.netflix.spinnaker.credentials.definition.error.GenericCredentialsDefinitionRepositoryException;
+import com.netflix.spinnaker.credentials.definition.error.InvalidCredentialsDefinitionException;
+import com.netflix.spinnaker.credentials.definition.error.NoMatchingCredentialsException;
+import com.netflix.spinnaker.credentials.definition.error.NoSuchCredentialsDefinitionException;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import com.netflix.spinnaker.kork.exceptions.InvalidCredentialsTypeException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import lombok.Getter;
+
+/** Provides CRUD persistence operations for account {@link CredentialsDefinition} instances. */
+@Alpha
+public interface CredentialsDefinitionRepository {
+
+  /**
+   * Searches for an existing credentials definition with the given name. If the credentials contain
+   * secret references, then those will be fetched and decrypted.
+   *
+   * @param name name of credentials to look up
+   * @return the credentials with that name or empty if none exist
+   */
+  @Nullable
+  CredentialsDefinition findByName(String name);
+
+  @Nullable
+  CredentialsView.Metadata findMetadataByName(String name);
+
+  /**
+   * Lists credentials definitions for a given credentials type. Credential types correspond to the
+   * value in the {@link CredentialsType} or {@code com.fasterxml.jackson.annotation.JsonTypeName}
+   * annotation present on the corresponding {@link CredentialsDefinition} class. If the credentials
+   * contain secret references, then those will be fetched and decrypted.
+   *
+   * @param typeName credential type to search for
+   * @return list of all stored credentials definitions matching the given credentials type name
+   */
+  List<CredentialsDefinition> listByType(String typeName);
+
+  /**
+   * Lists credentials definitions for a given credentials class. This works similarly to {@link
+   * #listByType(String)}, though the type name is extracted from the given class, and the result is
+   * safely cast to the provided class.
+   *
+   * @param type credential type to search for
+   * @return list of all stored credentials definitions with the given type
+   * @param <T> type of credentials
+   */
+  <T extends CredentialsDefinition> List<T> listByType(Class<T> type);
+
+  /**
+   * Lists credentials views for a given credentials type. These views should be post-processed by a
+   * {@link CredentialsNavigator}
+   *
+   * @return list of accessible credentials and their statuses
+   */
+  List<CredentialsView> listCredentialsViews(String typeName);
+
+  /**
+   * Creates a new credentials definition using the provided data. Secrets should use {@code
+   * UserSecretReference} encrypted URIs (e.g., {@code
+   * secret://secrets-manager?r=us-west-2&s=my-account-credentials}); raw secrets on sensitive
+   * fields will be excluded by default. Encrypted URIs will only be decrypted when loading account
+   * definitions, not when storing them. Note that account definitions correspond to the JSON
+   * representation of the underlying {@link CredentialsDefinition} object along with a JSON type
+   * discriminator field with the key {@code type} and value of the corresponding {@link
+   * CredentialsType} annotation. If an existing account exists for the same name, then this should
+   * return the existing account and metadata in a thrown {@link
+   * DuplicateCredentialsDefinitionException}.
+   *
+   * @param definition credentials definition to store as a new account
+   * @return metadata for the created credentials
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while saving the
+   *     credentials
+   * @throws InvalidCredentialsTypeException if the class of the provided credentials is not
+   *     annotated with @CredentialsType
+   * @throws InvalidCredentialsDefinitionException if there is an error serializing the provided
+   *     credentials
+   * @throws DuplicateCredentialsDefinitionException if credentials already exist with the same name
+   */
+  CredentialsView.Metadata create(CredentialsDefinition definition);
+
+  /**
+   * Creates or updates a credentials definition using the provided data. This is also known as an
+   * upsert operation. See {@link #create(CredentialsDefinition)} for more details.
+   *
+   * @param definition account definition to save
+   * @return metadata for the saved credentials
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while saving the
+   *     credentials
+   * @throws InvalidCredentialsTypeException if the class of the provided credentials is not
+   *     annotated with @CredentialsType
+   * @throws InvalidCredentialsDefinitionException if there is an error serializing the provided
+   *     credentials
+   */
+  CredentialsView.Metadata save(CredentialsDefinition definition);
+
+  /**
+   * Creates or updates credentials definitions in bulk.
+   *
+   * @return list of views of saved account definitions
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while saving the
+   *     credentials
+   * @throws InvalidCredentialsTypeException if the class of the provided credentials is not
+   *     annotated with @CredentialsType
+   * @throws InvalidCredentialsDefinitionException if there is an error serializing the provided
+   *     credentials
+   */
+  List<CredentialsView> saveAll(Collection<CredentialsDefinition> definitions);
+
+  /**
+   * Updates an existing credentials definition using the provided data. See details in {@link
+   * #create(CredentialsDefinition)} for details on the format.
+   *
+   * @param definition updated account definition to replace an existing account
+   * @return metadata of the updated account definition
+   * @throws NoSuchCredentialsDefinitionException if no account exists with the same name
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while saving the
+   *     account
+   * @throws InvalidCredentialsTypeException if the class of the provided credentials is not
+   *     annotated with @CredentialsType
+   * @throws InvalidCredentialsDefinitionException if there is an error serializing the provided
+   *     credentials
+   * @see #create(CredentialsDefinition)
+   */
+  CredentialsView.Metadata update(CredentialsDefinition definition);
+
+  /**
+   * Updates an existing credentials definition conditional on its existing etag matching one of the
+   * provided etag values.
+   *
+   * @param definition updated account definition to replace an existing account
+   * @param ifMatches list of one or more etag values to match an existing account against
+   * @return metadata of the updated account definition
+   * @throws NoSuchCredentialsDefinitionException if no account exists with the same name
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while saving the
+   *     account
+   * @throws InvalidCredentialsTypeException if the class of the provided credentials is not
+   *     annotated with @CredentialsType
+   * @throws InvalidCredentialsDefinitionException if there is an error serializing the provided
+   *     credentials
+   * @throws NoMatchingCredentialsException if an account exists with the same name and type but
+   *     does not match any of the provided etag values
+   * @see #create(CredentialsDefinition)
+   */
+  CredentialsView.Metadata updateIfMatch(CredentialsDefinition definition, List<String> ifMatches);
+
+  /**
+   * Returns the subset of names unknown to this repository from the provided collection of names.
+   * If this repository has credentials for all the provided names (or {@code names} is empty), then
+   * this returns an empty set.
+   *
+   * @param names credentials names to check
+   * @return subset of unknown credentials names
+   */
+  Set<String> getUnknownNames(Collection<String> names);
+
+  /**
+   * Deletes credentials by name.
+   *
+   * @param name name of account to delete
+   * @throws NoSuchCredentialsDefinitionException if no account exists with the same name
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while deleting the
+   *     account
+   */
+  void delete(String name);
+
+  /**
+   * Deletes multiple credentials by name.
+   *
+   * @param names names of accounts to delete
+   * @throws NoSuchCredentialsDefinitionException if one or more accounts requested do not exist
+   * @throws GenericCredentialsDefinitionRepositoryException if an error occurs while deleting the
+   *     accounts
+   */
+  void deleteAll(Collection<String> names);
+
+  /**
+   * Looks up the revision history of credentials by name. Revisions are sorted by latest version
+   * first.
+   *
+   * @param name account name to look up history for
+   * @return history of account updates for the given account name
+   */
+  List<Revision> revisionHistory(String name);
+
+  /**
+   * Provides metadata for a credentials definition revision when making updates to credentials via
+   * {@link CredentialsDefinitionRepository} APIs.
+   */
+  @Getter
+  class Revision {
+    /** Returns the revision id. Revision ids increase over time and are unique within a service. */
+    private final long revision;
+
+    /** Returns the instant when this revision was made. */
+    private final Instant timestamp;
+
+    /**
+     * Returns the credentials definition used in this revision. Returns {@code null} when this
+     * revision corresponds to a deletion.
+     */
+    private final @Nullable CredentialsDefinition account;
+
+    /**
+     * Returns the user who created this revision. May return {@code null} if this revision was made
+     * before this data began being tracked.
+     */
+    private final @Nullable String user;
+
+    /** Constructs a revision entry with a revision id, timestamp, and credentials definition. */
+    public Revision(long revision, Instant timestamp, @Nullable CredentialsDefinition account) {
+      this.revision = revision;
+      this.timestamp = timestamp;
+      this.account = account;
+      this.user = null;
+    }
+
+    /** Constructs a revision entry from a revision id, timestamp, definition, and userid. */
+    public Revision(
+        long revision,
+        Instant timestamp,
+        @Nullable CredentialsDefinition account,
+        @Nullable String user) {
+      this.revision = revision;
+      this.timestamp = timestamp;
+      this.account = account;
+      this.user = user;
+    }
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionSource.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionSource.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.credentials.definition;
 
+import com.netflix.spinnaker.credentials.CredentialsSource;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
 import java.util.List;
 
 /**
@@ -24,6 +26,13 @@ import java.util.List;
  *
  * @param <T>
  */
-public interface CredentialsDefinitionSource<T extends CredentialsDefinition> {
+public interface CredentialsDefinitionSource<T extends CredentialsDefinition>
+    extends SpinnakerExtensionPoint {
+  /** Returns the list of credential definitions provided by this source. */
   List<T> getCredentialsDefinitions();
+
+  /** Returns the type of source where these credential definitions are provided. */
+  default CredentialsSource getSource() {
+    return CredentialsSource.CONFIG;
+  }
 }

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionTypeProvider.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsDefinitionTypeProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
+import java.util.Map;
+
+/**
+ * Provides subtypes of {@link CredentialsDefinition} for registration as account definition types.
+ * All beans of this type contribute zero or more account classes.
+ */
+@Alpha
+public interface CredentialsDefinitionTypeProvider extends SpinnakerExtensionPoint {
+  Map<String, Class<? extends CredentialsDefinition>> getCredentialsTypes();
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsLoader.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsLoader.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.credentials.Credentials;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
+
+public interface CredentialsLoader<T extends Credentials> extends SpinnakerExtensionPoint {
+  CredentialsRepository<T> getCredentialsRepository();
+
+  void load();
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsNavigator.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsNavigator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.credentials.CredentialsView;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Navigates the sea of credentials provided by a Spinnaker service.
+ *
+ * @param <T> type of credentials definition tracked
+ */
+@Alpha
+public interface CredentialsNavigator<T extends CredentialsDefinition>
+    extends CredentialsDefinitionSource<T> {
+
+  /** Returns the {@link CredentialsType} type name tracked by this navigator. */
+  String getTypeName();
+
+  /** Returns the class of the credentials definition type supported. */
+  Class<T> getType();
+
+  /**
+   * Lists all views into credentials accessible to the current user of the type tracked by this
+   * navigator.
+   */
+  default List<CredentialsView> listCredentialsViews() {
+    return getCredentialsDefinitions().stream()
+        .map(
+            definition -> {
+              var metadata = new CredentialsView.Metadata();
+              metadata.setType(getTypeName());
+              metadata.setName(definition.getName());
+              metadata.setSource(getSource());
+              return new CredentialsView(metadata, definition);
+            })
+        .collect(Collectors.toList());
+  }
+
+  default Optional<T> findByName(String name) {
+    Class<T> type = getType();
+    return getCredentialsDefinitions().stream()
+        .filter(definition -> type.isInstance(definition) && name.equals(definition.getName()))
+        .map(type::cast)
+        .findFirst();
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/SafeCredentialsParser.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/SafeCredentialsParser.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition;
+
+import com.netflix.spinnaker.credentials.Credentials;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Wrapper for a {@link CredentialsParser} instance that prevents exceptions thrown during parsing
+ * from propagating to the caller. Invalid credentials are instead logged about and counted in
+ * metrics.
+ */
+@Log4j2
+@RequiredArgsConstructor
+public class SafeCredentialsParser<T extends CredentialsDefinition, U extends Credentials>
+    implements CredentialsParser<T, U> {
+  private final Counter parseErrors = Metrics.counter("credentials.parse.error");
+  private final CredentialsParser<T, U> delegate;
+
+  @Nullable
+  @Override
+  public U parse(T definition) {
+    try {
+      return delegate.parse(definition);
+    } catch (VirtualMachineError | ThreadDeath e) {
+      // these exceptions are unrecoverable and unremarkable (nothing to track here that JVM metrics
+      // don't already)
+      throw e;
+    } catch (Throwable t) {
+      parseErrors.increment();
+      log.warn("Unable to parse credentials definition with name '{}'", definition.getName(), t);
+      return null;
+    }
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/CredentialsDefinitionRepositoryException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/CredentialsDefinitionRepositoryException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.Getter;
+
+/**
+ * Base exception type for exceptions thrown by {@link CredentialsDefinitionRepository}. This
+ * exception type may also be used for wrapping transitive exceptions.
+ */
+public class CredentialsDefinitionRepositoryException extends SpinnakerException {
+  @Getter protected final Map<String, Object> additionalAttributes = new HashMap<>();
+
+  protected CredentialsDefinitionRepositoryException(String name, String message) {
+    this(name, message, null);
+  }
+
+  protected CredentialsDefinitionRepositoryException(Collection<String> names, String message) {
+    this(names, message, null);
+  }
+
+  protected CredentialsDefinitionRepositoryException(
+      String name, String message, @Nullable Throwable cause) {
+    super(message, cause);
+    additionalAttributes.put("name", name);
+  }
+
+  protected CredentialsDefinitionRepositoryException(
+      Collection<String> names, String message, @Nullable Throwable cause) {
+    super(message, cause);
+    additionalAttributes.put("names", names);
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/DuplicateCredentialsDefinitionException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/DuplicateCredentialsDefinitionException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import java.time.Instant;
+import javax.annotation.Nullable;
+import lombok.Getter;
+
+/** Exception thrown when a credentials definition already exists for a given name. */
+public class DuplicateCredentialsDefinitionException
+    extends CredentialsDefinitionRepositoryException {
+  @Getter private final Object existing;
+  @Getter private final String eTag;
+  @Getter private final Instant lastModified;
+
+  public DuplicateCredentialsDefinitionException(
+      Object existing, String name, String eTag, Instant lastModified, @Nullable Throwable cause) {
+    super(name, "Duplicate credentials", cause);
+    this.existing = existing;
+    this.eTag = eTag;
+    this.lastModified = lastModified;
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/GenericCredentialsDefinitionRepositoryException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/GenericCredentialsDefinitionRepositoryException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+import java.util.Collection;
+
+/**
+ * Exception thrown when an unknown error occurs in {@link CredentialsDefinitionRepository} actions.
+ */
+public class GenericCredentialsDefinitionRepositoryException
+    extends CredentialsDefinitionRepositoryException {
+
+  public GenericCredentialsDefinitionRepositoryException(
+      String name, String message, Throwable cause) {
+    super(name, message, cause);
+  }
+
+  public GenericCredentialsDefinitionRepositoryException(
+      Collection<String> names, String message, Throwable cause) {
+    super(names, message, cause);
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/InvalidCredentialsDefinitionException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/InvalidCredentialsDefinitionException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionRepository;
+
+/**
+ * Exception thrown when an attempt is made to store invalid credentials into a {@link
+ * CredentialsDefinitionRepository}.
+ */
+public class InvalidCredentialsDefinitionException
+    extends CredentialsDefinitionRepositoryException {
+  public InvalidCredentialsDefinitionException(String name, String message, Throwable cause) {
+    super(name, message, cause);
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/NoMatchingCredentialsException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/NoMatchingCredentialsException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import java.time.Instant;
+import javax.annotation.Nullable;
+import lombok.Getter;
+
+/** Exception thrown when a conditional update fails to match any requested etag. */
+public class NoMatchingCredentialsException extends CredentialsDefinitionRepositoryException {
+  @Getter private final Object existing;
+  @Getter private final String eTag;
+  @Getter private final Instant lastModified;
+
+  public NoMatchingCredentialsException(
+      Object existing, String name, String eTag, Instant lastModified) {
+    this(existing, name, eTag, lastModified, null);
+  }
+
+  public NoMatchingCredentialsException(
+      Object existing, String name, String eTag, Instant lastModified, @Nullable Throwable cause) {
+    super(name, "No matching credentials", cause);
+    this.existing = existing;
+    this.eTag = eTag;
+    this.lastModified = lastModified;
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/NoSuchCredentialsDefinitionException.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/NoSuchCredentialsDefinitionException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.credentials.definition.error;
+
+import java.util.Collection;
+import javax.annotation.Nullable;
+
+/**
+ * Exception thrown when no credentials definitions exist for a given name or collection of names
+ * (bulk operations).
+ */
+public class NoSuchCredentialsDefinitionException extends CredentialsDefinitionRepositoryException {
+  public NoSuchCredentialsDefinitionException(String name, String message) {
+    super(name, message);
+  }
+
+  public NoSuchCredentialsDefinitionException(
+      String name, String message, @Nullable Throwable cause) {
+    super(name, message, cause);
+  }
+
+  public NoSuchCredentialsDefinitionException(Collection<String> names, String message) {
+    super(names, message);
+  }
+}

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/package-info.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/error/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonnullByDefault
+package com.netflix.spinnaker.credentials.definition.error;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;

--- a/kork-credentials/kork-credentials.gradle
+++ b/kork-credentials/kork-credentials.gradle
@@ -20,6 +20,8 @@ apply from: "$rootDir/gradle/lombok.gradle"
 dependencies {
   api project(":kork-credentials-api")
   api project(":kork-annotations")
+  api project(":kork-plugins-api")
+  api project(":kork-secrets")
   implementation(platform(project(":spinnaker-dependencies")))
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation "org.springframework.boot:spring-boot"


### PR DESCRIPTION
This adds the credentials management API originally developed as part of Clouddriver.