### PR TITLE
chore(dependencies): pin io.netty:netty-bom to 4.1.100.Final

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -8,12 +8,13 @@ ext {
   versions = [
     arrow            : "0.13.2",
     aws              : "1.12.261",
-    awsv2            : "2.19.0",
+    awsv2            : "2.23.7",
     bouncycastle     : "1.77",
     brave            : "5.12.3",
     gcp              : "25.3.0",
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
+    netty            : "4.1.100.Final",
     protobuf         : "3.21.12",
     okhttp           : "2.7.5", // CVE-2016-2402
     okhttp3          : "4.9.3",
@@ -56,6 +57,7 @@ dependencies {
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
   api(platform("org.junit:junit-bom:5.8.2")) // remove with spring boot >= 2.6.2
+  api(platform("io.netty:netty-bom:${versions.netty}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
   api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))


### PR DESCRIPTION
to resolve sonatype-2023-4380 / https://github.com/advisories/GHSA-xpw8-rcwv-8f8p

Before this, spring boot 2.5.15 brought in version 4.1.92.Final of netty.  Note that one of the aws sdk v2 dependencies was expecting 4.1.86.Final:
```
|    \--- software.amazon.awssdk:netty-nio-client:2.19.0
|         +--- software.amazon.awssdk:annotations:2.19.0
|         +--- software.amazon.awssdk:http-client-spi:2.19.0 (*)
|         +--- software.amazon.awssdk:utils:2.19.0 (*)
|         +--- software.amazon.awssdk:metrics-spi:2.19.0 (*)
|         +--- io.netty:netty-codec-http:4.1.86.Final -> 4.1.92.Final
|         |    +--- io.netty:netty-common:4.1.92.Final
|         |    +--- io.netty:netty-buffer:4.1.92.Final
|         |    |    \--- io.netty:netty-common:4.1.92.Final
|         |    +--- io.netty:netty-transport:4.1.92.Final
|         |    |    +--- io.netty:netty-common:4.1.92.Final
|         |    |    +--- io.netty:netty-buffer:4.1.92.Final (*)
|         |    |    \--- io.netty:netty-resolver:4.1.92.Final
|         |    |         \--- io.netty:netty-common:4.1.92.Final
|         |    +--- io.netty:netty-codec:4.1.92.Final
|         |    |    +--- io.netty:netty-common:4.1.92.Final
|         |    |    +--- io.netty:netty-buffer:4.1.92.Final (*)
|         |    |    \--- io.netty:netty-transport:4.1.92.Final (*)
|         |    \--- io.netty:netty-handler:4.1.92.Final
|         |         +--- io.netty:netty-common:4.1.92.Final
|         |         +--- io.netty:netty-resolver:4.1.92.Final (*)
|         |         +--- io.netty:netty-buffer:4.1.92.Final (*)
|         |         +--- io.netty:netty-transport:4.1.92.Final (*)
|         |         +--- io.netty:netty-transport-native-unix-common:4.1.92.Final
|         |         |    +--- io.netty:netty-common:4.1.92.Final
|         |         |    +--- io.netty:netty-buffer:4.1.92.Final (*)
|         |         |    \--- io.netty:netty-transport:4.1.92.Final (*)
|         |         \--- io.netty:netty-codec:4.1.92.Final (*)
|         +--- io.netty:netty-codec-http2:4.1.86.Final -> 4.1.92.Final
|         |    +--- io.netty:netty-common:4.1.92.Final
|         |    +--- io.netty:netty-buffer:4.1.92.Final (*)
|         |    +--- io.netty:netty-transport:4.1.92.Final (*)
|         |    +--- io.netty:netty-codec:4.1.92.Final (*)
|         |    +--- io.netty:netty-handler:4.1.92.Final (*)
|         |    \--- io.netty:netty-codec-http:4.1.92.Final (*)
|         +--- io.netty:netty-codec:4.1.86.Final -> 4.1.92.Final (*)
|         +--- io.netty:netty-transport:4.1.86.Final -> 4.1.92.Final (*)
|         +--- io.netty:netty-common:4.1.86.Final -> 4.1.92.Final
|         +--- io.netty:netty-buffer:4.1.86.Final -> 4.1.92.Final (*)
|         +--- io.netty:netty-handler:4.1.86.Final -> 4.1.92.Final (*)
|         +--- io.netty:netty-transport-classes-epoll:4.1.86.Final -> 4.1.92.Final
|         |    +--- io.netty:netty-common:4.1.92.Final
|         |    +--- io.netty:netty-buffer:4.1.92.Final (*)
|         |    +--- io.netty:netty-transport:4.1.92.Final (*)
|         |    \--- io.netty:netty-transport-native-unix-common:4.1.92.Final (*)
```
This commit updates v2 of the aws sdk to 2.23.7 of v2 of the aws sdk.  As of 21-jan-24, this is the most recent version that uses version 4.1.100.Final of netty.
```
|    \--- software.amazon.awssdk:netty-nio-client:2.23.7
|         +--- software.amazon.awssdk:annotations:2.23.7
|         +--- software.amazon.awssdk:http-client-spi:2.23.7 (*)
|         +--- software.amazon.awssdk:utils:2.23.7 (*)
|         +--- software.amazon.awssdk:metrics-spi:2.23.7 (*)
|         +--- io.netty:netty-codec-http:4.1.100.Final
|         |    +--- io.netty:netty-common:4.1.100.Final
|         |    +--- io.netty:netty-buffer:4.1.100.Final
|         |    |    \--- io.netty:netty-common:4.1.100.Final
|         |    +--- io.netty:netty-transport:4.1.100.Final
|         |    |    +--- io.netty:netty-common:4.1.100.Final
|         |    |    +--- io.netty:netty-buffer:4.1.100.Final (*)
|         |    |    \--- io.netty:netty-resolver:4.1.100.Final
|         |    |         \--- io.netty:netty-common:4.1.100.Final
|         |    +--- io.netty:netty-codec:4.1.100.Final
|         |    |    +--- io.netty:netty-common:4.1.100.Final
|         |    |    +--- io.netty:netty-buffer:4.1.100.Final (*)
|         |    |    \--- io.netty:netty-transport:4.1.100.Final (*)
|         |    \--- io.netty:netty-handler:4.1.100.Final
|         |         +--- io.netty:netty-common:4.1.100.Final
|         |         +--- io.netty:netty-resolver:4.1.100.Final (*)
|         |         +--- io.netty:netty-buffer:4.1.100.Final (*)
|         |         +--- io.netty:netty-transport:4.1.100.Final (*)
|         |         +--- io.netty:netty-transport-native-unix-common:4.1.100.Final
|         |         |    +--- io.netty:netty-common:4.1.100.Final
|         |         |    +--- io.netty:netty-buffer:4.1.100.Final (*)
|         |         |    \--- io.netty:netty-transport:4.1.100.Final (*)
|         |         \--- io.netty:netty-codec:4.1.100.Final (*)
|         +--- io.netty:netty-codec-http2:4.1.100.Final
|         |    +--- io.netty:netty-common:4.1.100.Final
|         |    +--- io.netty:netty-buffer:4.1.100.Final (*)
|         |    +--- io.netty:netty-transport:4.1.100.Final (*)
|         |    +--- io.netty:netty-codec:4.1.100.Final (*)
|         |    +--- io.netty:netty-handler:4.1.100.Final (*)
|         |    \--- io.netty:netty-codec-http:4.1.100.Final (*)
|         +--- io.netty:netty-codec:4.1.100.Final (*)
|         +--- io.netty:netty-transport:4.1.100.Final (*)
|         +--- io.netty:netty-common:4.1.100.Final
|         +--- io.netty:netty-buffer:4.1.100.Final (*)
|         +--- io.netty:netty-handler:4.1.100.Final (*)
|         +--- io.netty:netty-transport-classes-epoll:4.1.100.Final
|         |    +--- io.netty:netty-common:4.1.100.Final
|         |    +--- io.netty:netty-buffer:4.1.100.Final (*)
|         |    +--- io.netty:netty-transport:4.1.100.Final (*)
|         |    \--- io.netty:netty-transport-native-unix-common:4.1.100.Final (*)
```