### PR TITLE
feat(moniker): Move OperationDescription from clouddriver to kork 

### DIFF
--- a/kork-moniker/src/main/java/com/netflix/spinnaker/moniker/Namer.java
+++ b/kork-moniker/src/main/java/com/netflix/spinnaker/moniker/Namer.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.moniker;
 
+import com.netflix.spinnaker.orchestration.OperationDescription;
+
 /**
  * A "Namer" takes some type "T" (e.g. a server group) and allows you to either
  *
@@ -28,6 +30,19 @@ package com.netflix.spinnaker.moniker;
  */
 public interface Namer<T> {
   void applyMoniker(T obj, Moniker moniker);
+
+  /**
+   * Sets a moniker on the given object with additional context provided by the description. This
+   * default implementation ignores the provided {@code description} and simply delegates to the
+   * {@link #applyMoniker(Object, Moniker)} method.
+   *
+   * @param obj the object to which the moniker will be applied
+   * @param moniker the moniker to apply
+   * @param description a description that provides additional context for the operation
+   */
+  default void applyMoniker(T obj, Moniker moniker, OperationDescription description) {
+    applyMoniker(obj, moniker);
+  }
 
   Moniker deriveMoniker(T obj);
 }

--- a/kork-moniker/src/main/java/com/netflix/spinnaker/orchestration/OperationDescription.java
+++ b/kork-moniker/src/main/java/com/netflix/spinnaker/orchestration/OperationDescription.java
@@ -1,0 +1,4 @@
+package com.netflix.spinnaker.orchestration;
+
+/** Marker interface for inputs to an AtomicOperation. */
+public interface OperationDescription {}


### PR DESCRIPTION
and add an overloaded applyMoniker method with the description parameter.

Added a new overloaded applyMoniker method to the Namer interface with an OperationDescription parameter. The new method defaults to calling the existing applyMoniker method without the description. Moved the OperationDescription from clouddriver's com.netflix.spinnaker.clouddriver.orchestration to kork-moniker's com.netflix.spinnaker.orchestration.

First used in https://github.com/spinnaker/kork/pull/1199