### PR TITLE
fix(dependency): pin rest-assured-common to prevent old groovy version leak during upgrade of groovy 4.x

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -94,6 +94,9 @@ dependencies {
     api("io.rest-assured:rest-assured:${versions.restassured}") {
       force = true
     }
+    api("io.rest-assured:rest-assured-common:${versions.restassured}") {
+      force = true
+    }
     api("com.amazonaws:aws-java-sdk:${versions.aws}")
     api("com.google.api-client:google-api-client:1.30.10") // TODO: Track update for CVE-2020-7692, reanalysis pending.
     api("com.google.apis:google-api-services-admin-directory:directory_v1-rev105-1.25.0")


### PR DESCRIPTION
`rest-assured-commons` dependency is used by clouddriver-artifacts, clouddriver-aws, clouddriver-kubernetes and clouddriver-ecs modules. Since this dependency is not pinned in kork along with other rest-assured dependencies, it is leaking groovy [3.0.9](https://repo1.maven.org/maven2/io/rest-assured/rest-assured-common/4.5.1/rest-assured-common-4.5.1.pom).
```
$ ./gradlew clouddriver-kubernetes:dI --dependency codehaus.groovy:groovy --configuration integrationCompileClasspath

> Task :clouddriver-kubernetes:dependencyInsight
org.codehaus.groovy:groovy:3.0.19
  Variant compile:
    | Attribute Name                     | Provided | Requested         |
    |------------------------------------|----------|-------------------|
    | org.gradle.status                  | release  |                   |
    | org.gradle.category                | library  | library           |
    | org.gradle.libraryelements         | jar      | classes+resources |
    | org.gradle.usage                   | java-api | java-api          |
    | org.gradle.dependency.bundling     |          | external          |
    | org.gradle.jvm.environment         |          | standard-jvm      |
    | org.gradle.jvm.version             |          | 11                |
    | org.jetbrains.kotlin.platform.type |          | jvm               |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy:3.0.19
\--- io.spinnaker.kork:kork-bom:7.238.0
     +--- integrationCompileClasspath
     +--- project :clouddriver-artifacts
     |    \--- integrationCompileClasspath
     +--- project :clouddriver-core
     |    \--- integrationCompileClasspath
     +--- project :clouddriver-configserver
     |    \--- integrationCompileClasspath
     +--- project :cats:cats-core
     |    \--- integrationCompileClasspath
     +--- project :clouddriver-security
     |    \--- integrationCompileClasspath
     \--- project :clouddriver-web
          \--- integrationCompileClasspath

org.codehaus.groovy:groovy:3.0.9 -> 3.0.19
\--- io.rest-assured:rest-assured-common:4.5.1
     +--- io.spinnaker.kork:kork-bom:7.238.0
     |    +--- integrationCompileClasspath
     |    +--- project :clouddriver-artifacts
     |    |    \--- integrationCompileClasspath
     |    +--- project :clouddriver-core
     |    |    \--- integrationCompileClasspath
     |    +--- project :clouddriver-configserver
     |    |    \--- integrationCompileClasspath
     |    +--- project :cats:cats-core
     |    |    \--- integrationCompileClasspath
     |    +--- project :clouddriver-security
     |    |    \--- integrationCompileClasspath
     |    \--- project :clouddriver-web
     |         \--- integrationCompileClasspath
     +--- io.rest-assured:xml-path:5.2.1 (requested io.rest-assured:rest-assured-common:5.2.1)
     |    +--- io.spinnaker.kork:kork-bom:7.238.0 (*)
     |    \--- io.rest-assured:rest-assured:5.2.1
     |         +--- integrationCompileClasspath (requested io.rest-assured:rest-assured)
     |         \--- io.spinnaker.kork:kork-bom:7.238.0 (*)
     \--- io.rest-assured:json-path:5.2.1 (requested io.rest-assured:rest-assured-common:5.2.1)
          +--- io.spinnaker.kork:kork-bom:7.238.0 (*)
          \--- io.rest-assured:rest-assured:5.2.1 (*)

```

To fix this issue pinned rest-assured-commons to 5.2.1. After pinning, dependency insight is :
```
$ ./gradlew clouddriver-kubernetes:dI --dependency codehaus.groovy:groovy --configuration integrationCompileClasspath

> Task :clouddriver-kubernetes:dependencyInsight
No dependencies matching given input were found in configuration ':clouddriver-kubernetes:integrationCompileClasspath'
```