### PR TITLE
Revert "chore(dependencies): upgrade liquibase to 4.27.0 (#1184)"

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -170,7 +170,11 @@ dependencies {
     api("org.jetbrains.spek:spek-junit-platform-engine:${versions.spek}")
     api("org.jetbrains.spek:spek-junit-platform-runner:${versions.spek}")
     api("org.jetbrains.spek:spek-subject-extension:${versions.spek}")
-    api("org.liquibase:liquibase-core:4.27.0")
+    api("org.liquibase:liquibase-core"){
+       version {
+         strictly "4.24.0"
+       }
+    }
     api("org.objenesis:objenesis:2.5.1")
     api("org.pf4j:pf4j:3.10.0")
     // pf4j:3.10.0 brings in slf4j-api:2.0.6 which is not compatible with logback 1.2.x.


### PR DESCRIPTION
This reverts commit 4ff407e8c4486e8d51dacbcdf24e2057482f74fa.

Turns out that we don't need liquibase 4.27.0 to fix migration issues with postgres. https://github.com/spinnaker/clouddriver/pull/6217 fixes the migration with 4.24.0.