### PR TITLE
chore(dependencies): specify org.junit:junit-bom:5.8.2

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -55,6 +55,7 @@ dependencies {
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
+  api(platform("org.junit:junit-bom:5.8.2")) // remove with spring boot >= 2.6.2
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
   api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))


### PR DESCRIPTION
to stay up to date.  Previously, org.spockframework:spock-core:2.0-groovy-3.0 and spring boot 2.5.15 brought in org.junit:junit-bom:5.7.2.  5.10.1 is currently the latest, but it causes failures in echo, so let's take a smaller step.  Spring boot 2.6.15 brings in 5.8.2 as well.