### PR TITLE
chore(dependency): upgrade junit-jupiter to 5.9.0

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -55,6 +55,7 @@ dependencies {
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
+  api(platform("org.junit:junit-bom:5.9.0")) // untill spring boot >= 3.0.0
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))


### PR DESCRIPTION
As part of upgrading the spock framework from 2.0-groovy-3.0 to 2.2-groovy-3.0, it is required to update junit5 to 5.9.0. 
https://spockframework.org/spock/docs/2.3/release_notes.html#_2_2_2022_08_31 
Spring boot 2.7.18 brings junit-jupiter 5.8.2.
https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom 
So, junit-bom version to be pinned to 5.9.0, untill spring boot >= 3.0.0.