### PR TITLE
feat(gce): support resourceManagerTags in instance template

### DIFF
--- a/kork-secrets-gcp/src/main/java/com/netflix/spinnaker/kork/secrets/engines/GcsSecretEngine.java
+++ b/kork-secrets-gcp/src/main/java/com/netflix/spinnaker/kork/secrets/engines/GcsSecretEngine.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.kork.secrets.engines;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.storage.Storage;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
@@ -82,7 +82,7 @@ public class GcsSecretEngine extends AbstractStorageSecretEngine {
 
     if (storage == null) {
       HttpTransport httpTransport = GoogleUtils.buildHttpTransport();
-      JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+      JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
       GoogleCredentials credentials = GoogleUtils.buildGoogleCredentials();
       HttpRequestInitializer requestInitializer =
           GoogleUtils.setTimeoutsAndRetryBehavior(credentials);

--- a/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/ConfigParams.java
+++ b/kork-stackdriver/src/main/java/com/netflix/spectator/stackdriver/ConfigParams.java
@@ -20,7 +20,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.monitoring.v3.Monitoring;
 import com.google.api.services.monitoring.v3.MonitoringScopes;
 import com.netflix.spectator.api.Measurement;
@@ -106,7 +106,7 @@ public class ConfigParams {
       if (result.monitoring == null) {
         try {
           HttpTransport transport = GoogleNetHttpTransport.newTrustedTransport();
-          JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+          JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
           GoogleCredential credential = loadCredential(transport, jsonFactory, credentialsPath);
           String version = getClass().getPackage().getImplementationVersion();
           if (version == null) {

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -95,13 +95,13 @@ dependencies {
       force = true
     }
     api("com.amazonaws:aws-java-sdk:${versions.aws}")
-    api("com.google.api-client:google-api-client:1.31.1") // TODO: Track update for CVE-2020-7692, reanalysis pending.
-    api("com.google.apis:google-api-services-admin-directory:directory_v1-rev105-1.25.0")
-    api("com.google.apis:google-api-services-cloudbuild:v1-rev836-1.25.0")
+    api("com.google.api-client:google-api-client:1.31.5") // TODO: Track update for CVE-2020-7692, reanalysis pending.
+    api("com.google.apis:google-api-services-admin-directory:directory_v1-rev20210531-1.31.5")
+    api("com.google.apis:google-api-services-cloudbuild:v1-rev20210625-1.31.5")
     api("com.google.apis:google-api-services-compute:beta-rev20210525-1.31.5")
-    api("com.google.apis:google-api-services-iam:v1-rev267-1.25.0")
-    api("com.google.apis:google-api-services-monitoring:v3-rev477-1.25.0")
-    api("com.google.apis:google-api-services-storage:v1-rev141-1.25.0")
+    api("com.google.apis:google-api-services-iam:v1-rev20210519-1.31.5")
+    api("com.google.apis:google-api-services-monitoring:v3-rev20210618-1.31.5") //v3-rev20210618-1.31.5
+    api("com.google.apis:google-api-services-storage:v1-rev20210127-1.31.5")
     api("com.google.cloud:google-cloud-secretmanager:2.3.10")
     api("com.google.code.findbugs:jsr305:3.0.2")
     api("com.google.guava:guava:33.0.0-jre")

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -95,10 +95,10 @@ dependencies {
       force = true
     }
     api("com.amazonaws:aws-java-sdk:${versions.aws}")
-    api("com.google.api-client:google-api-client:1.30.10") // TODO: Track update for CVE-2020-7692, reanalysis pending.
+    api("com.google.api-client:google-api-client:1.31.1") // TODO: Track update for CVE-2020-7692, reanalysis pending.
     api("com.google.apis:google-api-services-admin-directory:directory_v1-rev105-1.25.0")
     api("com.google.apis:google-api-services-cloudbuild:v1-rev836-1.25.0")
-    api("com.google.apis:google-api-services-compute:beta-rev20201102-1.30.10")
+    api("com.google.apis:google-api-services-compute:beta-rev20210525-1.31.5")
     api("com.google.apis:google-api-services-iam:v1-rev267-1.25.0")
     api("com.google.apis:google-api-services-monitoring:v3-rev477-1.25.0")
     api("com.google.apis:google-api-services-storage:v1-rev141-1.25.0")


### PR DESCRIPTION
Support `resourceManagerTags` in GCE. See: https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert

These changes upgrade the version of `google-api-services-compute` and `google-api-client`.


Issue related: https://github.com/spinnaker/spinnaker/issues/6931