### PR TITLE
chore(dependencies): use version 1.12.261 of the aws sdk

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -7,7 +7,7 @@ javaPlatform {
 ext {
   versions = [
     arrow            : "0.13.2",
-    aws              : "1.12.176",
+    aws              : "1.12.261",
     awsv2            : "2.19.0",
     bouncycastle     : "1.77",
     brave            : "5.12.3",


### PR DESCRIPTION
to remove vulnerability CVE-2022-31159 that version 1.12.176 is subject to