### PR TITLE
fix(artifacts/test): clear the ArtifactStore.instance in S3ArtifactSt…

### DIFF
--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreConfigurationTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreConfigurationTest.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfigura
 import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreURIBuilder;
 import com.netflix.spinnaker.kork.artifacts.artifactstore.NoopArtifactStoreGetter;
 import com.netflix.spinnaker.kork.artifacts.artifactstore.NoopArtifactStoreStorer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -40,6 +41,16 @@ class S3ArtifactStoreConfigurationTest {
   @BeforeEach
   void init(TestInfo testInfo) {
     System.out.println("--------------- Test " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void cleanup() {
+    // Clear ArtifactStore.instance so we don't leave lingering state for other
+    // tests that assume it's null.
+    //
+    // Note that ArtifactStore.setInstance(null) doesn't set instance to null
+    // if it's already set.
+    ReflectionTestUtils.setField(ArtifactStore.class, "instance", null);
   }
 
   @Test
@@ -63,29 +74,20 @@ class S3ArtifactStoreConfigurationTest {
 
   @Test
   void testArtifactStoreS3Enabled() {
-    try {
-      runner
-          .withPropertyValues(
-              "artifact-store.type=s3",
-              "artifact-store.s3.enabled=true",
-              "artifact-store.s3.region=us-west-2") // arbitrary region
-          .run(
-              ctx -> {
-                assertThat(ctx).hasSingleBean(ArtifactStoreURIBuilder.class);
-                assertThat(ctx).hasSingleBean(ArtifactStore.class);
-                assertThat(ctx).hasSingleBean(S3ArtifactStoreGetter.class);
-                assertThat(ctx).hasSingleBean(S3ArtifactStoreStorer.class);
-                assertThat(ctx).doesNotHaveBean(NoopArtifactStoreGetter.class);
-                assertThat(ctx).doesNotHaveBean(NoopArtifactStoreStorer.class);
-                assertThat(ctx).hasSingleBean(S3Client.class);
-              });
-    } finally {
-      // This test likely sets ArtifactStore.instance.  Clear it so we don't
-      // leave lingering state for other tests that assume it's null.
-      //
-      // Note that ArtifactStore.setInstance(null) doesn't set instance to null
-      // if it's already set.
-      ReflectionTestUtils.setField(ArtifactStore.class, "instance", null);
-    }
+    runner
+        .withPropertyValues(
+            "artifact-store.type=s3",
+            "artifact-store.s3.enabled=true",
+            "artifact-store.s3.region=us-west-2") // arbitrary region
+        .run(
+            ctx -> {
+              assertThat(ctx).hasSingleBean(ArtifactStoreURIBuilder.class);
+              assertThat(ctx).hasSingleBean(ArtifactStore.class);
+              assertThat(ctx).hasSingleBean(S3ArtifactStoreGetter.class);
+              assertThat(ctx).hasSingleBean(S3ArtifactStoreStorer.class);
+              assertThat(ctx).doesNotHaveBean(NoopArtifactStoreGetter.class);
+              assertThat(ctx).doesNotHaveBean(NoopArtifactStoreStorer.class);
+              assertThat(ctx).hasSingleBean(S3Client.class);
+            });
   }
 }


### PR DESCRIPTION
…oreConfigurationTest

so other tests that assume ArtifactStore.getInstance is null (e.g. ExpectedArtifactTest) don't try to store an artifact and fail trying to communicate with s3 with an error like:
```
software.amazon.awssdk.core.exception.SdkClientException: Unable to marshall request to JSON: Parameter 'Bucket' must not be null
	at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:111)
	at software.amazon.awssdk.services.s3.transform.HeadObjectRequestMarshaller.marshall(HeadObjectRequestMarshaller.java:53)
	at software.amazon.awssdk.services.s3.transform.HeadObjectRequestMarshaller.marshall(HeadObjectRequestMarshaller.java:31)
	at software.amazon.awssdk.core.internal.handler.BaseClientHandler.lambda$finalizeSdkHttpFullRequest$0(BaseClientHandler.java:73)
	at software.amazon.awssdk.core.internal.util.MetricUtils.measureDuration(MetricUtils.java:50)
	at software.amazon.awssdk.core.internal.handler.BaseClientHandler.finalizeSdkHttpFullRequest(BaseClientHandler.java:72)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:151)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:82)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:179)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:76)
	at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)
	at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:56)
	at software.amazon.awssdk.services.s3.DefaultS3Client.headObject(DefaultS3Client.java:5438)
	at com.netflix.spinnaker.kork.artifacts.artifactstore.s3.S3ArtifactStoreStorer.objectExists(S3ArtifactStoreStorer.java:132)
	at com.netflix.spinnaker.kork.artifacts.artifactstore.s3.S3ArtifactStoreStorer.store(S3ArtifactStoreStorer.java:90)
	at com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStore.store(ArtifactStore.java:39)
	at com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact.store(ExpectedArtifact.java:160)
	at com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact.<init>(ExpectedArtifact.java:56)
	at com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact$ExpectedArtifactBuilder.build(ExpectedArtifact.java:44)
	at com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifactTest.testReferenceMatches(ExpectedArtifactTest.java:205)
```
Yes, it's possible to configure a bucket name in S3ArtifactStoreConfiguration, but the more fundamental issue is having tests leaving a clean slate when they're done.