### PR TITLE
chore(dependency): upgrade groovy to 4.0.15

### DIFF
--- a/kork-aws/kork-aws.gradle
+++ b/kork-aws/kork-aws.gradle
@@ -24,7 +24,7 @@ dependencies {
   api "com.amazonaws:aws-java-sdk-core"
   api "com.amazonaws:aws-java-sdk-sns"
   api "com.amazonaws:aws-java-sdk-sqs"
-  api "org.codehaus.groovy:groovy"
+  api "org.apache.groovy:groovy"
   api "com.hubspot.jinjava:jinjava"
   api "com.jcraft:jsch.agentproxy.jsch"
   api "com.jcraft:jsch.agentproxy.connector-factory"

--- a/kork-core-tck/kork-core-tck.gradle
+++ b/kork-core-tck/kork-core-tck.gradle
@@ -7,6 +7,6 @@ dependencies {
   implementation(project(":kork-core"))
   implementation(project(":kork-exceptions"))
 
-  implementation("org.codehaus.groovy:groovy")
+  implementation("org.apache.groovy:groovy")
   implementation("org.spockframework:spock-core")
 }

--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -16,7 +16,7 @@ dependencies {
   api project(":kork-crypto")
   api project(":kork-security")
   api project(":kork-exceptions")
-  api "org.codehaus.groovy:groovy"
+  api "org.apache.groovy:groovy"
   api "org.springframework.boot:spring-boot-starter-web"
   api "org.springframework.boot:spring-boot-starter-webflux"
   api "org.springframework.boot:spring-boot-starter-security"

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -12,6 +12,7 @@ ext {
     bouncycastle     : "1.77",
     brave            : "5.12.3",
     gcp              : "25.3.0",
+    groovy           : "4.0.15",
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
     // spring boot 2.7.18 specifies logback 1.2.12.  Pin to 1.2.13 to resolve
@@ -22,6 +23,7 @@ ext {
     okhttp           : "2.7.5", // CVE-2016-2402
     okhttp3          : "4.9.3",
     openapi          : "1.3.9", // this needs to be kept in sync with spring boot as it pulls in the spring-boot-dependencies BOM
+    restassured      : "5.2.1", // spring boot 2.7.18 brings rest-assured 4.5.1. It uses groovy 3. Keep until spring boot >=3.0.13
     retrofit         : "1.9.0",
     retrofit2        : "2.8.1",
     spectator        : "1.0.6",
@@ -57,14 +59,17 @@ dependencies {
   api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
   api(platform("org.junit:junit-bom:5.9.0")) // untill spring boot >= 3.0.0
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
-  api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
+  api(platform("org.apache.groovy:groovy-bom:${versions.groovy}")) // until upgrade of spring boot >= 3.0.13
+  api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}")) {
+    exclude group: "org.codehaus.groovy", module: "*" // until upgrade of spring boot >= 3.0.13
+  }
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
   api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))
   api(platform("com.google.cloud:libraries-bom:${versions.gcp}"))
   api(platform("software.amazon.awssdk:bom:${versions.awsv2}"))
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
   api(platform("io.strikt:strikt-bom:0.31.0"))
-  api(platform("org.spockframework:spock-bom:2.2-groovy-3.0"))
+  api(platform("org.spockframework:spock-bom:2.2-groovy-4.0"))
   api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:3.21.0"))
   api(platform("org.testcontainers:testcontainers-bom:1.19.8"))
   api(platform("io.arrow-kt:arrow-stack:${versions.arrow}"))
@@ -79,6 +84,15 @@ dependencies {
     }
     api("ch.qos.logback:logback-access:${versions.logback}") {
        force = true
+    }
+    api("io.rest-assured:xml-path:${versions.restassured}") {
+      force = true
+    }
+    api("io.rest-assured:json-path:${versions.restassured}") {
+      force = true
+    }
+    api("io.rest-assured:rest-assured:${versions.restassured}") {
+      force = true
     }
     api("com.amazonaws:aws-java-sdk:${versions.aws}")
     api("com.google.api-client:google-api-client:1.30.10") // TODO: Track update for CVE-2020-7692, reanalysis pending.


### PR DESCRIPTION
As part of the effort to upgrade groovy from 3.x to 4.x, upgrading to 4.0.15 version that is supported by spring boot 3.0.13 (expected as next upgrade). Replacing the coordinates from `org.codehaus.groovy` to `org.apache.groovy` supported by groovy 4.x and above versions. Upgrading spockframework from 2.2-groovy-3.0 to 2.2-groovy-4.0 to support groovy 4.
Spring boot 2.7.18 brings rest-assured 4.5.1 as its transitive dependency, that uses groovy 3. In order to resolve the groovy version to 4, pinning `io.rest-assured` to 5.2.1 till spring boot upgrade >=3.0.13