### PR TITLE
test(expressions): demonstrate behavior of SpEL expression evaluation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,12 @@ allprojects {
 subprojects {
   group = "io.spinnaker.kork"
 
+  // This is required for some SpEL expressions to evaluate properly with java
+  // 17.  It works with java 11 as well, but isn't required there.
+  tasks.withType(Test).configureEach {
+    jvmArgs += '--add-opens=java.base/java.util=ALL-UNNAMED'
+  }
+
   if (it.name != "kork-bom" && it.name != "spinnaker-dependencies") {
     apply plugin: 'java-library'
     test {

--- a/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupportTest.java
+++ b/kork-expressions/src/test/java/com/netflix/spinnaker/kork/expressions/ExpressionsSupportTest.java
@@ -163,6 +163,30 @@ public class ExpressionsSupportTest {
     assertThat(evaluated).isEqualTo("00000000-0000-0000-0000-000000000000");
   }
 
+  @Test
+  public void testUnmodifiableMapToString() {
+    ExpressionProperties expressionProperties = new ExpressionProperties();
+
+    Map<String, Object> testContext = Collections.emptyMap();
+
+    // This fails under java 17 without something like
+    // --add-opens=java.base/java.util=ALL-UNNAMED as an argument ot the jvm.
+    String testInput = "${ {'foo': 'bar'}.toString() }";
+
+    ExpressionEvaluationSummary summary = new ExpressionEvaluationSummary();
+    String evaluated =
+        new ExpressionTransform(parserContext, parser, Function.identity())
+            .transformString(
+                testInput,
+                new ExpressionsSupport(null, expressionProperties)
+                    .buildEvaluationContext(testContext, true),
+                summary);
+
+    assertThat(summary.getExpressionResult()).isEmpty();
+    assertThat(summary.getFailureCount()).isEqualTo(0);
+    assertThat(evaluated).isEqualTo("{foo=bar}");
+  }
+
   public class MockArtifactStore extends ArtifactStore {
     public Map<String, String> cache = new HashMap<>();
 


### PR DESCRIPTION
that uses a non-public constructor/method, and so requires special treatment under java 17.