### PR TITLE
fix(cve): Update snakeyml to 1.31 to fix following CVEs CVE-2022-25857 CVE-2022-38749

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -187,7 +187,7 @@ dependencies {
     // making it strict as some of the modules have it resolved to higher versions (ex: kork-secrets-gcp to 1.30)
     api("org.yaml:snakeyaml") {
       version {
-        strictly "1.27"
+        strictly "1.31"
       }
     }
     api("org.springdoc:springdoc-openapi-webmvc-core:${versions.openapi}")


### PR DESCRIPTION
We've tested this in our Harness internal environments for some time and have not seen any misbehavior. 