### PR TITLE
feat(core): add Resilience4jHelper

### DIFF
--- a/kork-core/kork-core.gradle
+++ b/kork-core/kork-core.gradle
@@ -25,6 +25,8 @@ dependencies {
   implementation "com.netflix.spectator:spectator-ext-jvm"
   implementation "com.netflix.spectator:spectator-reg-micrometer"
 
+  testImplementation project(":kork-test")
+  testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation("org.mockito:mockito-core")
   testImplementation "org.spockframework:spock-core"

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/resilience4j/Resilience4jHelper.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/resilience4j/Resilience4jHelper.java
@@ -1,0 +1,83 @@
+package com.netflix.spinnaker.kork.resilience4j;
+
+import io.github.resilience4j.core.EventConsumer;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.retry.event.RetryEvent;
+import io.github.resilience4j.retry.event.RetryOnErrorEvent;
+import io.github.resilience4j.retry.event.RetryOnIgnoredErrorEvent;
+import io.github.resilience4j.retry.event.RetryOnRetryEvent;
+import io.github.resilience4j.retry.event.RetryOnSuccessEvent;
+import org.slf4j.Logger;
+
+public class Resilience4jHelper {
+  /** Configure helpful logging for RetryRegistry objects */
+  public static void configureLogging(RetryRegistry retryRegistry, String description, Logger log) {
+    // log whenever a new retry instance is added, removed or replaced from the registry
+    retryRegistry
+        .getEventPublisher()
+        .onEntryAdded(
+            entryAddedEvent -> {
+              Retry addedRetry = entryAddedEvent.getAddedEntry();
+              log.info("{} retries configured for: {}", description, addedRetry.getName());
+            })
+        .onEntryRemoved(
+            entryRemovedEvent -> {
+              Retry removedRetry = entryRemovedEvent.getRemovedEntry();
+              log.info("{} retries removed for: {}", description, removedRetry.getName());
+            })
+        .onEntryReplaced(
+            entryReplacedEvent -> {
+              Retry oldEntry = entryReplacedEvent.getOldEntry();
+              Retry newEntry = entryReplacedEvent.getNewEntry();
+              log.info(
+                  "{} retries: {} updated to: {}",
+                  description,
+                  oldEntry.getName(),
+                  newEntry.getName());
+            });
+
+    // Define an event consumer once for the entire registry as mentioned here:
+    // https://github.com/resilience4j/resilience4j/issues/974#issuecomment-619956673
+    //
+    // If we don't do this once, but add it for each individual retry
+    // instance, and if that retry instance is invoked by multiple threads,
+    // then there is a lot of log duplication.  For example, if 10 threads get
+    // an object from s3, there will be (10 * num_retries) log lines for each
+    // retry event instead of just the num_retries that we expect.
+    EventConsumer<RetryEvent> eventConsumer =
+        retryEvent -> {
+          if (retryEvent instanceof RetryOnErrorEvent) {
+            log.error(
+                "{} for {} failed after {} attempts. Exception: {}",
+                description,
+                retryEvent.getName(),
+                retryEvent.getNumberOfRetryAttempts(),
+                retryEvent.getLastThrowable().toString());
+          } else if (retryEvent instanceof RetryOnSuccessEvent) {
+            log.info(
+                "{} for {} is now successful in attempt #{}. Last attempt had failed with exception: {}",
+                description,
+                retryEvent.getName(),
+                retryEvent.getNumberOfRetryAttempts() + 1,
+                retryEvent.getLastThrowable().toString());
+          } else if (retryEvent instanceof RetryOnRetryEvent) {
+            log.info(
+                "Retrying {} for {}. Attempt #{} failed with exception: {}",
+                description,
+                retryEvent.getName(),
+                retryEvent.getNumberOfRetryAttempts(),
+                retryEvent.getLastThrowable().toString());
+          } else if (!(retryEvent instanceof RetryOnIgnoredErrorEvent)) {
+            // don't log anything for Ignored exceptions as it just leads to noise in the logs
+            log.info(retryEvent.toString());
+          }
+        };
+    retryRegistry
+        .getAllRetries()
+        .forEach(retry -> retry.getEventPublisher().onEvent(eventConsumer));
+    retryRegistry
+        .getEventPublisher()
+        .onEntryAdded(event -> event.getAddedEntry().getEventPublisher().onEvent(eventConsumer));
+  }
+}

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/resilience4j/Resilience4jHelper.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/resilience4j/Resilience4jHelper.java
@@ -53,21 +53,21 @@ public class Resilience4jHelper {
                 description,
                 retryEvent.getName(),
                 retryEvent.getNumberOfRetryAttempts(),
-                retryEvent.getLastThrowable().toString());
+                String.valueOf(retryEvent.getLastThrowable()));
           } else if (retryEvent instanceof RetryOnSuccessEvent) {
             log.info(
                 "{} for {} is now successful in attempt #{}. Last attempt had failed with exception: {}",
                 description,
                 retryEvent.getName(),
                 retryEvent.getNumberOfRetryAttempts() + 1,
-                retryEvent.getLastThrowable().toString());
+                String.valueOf(retryEvent.getLastThrowable()));
           } else if (retryEvent instanceof RetryOnRetryEvent) {
             log.info(
                 "Retrying {} for {}. Attempt #{} failed with exception: {}",
                 description,
                 retryEvent.getName(),
                 retryEvent.getNumberOfRetryAttempts(),
-                retryEvent.getLastThrowable().toString());
+                String.valueOf(retryEvent.getLastThrowable()));
           } else if (!(retryEvent instanceof RetryOnIgnoredErrorEvent)) {
             // don't log anything for Ignored exceptions as it just leads to noise in the logs
             log.info(retryEvent.toString());

--- a/kork-core/src/test/java/com/netflix/spinnaker/kork/resilience4j/Resilience4jHelperTest.java
+++ b/kork-core/src/test/java/com/netflix/spinnaker/kork/resilience4j/Resilience4jHelperTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.resilience4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.classic.Level;
+import com.netflix.spinnaker.kork.test.log.MemoryAppender;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class Resilience4jHelperTest {
+
+  private static final Logger log = LoggerFactory.getLogger(Resilience4jHelperTest.class);
+
+  @Test
+  void testConfigureLogging() {
+    // Verify that retries configured with Resilience4jHelper.configureLogging
+    // log the expected messages.
+
+    // given:
+    MemoryAppender memoryAppender = new MemoryAppender(Resilience4jHelperTest.class);
+
+    RetryRegistry retryRegistry = RetryRegistry.ofDefaults();
+    String description = "test retry description";
+    Resilience4jHelper.configureLogging(retryRegistry, description, log);
+
+    String retryName = "test retry name";
+    Retry retry = retryRegistry.retry(retryName);
+
+    RuntimeException exception = new RuntimeException("retryable exception");
+
+    // when:
+    assertThatThrownBy(
+            () ->
+                retry.executeRunnable(
+                    () -> {
+                      throw exception;
+                    }))
+        .isEqualTo(exception);
+
+    // then:
+    assertThat(
+            memoryAppender.search(
+                description + " retries configured for: " + retryName, Level.INFO))
+        .hasSize(1);
+    assertThat(
+            memoryAppender.search(
+                "Retrying "
+                    + description
+                    + " for "
+                    + retryName
+                    + ". Attempt #1 failed with exception: "
+                    + exception.toString(),
+                Level.INFO))
+        .hasSize(1);
+    assertThat(
+            memoryAppender.search(
+                "Retrying "
+                    + description
+                    + " for "
+                    + retryName
+                    + ". Attempt #2 failed with exception: "
+                    + exception.toString(),
+                Level.INFO))
+        .hasSize(1);
+    assertThat(
+            memoryAppender.search(
+                description
+                    + " for "
+                    + retryName
+                    + " failed after 3 attempts. Exception: "
+                    + exception.toString(),
+                Level.ERROR))
+        .hasSize(1);
+  }
+}

--- a/kork-core/src/test/java/com/netflix/spinnaker/kork/resilience4j/Resilience4jHelperTest.java
+++ b/kork-core/src/test/java/com/netflix/spinnaker/kork/resilience4j/Resilience4jHelperTest.java
@@ -21,15 +21,25 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ch.qos.logback.classic.Level;
 import com.netflix.spinnaker.kork.test.log.MemoryAppender;
+import io.github.resilience4j.retry.MaxRetriesExceededException;
 import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class Resilience4jHelperTest {
 
   private static final Logger log = LoggerFactory.getLogger(Resilience4jHelperTest.class);
+
+  @BeforeEach
+  void init(TestInfo testInfo) {
+    System.out.println("--------------- Test " + testInfo.getDisplayName());
+  }
 
   @Test
   void testConfigureLogging() {
@@ -89,6 +99,144 @@ class Resilience4jHelperTest {
                     + retryName
                     + " failed after 3 attempts. Exception: "
                     + exception.toString(),
+                Level.ERROR))
+        .hasSize(1);
+  }
+
+  @Test
+  void testHandleNullLastThrowableRetryOnRetryAndSuccess() {
+
+    // given:
+    MemoryAppender memoryAppender = new MemoryAppender(Resilience4jHelperTest.class);
+
+    RetryConfig.Builder<String> retryConfigBuilder = RetryConfig.custom();
+
+    // returning true means retry.  retry once, and then don't retry the next
+    // time to exercise logging for both RetryOnRetryEvent and
+    // RetryOnSuccessEvent.  Use an AtomicBoolean so the predicate can modify it.
+    AtomicBoolean retried = new AtomicBoolean();
+
+    retryConfigBuilder.retryOnResult(
+        (String string) -> {
+          if (retried.compareAndSet(false, true)) {
+            return true;
+          }
+          return false;
+        });
+
+    RetryConfig retryConfig = retryConfigBuilder.build();
+    RetryRegistry retryRegistry = RetryRegistry.of(retryConfig);
+
+    String description = "test retry description";
+    Resilience4jHelper.configureLogging(retryRegistry, description, log);
+
+    String retryName = "handle null lastThrowable";
+    Retry retry = retryRegistry.retry(retryName);
+
+    // when:
+    String result = retry.executeSupplier(() -> "result");
+
+    // then:
+    assertThat(result).isEqualTo("result");
+
+    assertThat(
+            memoryAppender.search(
+                "Retrying "
+                    + description
+                    + " for "
+                    + retryName
+                    + ". Attempt #1 failed with exception: null",
+                Level.INFO))
+        .hasSize(1);
+
+    assertThat(
+            memoryAppender.search(
+                description
+                    + " for "
+                    + retryName
+                    + " is now successful in attempt #2. "
+                    + "Last attempt had failed with exception: null",
+                Level.INFO))
+        .hasSize(1);
+  }
+
+  @Test
+  void testHandleNullLastThrowableRetryOnError() {
+
+    // given:
+    MemoryAppender memoryAppender = new MemoryAppender(Resilience4jHelperTest.class);
+
+    RetryConfig.Builder<String> retryConfigBuilder = RetryConfig.custom();
+
+    // returning true means retry.  retry every time to exercise behavior when
+    // attempts are exhausted.
+    retryConfigBuilder.retryOnResult((String string) -> true);
+
+    // Whether failAfterMaxAttempts is true or false, lastThrowable is either
+    // MaxRetriesExceeded or MaxRetriesExceededException in RetryOnErrorEvent
+    // (i.e. it isn't null).  So, either we need a different test, or the code
+    // that handles RetryOnErrorEvent can assume lastThrowable isn't null.  It
+    // still seems safer to handle it since it's straightforward, and since
+    // lastThrowable has a @Nullable annotation in AbstractRetryEvent.
+    retryConfigBuilder.failAfterMaxAttempts(true);
+
+    RetryConfig retryConfig = retryConfigBuilder.build();
+    RetryRegistry retryRegistry = RetryRegistry.of(retryConfig);
+
+    String description = "test retry description";
+    Resilience4jHelper.configureLogging(retryRegistry, description, log);
+
+    String retryName = "handle null lastThrowable";
+    Retry retry = retryRegistry.retry(retryName);
+
+    // when:
+    assertThatThrownBy(() -> retry.executeSupplier(() -> "result"))
+        .isInstanceOf(MaxRetriesExceededException.class);
+
+    // then:
+    assertThat(
+            memoryAppender.search(
+                "Retrying "
+                    + description
+                    + " for "
+                    + retryName
+                    + ". Attempt #1 failed with exception: null",
+                Level.INFO))
+        .hasSize(1);
+
+    assertThat(
+            memoryAppender.search(
+                "Retrying "
+                    + description
+                    + " for "
+                    + retryName
+                    + ". Attempt #2 failed with exception: null",
+                Level.INFO))
+        .hasSize(1);
+
+    assertThat(
+            memoryAppender.search(
+                description
+                    + " for "
+                    + retryName
+                    + " failed after "
+                    + retryConfig.getMaxAttempts()
+                    + " attempts. Exception: io.github.resilience4j.retry.MaxRetriesExceeded: max retries is reached out for the result predicate check",
+                Level.ERROR))
+        .hasSize(1);
+
+    assertThat(
+            memoryAppender.search(
+                description
+                    + " for "
+                    + retryName
+                    + " failed after "
+                    + (retryConfig.getMaxAttempts() + 1)
+                    + " attempts. Exception: io.github.resilience4j.retry.MaxRetriesExceededException: Retry '"
+                    + retryName
+                    + "' has exhausted all attempts ("
+                    + retryConfig.getMaxAttempts()
+                    + ")",
                 Level.ERROR))
         .hasSize(1);
   }


### PR DESCRIPTION
to help configure logging for RetryRegistry objects

Originally from [clouddriver](https://github.com/spinnaker/clouddriver/blob/3f31190d40419218fd1d31ca78bb1661f1ef881a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java#L134-L193).
