### PR TITLE
fix(artifacts): Addresses a couple things regarding artifact store

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/README.md
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/README.md
@@ -81,10 +81,23 @@ To enable artifact storage, simple add this to your `spinnaker-local.yml` file
 
 ```yaml
 artifact-store:
-  enabled: true
+  type: s3
   s3:
     enabled: true
     bucket: some-artifact-store-bucket
+```
+
+### Rosco and Helm
+
+If any pipelines are passing artifact references to bake stages as a parameter,
+enabling this field will allow those URIs to be expanded to the full
+references:
+
+```yaml
+artifact-store:
+  type: s3
+  helm:
+    expandOverrides: true
 ```
 
 ## Storage Options
@@ -97,7 +110,7 @@ against AWS.
 
 ```yaml
 artifact-store:
-  enabled: true
+  type: s3
   s3:
     enabled: true
     profile: dev # if you want to authenticate using a certain profile
@@ -119,7 +132,7 @@ Next enable the configuration
 
 ```yaml
 artifact-store:
-  enabled: true
+  type: s3
   s3:
     enabled: true
     url: http://localhost:8333 # this URL will be used to make S3 API requests to

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactReferenceURI.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactReferenceURI.java
@@ -29,24 +29,31 @@ import org.apache.logging.log4j.util.Strings;
 @Builder
 @Getter
 public class ArtifactReferenceURI {
-  private final String scheme;
+  /**
+   * uriScheme is used as an HTTP scheme to let us further distinguish a String that is a URI to an
+   * artifact. This is helpful in determining what is an artifact since sometimes we are only given
+   * a string rather than a full artifact.
+   */
+  private static final String uriScheme = "ref://";
+
   private final List<String> uriPaths;
 
   public String uri() {
-    return String.format("%s://%s", scheme, paths());
+    return uriScheme + paths();
   }
 
   public String paths() {
     return Strings.join(uriPaths, '/');
   }
 
+  /** Used to determine whether a String is in the artifact reference URI format. */
+  public static boolean is(String reference) {
+    return reference.startsWith(uriScheme);
+  }
+
   public static ArtifactReferenceURI parse(String reference) {
-    String noSchemeURI =
-        StringUtils.removeStart(reference, ArtifactStoreURIBuilder.uriScheme + "://");
+    String noSchemeURI = StringUtils.removeStart(reference, uriScheme);
     String[] paths = StringUtils.split(noSchemeURI, '/');
-    return ArtifactReferenceURI.builder()
-        .scheme(ArtifactStoreURIBuilder.uriScheme)
-        .uriPaths(Arrays.asList(paths))
-        .build();
+    return ArtifactReferenceURI.builder().uriPaths(Arrays.asList(paths)).build();
   }
 }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStore.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStore.java
@@ -57,8 +57,4 @@ public class ArtifactStore implements ArtifactStoreGetter, ArtifactStoreStorer {
       log.warn("Multiple attempts in setting the singleton artifact store");
     }
   }
-
-  public boolean isArtifactURI(String value) {
-    return value.startsWith(ArtifactStoreURIBuilder.uriScheme + "://");
-  }
 }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreConfigurationProperties.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreConfigurationProperties.java
@@ -44,5 +44,12 @@ public class ArtifactStoreConfigurationProperties {
     private boolean forcePathStyle = true;
   }
 
-  private S3ClientConfig s3 = null;
+  @Data
+  public static class HelmConfig {
+    /** Enables Rosco to expand any artifact URIs passed as parameters for Helm. */
+    private boolean expandOverrides = false;
+  }
+
+  private S3ClientConfig s3 = new S3ClientConfig();
+  private HelmConfig helm = new HelmConfig();
 }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreURIBuilder.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreURIBuilder.java
@@ -19,13 +19,6 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 
 public abstract class ArtifactStoreURIBuilder {
   /**
-   * uriScheme is used as an HTTP scheme to let us further distinguish a String that is a URI to an
-   * artifact. This is helpful in determining what is an artifact since sometimes we are only given
-   * a string rather than a full artifact.
-   */
-  public static final String uriScheme = "ref";
-
-  /**
    * Returns the remote artifact URI that will be associated with some artifact.
    *
    * @param context is the context in which this artifact was run in, e.g. the application.

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreURISHA256Builder.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactStoreURISHA256Builder.java
@@ -38,7 +38,7 @@ public class ArtifactStoreURISHA256Builder extends ArtifactStoreURIBuilder {
             Hashing.sha256()
                 .hashBytes(artifact.getReference().getBytes(StandardCharsets.UTF_8))
                 .toString());
-    return ArtifactReferenceURI.builder().scheme(uriScheme).uriPaths(uriPaths).build();
+    return ArtifactReferenceURI.builder().uriPaths(uriPaths).build();
   }
 
   @Override
@@ -47,6 +47,6 @@ public class ArtifactStoreURISHA256Builder extends ArtifactStoreURIBuilder {
     uriPaths.add(context);
     uriPaths.addAll(List.of(paths));
 
-    return ArtifactReferenceURI.builder().scheme(uriScheme).uriPaths(uriPaths).build();
+    return ArtifactReferenceURI.builder().uriPaths(uriPaths).build();
   }
 }

--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreConfiguration.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreConfiguration.java
@@ -66,7 +66,7 @@ public class S3ArtifactStoreConfiguration {
           "PermissionEvaluator is not present. This means anyone will be able to access any artifact in the store.");
     }
 
-    String bucket = properties.getS3() != null ? properties.getS3().getBucket() : null;
+    String bucket = properties.getS3().getBucket();
 
     return new S3ArtifactStoreGetter(s3Client, permissionEvaluator.orElse(null), bucket);
   }

--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ArtifactUriToReferenceConverter.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/ArtifactUriToReferenceConverter.java
@@ -55,7 +55,7 @@ public class ArtifactUriToReferenceConverter implements TypeConverter {
       return defaultTypeConverter.convertValue(value, sourceType, targetType);
     }
 
-    if (artifactStore == null || !artifactStore.isArtifactURI((String) value)) {
+    if (artifactStore == null || !ArtifactReferenceURI.is((String) value)) {
       return defaultTypeConverter.convertValue(value, sourceType, targetType);
     }
 


### PR DESCRIPTION
This PR has three commits which addresses 3 particular issues:

1. README updates to reflect on current artifact store usage
2. Moving of scheme from the builder to the `ArtifactReferenceURI` class instead as that makes more sense
3. Updates the artifact store to rely more easily on default values instead of requiring `null` checks for the individual storage types

Signed-off-by: benjamin-j-powell <bjp@apple.com>