### PR TITLE
feat(retrofit): Make HTTP method available in SpinnakerServerException

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerException.java
@@ -27,11 +27,13 @@ import retrofit.RetrofitError;
 public class SpinnakerServerException extends SpinnakerException {
 
   @Getter private final String url;
+  @Getter private final String httpMethod;
 
   /** Construct a SpinnakerServerException corresponding to a RetrofitError. */
   public SpinnakerServerException(RetrofitError e) {
     super(e.getMessage(), e.getCause());
     url = e.getUrl();
+    httpMethod = null;
   }
 
   /**
@@ -41,6 +43,7 @@ public class SpinnakerServerException extends SpinnakerException {
   public SpinnakerServerException(Request request) {
     super();
     url = request.url().toString();
+    httpMethod = request.method();
   }
 
   /**
@@ -50,6 +53,7 @@ public class SpinnakerServerException extends SpinnakerException {
   public SpinnakerServerException(Throwable cause, Request request) {
     super(cause);
     this.url = request.url().toString();
+    this.httpMethod = request.method();
   }
 
   /**
@@ -59,6 +63,7 @@ public class SpinnakerServerException extends SpinnakerException {
   public SpinnakerServerException(String message, Throwable cause, Request request) {
     super(message, cause);
     this.url = request.url().toString();
+    this.httpMethod = request.method();
   }
 
   /**
@@ -68,6 +73,7 @@ public class SpinnakerServerException extends SpinnakerException {
   public SpinnakerServerException(String message, SpinnakerServerException cause) {
     super(message, cause);
     this.url = cause.getUrl();
+    this.httpMethod = cause.getHttpMethod();
   }
 
   @Override

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
@@ -92,6 +93,7 @@ class SpinnakerHttpExceptionTest {
     assertThat(notFoundException.getResponseCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
     assertThat(notFoundException)
         .hasMessageContaining(String.valueOf(HttpStatus.NOT_FOUND.value()));
+    assertThat(notFoundException.getHttpMethod()).isEqualTo(HttpMethod.GET.toString());
   }
 
   @Test

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java
@@ -64,6 +64,7 @@ class SpinnakerHttpExceptionTest {
         .isEqualTo("Status: " + statusCode + ", URL: " + url + ", Message: " + message);
     assertThat(spinnakerHttpException.getUrl()).isEqualTo(url);
     assertThat(spinnakerHttpException.getReason()).isEqualTo(reason);
+    assertThat(spinnakerHttpException.getHttpMethod()).isNull();
   }
 
   @Test

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
@@ -31,6 +31,7 @@ import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import retrofit2.Call;
 import retrofit2.Retrofit;
@@ -146,6 +147,21 @@ class SpinnakerRetrofit2ErrorHandleTest {
   }
 
   @Test
+  void testHttpMethodInException() {
+    // Check http request method is retrievable from a SpinnakerHttpException
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(HttpStatus.BAD_REQUEST.value())
+            .setBody(responseBodyString));
+    SpinnakerHttpException spinnakerHttpException =
+        catchThrowableOfType(
+            () -> retrofit2Service.deleteRetrofit2().execute(), SpinnakerHttpException.class);
+    assertThat(spinnakerHttpException.getUrl())
+        .isEqualTo(mockWebServer.url("/retrofit2").toString());
+    assertThat(spinnakerHttpException.getHttpMethod()).isEqualTo(HttpMethod.DELETE.toString());
+  }
+
+  @Test
   void testNotParameterizedException() {
     IllegalArgumentException illegalArgumentException =
         catchThrowableOfType(
@@ -177,6 +193,9 @@ class SpinnakerRetrofit2ErrorHandleTest {
 
     @retrofit2.http.GET("/retrofit2/wrongReturnType")
     DummyWithExecute testWrongReturnType();
+
+    @retrofit2.http.DELETE("/retrofit2")
+    Call<String> deleteRetrofit2();
   }
 
   @Test

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitErrorHandlerTest.java
@@ -177,6 +177,17 @@ class SpinnakerRetrofitErrorHandlerTest {
   }
 
   @Test
+  void testExceptionFromRetrofitErrorHasNullHttpMethod() {
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(HttpStatus.BAD_REQUEST.value())
+            .setHeader("Test", "true"));
+    SpinnakerHttpException spinnakerHttpException =
+        catchThrowableOfType(() -> retrofitService.getFoo(), SpinnakerHttpException.class);
+    assertThat(spinnakerHttpException.getHttpMethod()).isNull();
+  }
+
+  @Test
   void testSimpleSpinnakerNetworkException() {
     String message = "my custom message";
     IOException e = new IOException(message);

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerServerExceptionTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import okhttp3.Request;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
 import retrofit.converter.ConversionException;
@@ -41,6 +42,19 @@ class SpinnakerServerExceptionTest {
     SpinnakerNetworkException spinnakerNetworkException =
         new SpinnakerNetworkException(cause, request);
     assertThat(spinnakerNetworkException.getUrl()).isEqualTo(url);
+    assertThat(spinnakerNetworkException.getHttpMethod()).isEqualTo(HttpMethod.GET.toString());
+  }
+
+  @Test
+  void testSpinnakerNetworkExceptionWithSpecificMethod() {
+    Throwable cause = new Throwable("arbitrary message");
+    String url = "http://some-url/";
+    Request request =
+        new Request.Builder().url(url).method(HttpMethod.DELETE.toString(), null).build();
+    SpinnakerNetworkException spinnakerNetworkException =
+        new SpinnakerNetworkException(cause, request);
+    assertThat(spinnakerNetworkException.getUrl()).isEqualTo(url);
+    assertThat(spinnakerNetworkException.getHttpMethod()).isEqualTo(HttpMethod.DELETE.toString());
   }
 
   @Test
@@ -70,6 +84,19 @@ class SpinnakerServerExceptionTest {
     SpinnakerServerException spinnakerServerException =
         new SpinnakerServerException(cause, request);
     assertThat(spinnakerServerException.getUrl()).isEqualTo(url);
+    assertThat(spinnakerServerException.getHttpMethod()).isEqualTo(HttpMethod.GET.toString());
+  }
+
+  @Test
+  void testSpinnakerServerExceptionWithSpecificMethod() {
+    Throwable cause = new Throwable("arbitrary message");
+    String url = "http://some-url/";
+    Request request =
+        new Request.Builder().url(url).method(HttpMethod.DELETE.toString(), null).build();
+    SpinnakerServerException spinnakerServerException =
+        new SpinnakerServerException(cause, request);
+    assertThat(spinnakerServerException.getUrl()).isEqualTo(url);
+    assertThat(spinnakerServerException.getHttpMethod()).isEqualTo(HttpMethod.DELETE.toString());
   }
 
   @Test


### PR DESCRIPTION
This PR adds the HTTP request method as an instance variable to `SpinnakerServerException`. The value is retrieved from the constructor params except in the case that the exception is created from a `RetrofitError` where the HTTP method is not available and thus set to `null` in the exception. There are also some test updates included to make sure the getter works as expected for server, HTTP, and network exceptions.