### PR TITLE
fix(artifactStore): Make applicationsRegex pattern matching case-insensitive

### DIFF
--- a/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorer.java
+++ b/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorer.java
@@ -59,7 +59,9 @@ public class S3ArtifactStoreStorer implements ArtifactStoreStorer {
     this.bucket = bucket;
     this.uriBuilder = uriBuilder;
     this.applicationsPattern =
-        (applicationsRegex != null) ? Pattern.compile(applicationsRegex) : null;
+        (applicationsRegex != null)
+            ? Pattern.compile(applicationsRegex, Pattern.CASE_INSENSITIVE)
+            : null;
   }
 
   /**

--- a/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorerTest.java
+++ b/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorerTest.java
@@ -99,6 +99,8 @@ public class S3ArtifactStoreStorerTest {
         Arguments.of("any", null, true),
         Arguments.of("app-one", allowRegex, true),
         Arguments.of("app-four", allowRegex, false),
+        Arguments.of("APP-One", allowRegex, true),
+        Arguments.of("APP-FOUR", allowRegex, false),
         Arguments.of("one", allowRegex, false),
         Arguments.of("app-one-more", allowRegex, false),
         Arguments.of("app-five", allowRegex, true),


### PR DESCRIPTION
Front50 applications in many situations (especially when created via templates or pipeline as code automation) have a mix of Upper/Lower case names.  Deck is always presenting the application names in lower-case so the end-user needs to query front50 directly to find out how the application name is actually stored.  

This PR is making the pattern matching for the artifactStore enabling per application as case-insensitive to avoid a situation when the user expects the artifact-store to be enabled in an application and finds out it is stored in different case in front50. 