### PR TITLE
chore(dependencies): upgrade bouncycastle from 1.70 to 1.77

### DIFF
--- a/kork-crypto/kork-crypto.gradle
+++ b/kork-crypto/kork-crypto.gradle
@@ -23,11 +23,11 @@ dependencies {
 
   api project(":kork-annotations")
 
-  implementation "org.bouncycastle:bcpkix-jdk15on"
+  implementation "org.bouncycastle:bcpkix-jdk18on"
   implementation "org.springframework:spring-aop"
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 
-  testFixturesApi  "org.bouncycastle:bcpkix-jdk15on"
+  testFixturesApi  "org.bouncycastle:bcpkix-jdk18on"
   testFixturesApi  "org.springframework:spring-core"
 }

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -64,7 +64,7 @@ dependencies {
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
   api(platform("io.strikt:strikt-bom:0.31.0"))
   api(platform("org.spockframework:spock-bom:2.0-groovy-3.0"))
-  api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:1.5.17"))
+  api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:3.21.0"))
   api(platform("org.testcontainers:testcontainers-bom:1.16.2"))
   api(platform("io.arrow-kt:arrow-stack:${versions.arrow}"))
 

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -61,7 +61,6 @@ dependencies {
   api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))
   api(platform("com.google.cloud:libraries-bom:${versions.gcp}"))
   api(platform("software.amazon.awssdk:bom:${versions.awsv2}"))
-  api(platform("com.google.cloud:google-cloud-secretmanager:2.1.7"))
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
   api(platform("io.strikt:strikt-bom:0.31.0"))
   api(platform("org.spockframework:spock-bom:2.0-groovy-3.0"))
@@ -79,6 +78,7 @@ dependencies {
     api("com.google.apis:google-api-services-iam:v1-rev267-1.25.0")
     api("com.google.apis:google-api-services-monitoring:v3-rev477-1.25.0")
     api("com.google.apis:google-api-services-storage:v1-rev141-1.25.0")
+    api("com.google.cloud:google-cloud-secretmanager:2.3.10")
     api("com.google.code.findbugs:jsr305:3.0.2")
     api("com.google.guava:guava:30.0-jre")
     // JinJava 2.5.3 has a bad bug: https://github.com/HubSpot/jinjava/issues/429

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -9,7 +9,7 @@ ext {
     arrow            : "0.13.2",
     aws              : "1.12.176",
     awsv2            : "2.19.0",
-    bouncycastle     : "1.70",
+    bouncycastle     : "1.77",
     brave            : "5.12.3",
     gcp              : "25.3.0",
     jooq             : "3.13.6",
@@ -140,9 +140,14 @@ dependencies {
     api("javax.xml.bind:jaxb-api:2.3.1")
     api("net.logstash.logback:logstash-logback-encoder:4.11")
     api("org.apache.commons:commons-exec:1.3")
-    // TODO(jvz): beginning in BC 1.71, this should use the -jdk18on artifacts
-    api("org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}")
-    api("org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}")
+    //  from BC 1.71, module names changed from *-jdk15on to *-jdk18on
+    // due to this change, some of the modules in downstream services like clouddriver, gate would fall back to
+    // lower versions(<1.70) as transitive dependencies. So to make them use BC >=1.74(CVE free versions),
+    // the following dependencies are upgraded: oci-java-sdk-bom, google-cloud-secretmanager
+    // and in some cases *-jdk15on libraries are excluded so as to use the available *-jdk18on or *-jdk15to18
+    // some of the modules would still use <1.70 as they can't be upgraded without upgrading spring boot
+    api("org.bouncycastle:bcpkix-jdk18on:${versions.bouncycastle}")
+    api("org.bouncycastle:bcprov-jdk18on:${versions.bouncycastle}")
     api("org.jetbrains:annotations:19.0.0")
     api("org.spekframework.spek2:spek-dsl-jvm:${versions.spek2}")
     api("org.spekframework.spek2:spek-runner-junit5:${versions.spek2}")


### PR DESCRIPTION
bouncycastle <1.74 versions suffer from [CVE-2023-33201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-33201) 
Also bouncycastle module names changed from *-jdk15on to *-jdk18on from 1.71 version.

Through this PR(and subsequent gate and clouddriver PRs), though not all modules from all spinnaker services get to use bouncycastle >1.74, it is done wherever possible.

|google-cloud-secretmanager| bouncycastle dependency|
|--------------------------------------|------------------------------------|
|2.1.7                                     | 1.67                                    |
|2.3.10                                   |  no bouncycastle dependency  |


|com.oracle.oci.sdk:oci-java-sdk-bom | bouncycastle dependency|
|--------------------------------------|------------------------------------|
|1.5.17                                    | 1.60                                    |
|3.21.0                                  |  1.74  |
