### PR TITLE
chore(dependencies): use version 0.9.4 of org.bitbucket.b_c:jose4j

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -141,7 +141,7 @@ dependencies {
     api("javax.xml.bind:jaxb-api:2.3.1")
     api("net.logstash.logback:logstash-logback-encoder:4.11")
     api("org.apache.commons:commons-exec:1.3")
-    api("org.bitbucket.b_c:jose4j:0.9.3")
+    api("org.bitbucket.b_c:jose4j:0.9.4")
     //  from BC 1.71, module names changed from *-jdk15on to *-jdk18on
     // due to this change, some of the modules in downstream services like clouddriver, gate would fall back to
     // lower versions(<1.70) as transitive dependencies. So to make them use BC >=1.74(CVE free versions),


### PR DESCRIPTION
to resolve CVE-2023-51775.

No change to dependencies in kork.  `$ ./gradlew clouddriver-kubernetes:dependencies` and `./gradlew orca-clouddriver:dependencies` change as follows:

before:
```
+--- io.kubernetes:client-java -> 11.0.4
|    \--- org.bitbucket.b_c:jose4j:0.7.3 -> 0.9.3
|         \--- org.slf4j:slf4j-api:1.7.21 -> 1.7.32
```
after:
```
+--- io.kubernetes:client-java -> 11.0.4
|    \--- org.bitbucket.b_c:jose4j:0.7.3 -> 0.9.4
|         \--- org.slf4j:slf4j-api:1.7.36 -> 1.7.32
```