### PR TITLE
chore(dependencies): upgrade liquibase to 4.27.0

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -170,11 +170,7 @@ dependencies {
     api("org.jetbrains.spek:spek-junit-platform-engine:${versions.spek}")
     api("org.jetbrains.spek:spek-junit-platform-runner:${versions.spek}")
     api("org.jetbrains.spek:spek-subject-extension:${versions.spek}")
-    api("org.liquibase:liquibase-core"){
-       version {
-         strictly "4.24.0"
-       }
-    }
+    api("org.liquibase:liquibase-core:4.27.0")
     api("org.objenesis:objenesis:2.5.1")
     api("org.pf4j:pf4j:3.10.0")
     // pf4j:3.10.0 brings in slf4j-api:2.0.6 which is not compatible with logback 1.2.x.


### PR DESCRIPTION
postgresql not supporting `afterColumn` feature and various issues with liquibase versions resulted in delayed liquibase upgrade from 3.10.3 to 4.24.0 in spinnaker 1.33.0 release. Here is the PR- https://github.com/spinnaker/kork/pull/1117
 
But even after the upgrade, migrating databases faced [checksum issues](https://github.com/spinnaker/spinnaker/issues/6941).

In order to fix this issue two changes are needed.
1. Upgrade liquibase further to 4.27.0 (through this PR)
2. Add validCheckSum tags to those changeSets in clouddriver and Orca which are failing with CheckSum errors.
    - https://github.com/spinnaker/clouddriver/pull/6217
    - https://github.com/spinnaker/orca/pull/4727

### Some background:

#### Broken Sprinnaker upgrades
Kork 7.201.0 upgraded liquibase to 4.24.0. And this is causing checkSum error for spinnaker upgrades. So all the releases starting from 1.33.0(1.33.0, 1.33.1, 1.33.2, 1.34.0, 1.34.1 and 1.34.2) are broken for Spinnaker upgrades. 

#### Broken new Spinnaker Installation when Clouddriver uses Postgresql
Post liquibase 4.24.0 upgrade, due to lack of changes from https://github.com/spinnaker/clouddriver/pull/6194, releases 1.33.0, 1.33.1, 1.34.0 and 1.34.1 would fail for new spinnaker installation if clouddriver uses Postgres and the error being "addAfterColumn is not allowed on postgresql".  After including the changes 1.33.2 and 1.34.2 have no issues for new spinnaker installation.



So when the current fixes are merged and released, the versions 1.35.0, 1.33.3 and 1.34.3 and all later versions will work for both new installation and upgrade of Spinnaker.

