### PR TITLE
feat(SpEL): implement to configure the limit of characters for SpEL expressions

### DIFF
--- a/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
+++ b/kork-expressions/src/main/java/com/netflix/spinnaker/kork/expressions/config/ExpressionProperties.java
@@ -20,11 +20,19 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/** Configuration properties for Spring Expression Language (SpEL) evaluation related features. */
 @Data
 @ConfigurationProperties(prefix = "expression")
 public class ExpressionProperties {
 
+  /** Flag to determine if SpEL evaluation to be skipped. */
   private final FeatureFlag doNotEvalSpel = new FeatureFlag().setEnabled(true);
+
+  /**
+   * To set the maximum limit of characters in expression for SpEL evaluation. Default value -1
+   * signifies to use default maximum limit of 10,000 characters provided by springframework.
+   */
+  private int maxExpressionLength = -1;
 
   @Data
   @Accessors(chain = true)


### PR DESCRIPTION
Spring Expression Lanuage (SpEL) has a default limit of 10,000 characters. Springframework provides the feature to configure the limit. This feature allows to configure the limit of characters for SpEL expressions.

Approach:
In order to use an expression with characters more than the given default limit, require to follow either of the below approaches:
1. For Springframework >=5.3.28 and <6.1.3, by setting `maximumExpressionLength` field while instantiating the custom `SpelParserConfiguration` class. 
https://github.com/spring-projects/spring-framework/issues/30380 
https://github.com/spring-projects/spring-framework/issues/30446
2. For Springframework >=6.1.3, by setting a JVM system property or Spring property named `spring.context.expression.maxLength` to the maximum expression length needed by your application. 
https://github.com/spring-projects/spring-framework/issues/31952 
https://github.com/spring-projects/spring-framework/commit/785598629abda944343a02307ad82a79bb31b589 

Spinnaker supports spring boot 2.7.18, that brings springframework 5.3.31 [https://docs.spring.io/spring-boot/docs/2.7.18/reference/html/dependency-versions.html#appendix.dependency-versions.propertie9]. So first approach need to be implemented along with spinnaker enhancement to expose the `maximumExpressionLength` field.