### PR TITLE
feat(retrofit2): Improvise OkHttpClientProvider to accept interceptors

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactory.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactory.java
@@ -27,6 +27,8 @@ import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.client.ServiceClientFactory;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
+import java.util.List;
+import okhttp3.Interceptor;
 import retrofit.Endpoint;
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
@@ -61,5 +63,17 @@ class RetrofitServiceFactory implements ServiceClientFactory {
         .setLog(new Slf4jRetrofitLogger(type))
         .build()
         .create(type);
+  }
+
+  @Override
+  public <T> T create(
+      Class<T> type,
+      ServiceEndpoint serviceEndpoint,
+      ObjectMapper objectMapper,
+      List<Interceptor> interceptors) {
+    throw new IllegalArgumentException(
+        String.format(
+            "Retrofit1 client doesn't support okhttp3 Interceptors. Failed to build %s ",
+            type.getName()));
   }
 }

--- a/kork-retrofit2/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactory.java
+++ b/kork-retrofit2/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactory.java
@@ -22,8 +22,10 @@ import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.client.ServiceClientFactory;
+import java.util.List;
 import java.util.Objects;
 import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import retrofit2.Call;
 import retrofit2.Retrofit;
@@ -40,7 +42,16 @@ public class Retrofit2ServiceFactory implements ServiceClientFactory {
 
   @Override
   public <T> T create(Class<T> type, ServiceEndpoint serviceEndpoint, ObjectMapper objectMapper) {
-    OkHttpClient okHttpClient = clientProvider.getClient(serviceEndpoint);
+    return create(type, serviceEndpoint, objectMapper, List.of());
+  }
+
+  @Override
+  public <T> T create(
+      Class<T> type,
+      ServiceEndpoint serviceEndpoint,
+      ObjectMapper objectMapper,
+      List<Interceptor> interceptors) {
+    OkHttpClient okHttpClient = clientProvider.getClient(serviceEndpoint, interceptors);
 
     return new Retrofit.Builder()
         .baseUrl(Objects.requireNonNull(HttpUrl.parse(serviceEndpoint.getBaseUrl())))

--- a/kork-web/src/main/java/com/netflix/spinnaker/config/DefaultServiceClientProvider.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/config/DefaultServiceClientProvider.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.kork.client.ServiceClientFactory;
 import com.netflix.spinnaker.kork.client.ServiceClientProvider;
 import com.netflix.spinnaker.kork.exceptions.SystemException;
 import java.util.List;
+import okhttp3.Interceptor;
 import org.springframework.stereotype.Component;
 
 /** Provider that returns a suitable service client capable of making http calls. */
@@ -52,6 +53,16 @@ public class DefaultServiceClientProvider implements ServiceClientProvider {
       Class<T> type, ServiceEndpoint serviceEndpoint, ObjectMapper objectMapper) {
     ServiceClientFactory serviceClientFactory = findProvider(type, serviceEndpoint);
     return serviceClientFactory.create(type, serviceEndpoint, objectMapper);
+  }
+
+  @Override
+  public <T> T getService(
+      Class<T> type,
+      ServiceEndpoint serviceEndpoint,
+      ObjectMapper objectMapper,
+      List<Interceptor> interceptors) {
+    ServiceClientFactory serviceClientFactory = findProvider(type, serviceEndpoint);
+    return serviceClientFactory.create(type, serviceEndpoint, objectMapper, interceptors);
   }
 
   private ServiceClientFactory findProvider(Class<?> type, ServiceEndpoint service) {

--- a/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProvider.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProvider.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.kork.exceptions.SystemException;
 import java.util.List;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import org.springframework.stereotype.Component;
 
@@ -41,8 +42,13 @@ public class OkHttpClientProvider {
    * @return okHttpClient
    */
   public OkHttpClient getClient(ServiceEndpoint service) {
-    OkHttpClientBuilderProvider provider = findProvider(service);
-    return provider.get(service).build();
+    return getClient(service, List.of());
+  }
+
+  public OkHttpClient getClient(ServiceEndpoint service, List<Interceptor> interceptors) {
+    OkHttpClient.Builder builder = findProvider(service).get(service);
+    interceptors.forEach(builder::addInterceptor);
+    return builder.build();
   }
 
   private OkHttpClientBuilderProvider findProvider(ServiceEndpoint service) {

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientFactory.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientFactory.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.kork.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.config.ServiceEndpoint;
+import java.util.List;
+import okhttp3.Interceptor;
 
 /** Factory to build a client for a service. */
 public interface ServiceClientFactory {
@@ -29,10 +31,26 @@ public interface ServiceClientFactory {
    * @param type client type
    * @param serviceEndpoint endpoint configuration
    * @param objectMapper mapper
-   * @param <T> type of client , usually a interface with all the remote method definitions.
-   * @return a implementation of the type of client given.
+   * @param <T> type of client , usually an interface with all the remote method definitions.
+   * @return an implementation of the type of client given.
    */
   public <T> T create(Class<T> type, ServiceEndpoint serviceEndpoint, ObjectMapper objectMapper);
+
+  /**
+   * Builds a concrete client capable of making HTTP calls.
+   *
+   * @param type client type
+   * @param serviceEndpoint endpoint configuration
+   * @param objectMapper mapper
+   * @param interceptors list of interceptors
+   * @param <T> type of client , usually an interface with all the remote method definitions.
+   * @return an implementation of the type of client given.
+   */
+  public <T> T create(
+      Class<T> type,
+      ServiceEndpoint serviceEndpoint,
+      ObjectMapper objectMapper,
+      List<Interceptor> interceptors);
 
   /**
    * Decide if this factory can support the endpoint provided.

--- a/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientProvider.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientProvider.java
@@ -20,6 +20,8 @@ package com.netflix.spinnaker.kork.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.List;
+import okhttp3.Interceptor;
 
 @NonnullByDefault
 public interface ServiceClientProvider {
@@ -29,7 +31,7 @@ public interface ServiceClientProvider {
    *
    * @param type retrofit interface type
    * @param serviceEndpoint endpoint definition
-   * @param <T> type of client , usually a interface with all the remote method definitions.
+   * @param <T> type of client , usually an interface with all the remote method definitions.
    * @return the retrofit interface implementation
    */
   public <T> T getService(Class<T> type, ServiceEndpoint serviceEndpoint);
@@ -40,9 +42,25 @@ public interface ServiceClientProvider {
    * @param type retrofit interface type
    * @param serviceEndpoint endpoint definition
    * @param objectMapper object mapper for conversion
-   * @param <T> type of client , usually a interface with all the remote method definitions.
+   * @param <T> type of client , usually an interface with all the remote method definitions.
    * @return the retrofit interface implementation
    */
   public <T> T getService(
       Class<T> type, ServiceEndpoint serviceEndpoint, ObjectMapper objectMapper);
+
+  /**
+   * Returns the concrete retrofit service client
+   *
+   * @param type retrofit interface type
+   * @param serviceEndpoint endpoint definition
+   * @param objectMapper object mapper for conversion
+   * @param interceptors list of interceptors
+   * @param <T> type of client , usually an interface with all the remote method definitions.
+   * @return the retrofit interface implementation
+   */
+  public <T> T getService(
+      Class<T> type,
+      ServiceEndpoint serviceEndpoint,
+      ObjectMapper objectMapper,
+      List<Interceptor> interceptors);
 }

--- a/kork-web/src/test/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProviderTest.java
+++ b/kork-web/src/test/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProviderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config.okhttp3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.config.ServiceEndpoint;
+import com.netflix.spinnaker.kork.exceptions.SystemException;
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import java.util.List;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = {OkHttpClient.class, OkHttpClientConfigurationProperties.class})
+public class OkHttpClientProviderTest {
+
+  @Mock private DefaultOkHttpClientBuilderProvider defaultProvider;
+
+  @Mock private ServiceEndpoint service;
+
+  private OkHttpClient.Builder builder;
+
+  @Mock private Interceptor interceptor;
+
+  @Mock private Interceptor interceptor2;
+
+  private OkHttpClientProvider clientProvider;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    builder = new OkHttpClient.Builder();
+    clientProvider = new OkHttpClientProvider(List.of(defaultProvider));
+  }
+
+  @Test
+  void getClient_withInterceptors_shouldAddInterceptors() {
+    when(defaultProvider.supports(service)).thenReturn(true);
+    when(defaultProvider.get(service)).thenReturn(builder);
+
+    OkHttpClient result = clientProvider.getClient(service, List.of(interceptor, interceptor2));
+
+    assertEquals(result.interceptors().size(), 2);
+    assertEquals(result.interceptors().get(0), interceptor);
+    assertEquals(result.interceptors().get(1), interceptor2);
+  }
+
+  @Test
+  void getClient_noProviderFound_shouldThrowException() {
+    when(defaultProvider.supports(service)).thenReturn(false);
+    when(service.getBaseUrl()).thenReturn("http://example.com");
+
+    SystemException exception =
+        assertThrows(
+            SystemException.class,
+            () -> clientProvider.getClient(service),
+            "Expected an exception if no provider supports the service");
+    assertEquals(
+        "No client provider found for url (http://example.com)",
+        exception.getMessage(),
+        "The exception message should indicate no provider was found.");
+  }
+}


### PR DESCRIPTION
As an alternate to using `OkHttp3ClientConfiguration` for creating an OkHttpClient, `OkHttpClientProvider` was created through
https://github.com/spinnaker/kork/pull/639. But there are many existing retrofit clients that are passing Interceptor(s) which is not supported by `OkHttpClientProvider`.  This PR allows `OkHttpClientProvider` to accept `okhttp3.Interceptor` list. 

As we are slowly moving to retrofit2(rosco completed, [echo](https://github.com/spinnaker/echo/pull/1466) under review), the real consumer of OkHttpClientProvider will be `Retrofit2ServiceFactory`(as opposed to `RetrofitServiceFactory`) but since it's an implementation of `ServiceClientFactory`,  I had to add a method that takes `List<Interceptor>` which is specific to `Retrofit2ServiceFactory` and hence the method has no significance wrt `RetrofitServiceFactory`.

The idea is to use `OkHttpClientProvider` instead of `OkHttp3ClientConfiguration` while upgrading the http clients from retrofit1 to retrofit2.