### PR TITLE
chore(dependency): upgrade nimbus-jose to fix CVE-2023-52428

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -111,7 +111,7 @@ dependencies {
     api("com.netflix.spectator:spectator-reg-atlas:${versions.spectator}")
     api("com.netflix.spectator:spectator-web-spring:${versions.spectator}")
     api("com.netflix.spectator:spectator-reg-micrometer:${versions.spectator}")
-    api("com.nimbusds:nimbus-jose-jwt:7.9")
+    api("com.nimbusds:nimbus-jose-jwt:9.37.2")
     api("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
     api("com.nhaarman:mockito-kotlin:1.6.0")
     api("com.ninja-squad:springmockk:2.0.3")


### PR DESCRIPTION
`com.nimbusds:nimbus-jose-jwt` dependency is pinned to version 7.9, that is old version and shows [CVE-2023-52428](https://nvd.nist.gov/vuln/detail/CVE-2023-52428) as direct vulnerability. In order to fix this vulnerability upgrading and pinning nimbus-jose to 9.37.2.

The components using nimbus-jose as direct or transitive dependency are gate, clouddriver, front50 and halyard.