### PR TITLE
chore(dependencies): unpin jooq since the spring boot bom specifies it

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -12,7 +12,6 @@ ext {
     bouncycastle     : "1.77",
     brave            : "5.12.3",
     gcp              : "25.3.0",
-    jooq             : "3.13.6",
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
     protobuf         : "3.21.12",
@@ -155,8 +154,6 @@ dependencies {
     api("org.jetbrains.spek:spek-junit-platform-engine:${versions.spek}")
     api("org.jetbrains.spek:spek-junit-platform-runner:${versions.spek}")
     api("org.jetbrains.spek:spek-subject-extension:${versions.spek}")
-    api("org.jooq:jooq:${versions.jooq}")
-    api("org.jooq:jooq-kotlin:${versions.jooq}")
     api("org.liquibase:liquibase-core"){
        version {
          strictly "4.24.0"


### PR DESCRIPTION
[version 2.15.15 of the spring boot bom](https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.5.15/spring-boot-dependencies-2.5.15.pom) specifies 3.14.16, so that's what we were getting even though we specified 3.13.6.

before:
```
org.jooq:jooq:3.13.6 -> 3.14.16 (c)
```
after
```
org.jooq:jooq -> 3.14.16
```