### PR TITLE
feature(retrofit): Add exception handler to service factory

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactory.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactory.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.client.ServiceClientFactory;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import retrofit.Endpoint;
 import retrofit.RequestInterceptor;
@@ -54,6 +55,7 @@ class RetrofitServiceFactory implements ServiceClientFactory {
         .setRequestInterceptor(spinnakerRequestInterceptor)
         .setConverter(new JacksonConverter(objectMapper))
         .setEndpoint(endpoint)
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
         .setClient(new Ok3Client(clientProvider.getClient(serviceEndpoint)))
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(type))


### PR DESCRIPTION
This commit adds the SpinnakerRetrofitErrorHandler to service factories which allows for clients that rely on service factories to properly have RetrofitErrors be converted to some Spinnaker*Exception.

This PR needs to remain as a draft until gate has fully changed its exception handling to support non-RetrofitError exceptions