### PR TITLE
chore(deps): use version 2.7.1 of jinjava

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -81,8 +81,7 @@ dependencies {
     api("com.google.cloud:google-cloud-secretmanager:2.3.10")
     api("com.google.code.findbugs:jsr305:3.0.2")
     api("com.google.guava:guava:30.0-jre")
-    // JinJava 2.5.3 has a bad bug: https://github.com/HubSpot/jinjava/issues/429
-    api("com.hubspot.jinjava:jinjava:2.5.2")
+    api("com.hubspot.jinjava:jinjava:2.7.1")
     api("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
     api("com.jcraft:jsch:${versions.jsch}")
     api("com.jcraft:jsch.agentproxy.connector-factory:${versions.jschAgentProxy}")


### PR DESCRIPTION
Here are snippets from `$ ./gradlew orca-web:dependencies`

before:
```
|    |    \--- com.hubspot.jinjava:jinjava:2.5.2
|    |         +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
|    |         +--- com.google.guava:guava:22.0 -> 30.0-jre
|    |         |    +--- com.google.guava:failureaccess:1.0.1
|    |         |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    |         |    +--- com.google.code.findbugs:jsr305:3.0.2
|    |         |    +--- org.checkerframework:checker-qual:3.5.0 -> 3.19.0
|    |         |    +--- com.google.errorprone:error_prone_annotations:2.3.4 -> 2.10.0
|    |         |    \--- com.google.j2objc:j2objc-annotations:1.3
|    |         +--- org.javassist:javassist:3.24.1-GA
|    |         +--- org.jsoup:jsoup:1.10.3
|    |         +--- com.google.re2j:re2j:1.2
|    |         +--- org.apache.commons:commons-lang3:3.5 -> 3.12.0
|    |         +--- commons-net:commons-net:3.3
|    |         +--- com.google.code.findbugs:annotations:3.0.1
|    |         +--- com.fasterxml.jackson.core:jackson-databind:2.7.9.5 -> 2.12.7.1 (*)
|    |         +--- com.fasterxml.jackson.core:jackson-core:2.7.9 -> 2.12.7 (*)
|    |         \--- ch.obermuhlner:big-math:2.0.0
```
after:
```
|    |    \--- com.hubspot.jinjava:jinjava:2.7.1
|    |         +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.36
|    |         +--- com.google.guava:guava:31.1-jre -> 30.0-jre
|    |         |    +--- com.google.guava:failureaccess:1.0.1
|    |         |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    |         |    +--- com.google.code.findbugs:jsr305:3.0.2
|    |         |    +--- org.checkerframework:checker-qual:3.5.0 -> 3.19.0
|    |         |    +--- com.google.errorprone:error_prone_annotations:2.3.4 -> 2.10.0
|    |         |    \--- com.google.j2objc:j2objc-annotations:1.3
|    |         +--- org.javassist:javassist:3.24.1-GA
|    |         +--- com.google.re2j:re2j:1.2
|    |         +--- org.apache.commons:commons-lang3:3.9 -> 3.12.0
|    |         +--- commons-net:commons-net:3.9.0
|    |         +--- com.googlecode.java-ipv6:java-ipv6:0.17
|    |         +--- com.google.code.findbugs:annotations:3.0.1
|    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.12.7 (*)
|    |         +--- com.fasterxml.jackson.core:jackson-databind:2.14.0 -> 2.12.7.1 (*)
|    |         +--- com.fasterxml.jackson.core:jackson-core:2.14.0 -> 2.12.7 (*)
|    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0 -> 2.12.7
|    |         |    +--- com.fasterxml.jackson.core:jackson-databind:2.12.7 -> 2.12.7.1 (*)
|    |         |    +--- org.yaml:snakeyaml:1.27
|    |         |    +--- com.fasterxml.jackson.core:jackson-core:2.12.7 (*)
|    |         |    \--- com.fasterxml.jackson:jackson-bom:2.12.7 (*)
|    |         \--- ch.obermuhlner:big-math:2.0.0
```
Note the following CVE exposure before this PR:

- jinjava 2.5.2
  - CVE-2020-12668, fixed in 2.5.3
  - sonatype-2021-0948, fixed in 2.5.10
- commons-net 3.3
  - CVE-2021-37533, fixed in 3.9
- jsoup 1.10.3
  - CVE-2021-37714, fixed in 1.14.2
  - CVE-2022-36033, fixed in 1.15.3

After this PR, all these are resolved.  jinjava 2.7.1 brings in commons-net 3.9 and jsoup 1.15.3, though jsoup is shaded.  See
https://github.com/HubSpot/jinjava/blob/jinjava-2.7.1/pom.xml#L34 and https://github.com/HubSpot/jinjava/blob/jinjava-2.7.1/pom.xml#L240.

Use version 2.7.1 of jinjava since it's the first version that fixes https://github.com/HubSpot/jinjava/issues/429 via https://github.com/HubSpot/jinjava/pull/1008.