### PR TITLE
chore(dependency): upgrade spring boot from 2.6.15 to 2.7.18

### DIFF
--- a/kork-actuator/src/main/resources/META-INF/spring.factories
+++ b/kork-actuator/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.actuator.ActuatorEndpointsConfiguration,\
-  com.netflix.spinnaker.kork.actuator.ResolvedEnvEndpointAutoConfiguration

--- a/kork-actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.netflix.spinnaker.kork.actuator.ActuatorEndpointsConfiguration
+com.netflix.spinnaker.kork.actuator.ResolvedEnvEndpointAutoConfiguration

--- a/kork-aws/src/main/resources/META-INF/spring.factories
+++ b/kork-aws/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.aws.AwsComponents

--- a/kork-aws/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-aws/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.spinnaker.kork.aws.AwsComponents

--- a/kork-cloud-config-server/src/main/resources/META-INF/spring.factories
+++ b/kork-cloud-config-server/src/main/resources/META-INF/spring.factories
@@ -1,7 +1,2 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.configserver.autoconfig.CloudConfigAutoConfiguration, \
-  com.netflix.spinnaker.kork.configserver.autoconfig.SpringCloudAwsConfiguration, \
-  com.netflix.spinnaker.kork.configserver.autoconfig.SpringCloudAwsS3ResourceLoaderConfiguration, \
-  io.awspring.cloud.context.config.annotation.ContextResourceLoaderConfiguration
 org.springframework.context.ApplicationListener=\
   com.netflix.spinnaker.kork.configserver.CloudConfigApplicationListener

--- a/kork-cloud-config-server/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-cloud-config-server/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,4 @@
+com.netflix.spinnaker.kork.configserver.autoconfig.CloudConfigAutoConfiguration
+com.netflix.spinnaker.kork.configserver.autoconfig.SpringCloudAwsConfiguration
+com.netflix.spinnaker.kork.configserver.autoconfig.SpringCloudAwsS3ResourceLoaderConfiguration
+io.awspring.cloud.context.config.annotation.ContextResourceLoaderConfiguration

--- a/kork-core/src/main/resources/META-INF/spring.factories
+++ b/kork-core/src/main/resources/META-INF/spring.factories
@@ -1,8 +1,3 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.PlatformComponents,\
-  com.netflix.spinnaker.kork.discovery.DiscoveryAutoConfiguration
-
-
 org.springframework.context.ApplicationListener=\
   com.netflix.spinnaker.kork.spring.SpringBoot1CompatibilityApplicationListener,\
   com.netflix.spinnaker.kork.web.exceptions.DefaultThreadUncaughtExceptionHandler

--- a/kork-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.netflix.spinnaker.kork.PlatformComponents
+com.netflix.spinnaker.kork.discovery.DiscoveryAutoConfiguration

--- a/kork-credentials/src/main/resources/META-INF/spring.factories
+++ b/kork-credentials/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.credentials.jackson.SensitiveAutoConfiguration
+

--- a/kork-credentials/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-credentials/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.spinnaker.credentials.jackson.SensitiveAutoConfiguration

--- a/kork-eureka/src/main/resources/META-INF/spring.factories
+++ b/kork-eureka/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.archaius.ArchaiusAutoConfiguration,\
-  com.netflix.spinnaker.kork.eureka.EurekaAutoConfiguration
+

--- a/kork-eureka/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-eureka/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.netflix.spinnaker.kork.archaius.ArchaiusAutoConfiguration
+com.netflix.spinnaker.kork.eureka.EurekaAutoConfiguration

--- a/kork-retrofit/src/main/resources/META-INF/spring.factories
+++ b/kork-retrofit/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.retrofit.RetrofitServiceFactoryAutoConfiguration
+

--- a/kork-retrofit/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-retrofit/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.spinnaker.kork.retrofit.RetrofitServiceFactoryAutoConfiguration

--- a/kork-retrofit2/src/main/resources/META-INF/spring.factories
+++ b/kork-retrofit2/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.retrofit.Retrofit2ServiceFactoryAutoConfiguration
+

--- a/kork-retrofit2/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-retrofit2/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.spinnaker.kork.retrofit.Retrofit2ServiceFactoryAutoConfiguration

--- a/kork-secrets/src/main/resources/META-INF/spring.factories
+++ b/kork-secrets/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.secrets.SecretConfiguration
+

--- a/kork-secrets/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-secrets/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.spinnaker.kork.secrets.SecretConfiguration

--- a/kork-sql-test/kork-sql-test.gradle
+++ b/kork-sql-test/kork-sql-test.gradle
@@ -11,7 +11,7 @@ dependencies {
 
   runtimeOnly "com.h2database:h2"
 
-  testRuntimeOnly "mysql:mysql-connector-java"
+  testRuntimeOnly "com.mysql:mysql-connector-j"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
   testRuntimeOnly "org.postgresql:postgresql"
 }

--- a/kork-sql/kork-sql.gradle
+++ b/kork-sql/kork-sql.gradle
@@ -22,7 +22,7 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 
   testRuntimeOnly project(":kork-web")
-  testRuntimeOnly "mysql:mysql-connector-java"
+  testRuntimeOnly "com.mysql:mysql-connector-j"
 }
 
 detekt {

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -35,6 +35,7 @@ import org.jooq.impl.DefaultExecuteListenerProvider
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.BeanCreationException
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -55,7 +56,7 @@ import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy
 @Configuration
 @ConditionalOnProperty("sql.enabled")
 @EnableConfigurationProperties(SqlProperties::class)
-@EnableAutoConfiguration(exclude = [DataSourceAutoConfiguration::class])
+@EnableAutoConfiguration(exclude = [DataSourceAutoConfiguration::class, DataSourcePoolMetricsAutoConfiguration::class])
 @Import(HikariDataSourceConfiguration::class, DataSourcePoolMetadataProvidersConfiguration::class)
 class DefaultSqlConfiguration {
 

--- a/kork-swagger/src/main/resources/META-INF/spring.factories
+++ b/kork-swagger/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.config.SpringfoxHandlerProviderBeanPostProcessor
+

--- a/kork-swagger/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-swagger/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.spinnaker.config.SpringfoxHandlerProviderBeanPostProcessor

--- a/kork-tomcat/src/main/resources/META-INF/spring.factories
+++ b/kork-tomcat/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,2 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.spinnaker.kork.tomcat.TomcatConfiguration
+
 

--- a/kork-tomcat/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-tomcat/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.spinnaker.kork.tomcat.TomcatConfiguration

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -14,11 +14,10 @@ ext {
     gcp              : "25.3.0",
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
-    // spring boot 2.6.15 specifies logback 1.2.12.  Pin to 1.2.13 to resolve
+    // spring boot 2.7.18 specifies logback 1.2.12.  Pin to 1.2.13 to resolve
     // CVE-2023-6378 and CVE-2023-6481 until spring boot 3.1.7 which brings in
     // 1.4.14.  See https://logback.qos.ch/news.html#1.3.12.
     logback          : "1.2.13",
-    netty            : "4.1.100.Final",
     protobuf         : "3.21.12",
     okhttp           : "2.7.5", // CVE-2016-2402
     okhttp3          : "4.9.3",
@@ -28,14 +27,12 @@ ext {
     spectator        : "1.0.6",
     spek             : "1.1.5",
     spek2            : "2.0.9",
-    springBoot       : "2.6.15",
+    springBoot       : "2.7.18",
     springCloud      : "2021.0.8",
     springfoxSwagger : "3.0.0",
     swagger          : "1.5.20", //this should stay in sync with what springfoxSwagger expects.
 
-    // Spring boot 2.6.15 bring in 9.0.75.  2.7.18
-    // brings in 9.0.83, which fixes all CVEs to date (20-feb-24).
-    //
+    // 2.7.18 brings in 9.0.83, which fixes all CVEs to date (20-feb-24). Continue to pin.
     // See https://tomcat.apache.org/security-9.html for latest security fixes.
     tomcat           : "9.0.83"
   ]
@@ -59,8 +56,6 @@ dependencies {
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
-  api(platform("org.junit:junit-bom:5.8.2")) // remove with spring boot >= 2.6.2
-  api(platform("io.netty:netty-bom:${versions.netty}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
   api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))
@@ -180,7 +175,7 @@ dependencies {
     // pf4j:3.10.0 brings in slf4j-api:2.0.6 which is not compatible with logback 1.2.x.
     // And the upgraded logback version(1.3.8) is becoming incompatible with SpringBoot's LogbackLoggingSystem:
     // java.lang.NoClassDefFoundError at LogbackLoggingSystem.java:293
-    // Hence pinning slf4j-api at 1.7.36 which spring boot 2.6.15 brings in.
+    // Hence pinning slf4j-api at 1.7.36 which spring boot 2.7.18 brings in.
     api("org.slf4j:slf4j-api"){
       version {
         strictly("1.7.36")
@@ -188,7 +183,7 @@ dependencies {
     }
     api("org.pf4j:pf4j-update:2.3.0")
 
-    // Spring boot 2.6.15 brings in snakeyaml 1.29, which fails to parse yaml (including some
+    // Spring boot 2.7.18 brings in snakeyaml 1.30, which fails to parse yaml (including some
     // k8s manifests).  See https://github.com/spring-projects/spring-boot/issues/30159#issuecomment-1125969155.
     // It's safe to upgrade beyond 1.29 with spring boot >= 2.6.12 (see
     // https://github.com/spring-projects/spring-boot/issues/32228#issue-136185850.0). However,


### PR DESCRIPTION
Unpin netty-bom to align with spring boot during upgrade to spring boot 2.7.x 
With spring boot 2.7.18, separate dependency management for netty-tcnative has been removed in favor of the dependency management provided by Netty’s bom. 
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#separate-dependency-management-for-netty-tcnative-removed


Exclude `DataSourcePoolMetricsAutoConfiguration` class from auto-configuration to resolve circular reference issue during upgrade to spring boot 2.7.x. 
While upgrading spring boot 2.7.18, encounter below error during test compilation of kork-sql module:
```
***************************
APPLICATION FAILED TO START
***************************

Description:

The dependencies of some of the beans in the application context form a cycle:

┌─────┐
|  registry defined in class path resource [com/netflix/spinnaker/kork/metrics/SpectatorConfiguration.class]
↑     ↓
|  simpleMeterRegistry defined in class path resource [org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleMetricsExportAutoConfiguration.class]
↑     ↓
|  dataSourcePoolMetadataMeterBinder defined in class path resource [org/springframework/boot/actuate/autoconfigure/metrics/jdbc/DataSourcePoolMetricsAutoConfiguration$DataSourcePoolMetadataMetricsConfiguration.class]
↑     ↓
|  dataSource defined in class path resource [com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.class]
↑     ↓
|  dataSourceFactory defined in class path resource [com/netflix/spinnaker/kork/sql/config/HikariDataSourceConfiguration.class]
↑     ↓
|  hikariMetricsTrackerFactory defined in class path resource [com/netflix/spinnaker/kork/sql/config/HikariDataSourceConfiguration.class]
└─────┘

Action:

Relying upon circular references is discouraged and they are prohibited by default. Update your application to remove the dependency cycle between beans. As a last resort, it may be possible to break the cycle automatically by setting spring.main.allow-circular-references to true.
```
To fix circular reference issue excluded the `org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration` class from auto-configuration while building sql configuration in `DefaultSqlConfiguration` class.


Replace spring.factories with AutoConfiguration.imports file to enable auto-configuration during upgrade to spring boot 2.7.x. 
In spring boot 2.7.x, major change has been introduced for auto-configuration registration. The registration has been moved from spring.factories under the org.springframework.boot.autoconfigure.EnableAutoConfiguration key to a new file named META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports. 
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#changes-to-auto-configuration 
So, replacing the registration of auto-configuration classes from spring.factories to META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports.


Update mysql connector coordinate during upgrade to spring boot 2.7.x In spring boot 2.7.8 onwards mysql connector coordinate `mysql:mysql-connector-java` has been removed and only `com.mysql:mysql-connector-j` coordinate exist. https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#mysql-jdbc-driver So, updating the mysql connector coordinate as `com.mysql:mysql-connector-j` with spring boot upgrade to 2.7.18. https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom

Groovy is also moving from 3.0.17 to 3.0.19.