### PR TITLE
chore(dependency): replace javax.inject with jakarta.inject and javax with jakarta

### DIFF
--- a/kork-eureka/kork-eureka.gradle
+++ b/kork-eureka/kork-eureka.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation project(":kork-core")
   implementation project(":kork-exceptions")
 
-  implementation "javax.inject:javax.inject:1"
+  implementation "jakarta.inject:jakarta.inject-api:1.0"
   implementation "org.springframework.boot:spring-boot-autoconfigure"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
 

--- a/kork-plugins/kork-plugins.gradle
+++ b/kork-plugins/kork-plugins.gradle
@@ -28,7 +28,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation("com.google.guava:guava")
-  implementation "javax.inject:javax.inject:1"
+  implementation "jakarta.inject:jakarta.inject-api:1.0"
 
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-properties")

--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -28,7 +28,7 @@ dependencies {
   api "com.squareup.retrofit:retrofit"
 
   implementation "com.google.guava:guava"
-  implementation "javax.inject:javax.inject:1"
+  implementation "jakarta.inject:jakarta.inject-api:1.0"
   implementation("com.netflix.spectator:spectator-web-spring") {
     // exclude transitives since this brings in a newer version of spring (boot)
     // dependencies than we're compatible with (2.2.x for spring boot and 5.2.x


### PR DESCRIPTION
Replacing `javax.inject` with `jakarta.inject`, as moving forward the new coordinates will house the feature development and upgrades. So, updating the coordinates in kork-eureka, kork-plugins and kork-web modules. 
https://github.com/google/guice/issues/1463
https://github.com/google/guice/issues/1383
https://docs.openrewrite.org/recipes/java/migrate/jakarta/javaxinjectmigrationtojakartainject