### PR TITLE
chore(dependencies): use version 2.9.0 of com.jayway.jsonpath:json-path

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -85,6 +85,7 @@ dependencies {
     api("com.google.guava:guava:33.0.0-jre")
     api("com.hubspot.jinjava:jinjava:2.7.1")
     api("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
+    api("com.jayway.jsonpath:json-path:2.9.0") // until spring boot >= 3.1.9 or 3.2.3
     api("com.jcraft:jsch:${versions.jsch}")
     api("com.jcraft:jsch.agentproxy.connector-factory:${versions.jschAgentProxy}")
     api("com.jcraft:jsch.agentproxy.jsch:${versions.jschAgentProxy}")


### PR DESCRIPTION
to resolve CVE-2023-51074.

before:
```
     +--- com.jayway.jsonpath:json-path:2.5.0
     |    +--- net.minidev:json-smart:2.3 -> 2.4.10
     |    |    \--- net.minidev:accessors-smart:2.4.9
     |    |         \--- org.ow2.asm:asm:9.3
     |    \--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
```
after:
```
     +--- com.jayway.jsonpath:json-path:2.5.0 -> 2.9.0
     |    +--- net.minidev:json-smart:2.5.0
     |    |    \--- net.minidev:accessors-smart:2.5.0
     |    |         \--- org.ow2.asm:asm:9.3
     |    \--- org.slf4j:slf4j-api:2.0.11 -> 1.7.36
```