### PR TITLE
fix(artifacts): Do not store non-base64 artifacts

### DIFF
--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorerTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorerTest.java
@@ -110,4 +110,21 @@ public class S3ArtifactStoreStorerTest {
         Arguments.of("app-five", denyRegex, false),
         Arguments.of("app-five-more", denyRegex, false));
   }
+
+  @Test
+  public void testInvalidEmbeddedBase64StillSucceeds() {
+    S3Client client = mock(S3Client.class);
+    AuthenticatedRequest.set(Header.APPLICATION, "my-application");
+    S3ArtifactStoreStorer artifactStore =
+        new S3ArtifactStoreStorer(client, "my-bucket", new ArtifactStoreURISHA256Builder(), null);
+    String expectedReference = "${ #nonbase64spel() }";
+    Artifact artifact =
+        artifactStore.store(
+            Artifact.builder()
+                .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
+                .reference(expectedReference)
+                .build());
+    assertEquals(expectedReference, artifact.getReference());
+    assertEquals(ArtifactTypes.EMBEDDED_BASE64.getMimeType(), artifact.getType());
+  }
 }


### PR DESCRIPTION
This commit addresses a bug where storing SpEL can cause major issues down the chain, e.g. expected artifacts.

The easiest solution is to simply not store the artifact, but improvements could be made to evaluate the SpEL, if it makes sense to do