### PR TITLE
chore(dependency): upgrade kotlin to 1.6.21 and unpin kotlinx-coroutines

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.5.32
+kotlinVersion=1.6.21
 org.gradle.parallel=true
 spinnakerGradleVersion=8.32.1
 targetJava11=true

--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -37,7 +37,7 @@ dependencies {
 
 compileTestKotlin {
   kotlinOptions {
-    languageVersion = "1.5"
+    languageVersion = "1.6"
     jvmTarget = "11"
   }
 }

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -39,14 +39,14 @@ dependencies {
 
 compileKotlin {
   kotlinOptions {
-    languageVersion = "1.5"
+    languageVersion = "1.6"
     jvmTarget = "11"
   }
 }
 
 compileTestKotlin {
   kotlinOptions {
-    languageVersion = "1.5"
+    languageVersion = "1.6"
     jvmTarget = "11"
   }
 }

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -55,7 +55,6 @@ dependencies {
    // 2.16.0 is subject to CVE-2021-45105.  2.17.0 is subject to CVE-2021-44832, so use >= 2.17.1.
   api(platform("org.apache.logging.log4j:log4j-bom:2.20.0"))
 
-  api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.5.2"))
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))


### PR DESCRIPTION
Upgrade kotlin from 1.5.32 to 1.6.21, in order to sync with spring boot 2.6.15. Unpinning kotlinx-coroutines, that brings version 1.5.2 as transitive dependency of spring boot 2.6.15. So, effectively no change in kotlinx-coroutines version. 
https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.6.15/spring-boot-dependencies-2.6.15.pom