### PR TITLE
feature(credentials-api): CredentialsLoader extensions

### DIFF
--- a/kork-credentials-api/kork-credentials-api.gradle
+++ b/kork-credentials-api/kork-credentials-api.gradle
@@ -19,6 +19,7 @@ apply from: "$rootDir/gradle/lombok.gradle"
 
 dependencies {
   implementation(platform(project(":spinnaker-dependencies")))
+  api project(":kork-plugins-api")
   implementation project(":kork-annotations")
   implementation project(":kork-exceptions")
   implementation 'javax.annotation:javax.annotation-api'

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsLifecycleHandler.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsLifecycleHandler.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.credentials;
 
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
+
 /**
  * After {@link Credentials} have been parsed, they can be activated, refreshed, or retired - e.g.
  * adding agents. This happens before credentials are added or updated in the {@link
@@ -23,7 +25,8 @@ package com.netflix.spinnaker.credentials;
  *
  * @param <T>
  */
-public interface CredentialsLifecycleHandler<T extends Credentials> {
+public interface CredentialsLifecycleHandler<T extends Credentials>
+    extends SpinnakerExtensionPoint {
 
   /**
    * Credentials have been added. This is called before credentials are available in {@link

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsRepository.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/CredentialsRepository.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.credentials;
 
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -24,7 +25,7 @@ import javax.annotation.Nullable;
  *
  * @param <T>
  */
-public interface CredentialsRepository<T extends Credentials> {
+public interface CredentialsRepository<T extends Credentials> extends SpinnakerExtensionPoint {
   /**
    * @param name
    * @return Credentials with the given name or null

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/AbstractCredentialsLoader.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/AbstractCredentialsLoader.java
@@ -21,7 +21,8 @@ import com.netflix.spinnaker.credentials.CredentialsRepository;
 import javax.annotation.PostConstruct;
 import lombok.Getter;
 
-public abstract class AbstractCredentialsLoader<T extends Credentials> {
+public abstract class AbstractCredentialsLoader<T extends Credentials>
+    implements CredentialsLoader<T> {
   @Getter protected final CredentialsRepository<T> credentialsRepository;
 
   public AbstractCredentialsLoader(CredentialsRepository<T> credentialsRepository) {
@@ -34,5 +35,6 @@ public abstract class AbstractCredentialsLoader<T extends Credentials> {
    * thereafter.
    */
   @PostConstruct
+  @Override
   public abstract void load();
 }

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsLoader.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Armory
+ * Copyright 2023 Apple Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,12 @@
 
 package com.netflix.spinnaker.credentials.definition;
 
+import com.netflix.spinnaker.credentials.Credentials;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
-import java.util.List;
 
-/**
- * A source of credentials definitions. It could be backed by Spring properties or fetched from an
- * external system.
- *
- * @param <T>
- */
-public interface CredentialsDefinitionSource<T extends CredentialsDefinition>
-    extends SpinnakerExtensionPoint {
-  List<T> getCredentialsDefinitions();
+public interface CredentialsLoader<T extends Credentials> extends SpinnakerExtensionPoint {
+  CredentialsRepository<T> getCredentialsRepository();
+
+  void load();
 }

--- a/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsParser.java
+++ b/kork-credentials-api/src/main/java/com/netflix/spinnaker/credentials/definition/CredentialsParser.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.credentials.definition;
 
 import com.netflix.spinnaker.credentials.Credentials;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
 import javax.annotation.Nullable;
 
 /**
@@ -25,7 +26,8 @@ import javax.annotation.Nullable;
  * @param <T>
  * @param <U>
  */
-public interface CredentialsParser<T extends CredentialsDefinition, U extends Credentials> {
+public interface CredentialsParser<T extends CredentialsDefinition, U extends Credentials>
+    extends SpinnakerExtensionPoint {
   /** Parses a definition into credentials. Can return null if the definition is to be ignored. */
   @Nullable
   U parse(T credentials);

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/poller/Poller.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/poller/Poller.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.credentials.poller;
 
 import com.netflix.spinnaker.credentials.Credentials;
-import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.CredentialsLoader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class Poller<T extends Credentials> implements Runnable {
-  private final AbstractCredentialsLoader<T> credentialsLoader;
+  private final CredentialsLoader<T> credentialsLoader;
 
   public void run() {
     try {

--- a/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/poller/PollerConfiguration.java
+++ b/kork-credentials/src/main/java/com/netflix/spinnaker/credentials/poller/PollerConfiguration.java
@@ -16,11 +16,12 @@
 
 package com.netflix.spinnaker.credentials.poller;
 
-import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
-import java.util.List;
+import com.netflix.spinnaker.credentials.Credentials;
+import com.netflix.spinnaker.credentials.definition.CredentialsLoader;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
@@ -28,10 +29,10 @@ import org.springframework.scheduling.support.PeriodicTrigger;
 
 @EnableConfigurationProperties(PollerConfigurationProperties.class)
 @RequiredArgsConstructor
-@Slf4j
+@NonnullByDefault
 public class PollerConfiguration implements SchedulingConfigurer {
   private final PollerConfigurationProperties config;
-  private final List<AbstractCredentialsLoader<?>> pollers;
+  private final ObjectProvider<CredentialsLoader<? extends Credentials>> pollers;
 
   @Override
   public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {


### PR DESCRIPTION
This adds a CredentialsLoader interface extracted from AbstractCredentialsLoader along with additional SpinnakerExtensionPoint classes updated to allow for plugins to define credentials beans.

Related to https://github.com/spinnaker/spinnaker/issues/6914