### PR TITLE
chore(dependency): refactor correct coordinate of jsch dependency

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -83,7 +83,7 @@ dependencies {
     // JinJava 2.5.3 has a bad bug: https://github.com/HubSpot/jinjava/issues/429
     api("com.hubspot.jinjava:jinjava:2.5.2")
     api("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
-    api("com.jcraft.jsch:${versions.jsch}")
+    api("com.jcraft:jsch:${versions.jsch}")
     api("com.jcraft:jsch.agentproxy.connector-factory:${versions.jschAgentProxy}")
     api("com.jcraft:jsch.agentproxy.jsch:${versions.jschAgentProxy}")
     api("com.natpryce:hamkrest:1.4.2.2")


### PR DESCRIPTION
Correct coordinate of jsch dependency is com.jcraft:jsch.
 https://repo1.maven.org/maven2/com/jcraft/jsch/0.1.54/jsch-0.1.54.pom