### PR TITLE
feat(retrofit2): add a method that returns Response object when retrofit2 client invokes an api

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2SyncCall.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2SyncCall.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.kork.retrofit;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerNetworkException;
 import java.io.IOException;
 import retrofit2.Call;
+import retrofit2.Response;
 
 public class Retrofit2SyncCall<T> {
 
@@ -30,8 +31,20 @@ public class Retrofit2SyncCall<T> {
    * @param <T> Successful response body type.
    */
   public static <T> T execute(Call<T> call) {
+    return executeCall(call).body();
+  }
+
+  /**
+   * Handle IOExceptions from {@link Call}.execute method centrally, instead of all places that make
+   * retrofit2 API calls.
+   *
+   * @throws SpinnakerNetworkException if IOException occurs.
+   * @param call call to be executed
+   * @return Response<T> response after execution
+   */
+  public static <T> Response<T> executeCall(Call<T> call) {
     try {
-      return call.execute().body();
+      return call.execute();
     } catch (IOException e) {
       throw new SpinnakerNetworkException(e, call.request());
     }

--- a/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
+++ b/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
@@ -50,6 +50,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import retrofit2.Call;
+import retrofit2.Response;
 import retrofit2.http.GET;
 
 @SpringBootTest(
@@ -98,6 +99,25 @@ public class Retrofit2ServiceFactoryTest {
     Map<String, String> response = Retrofit2SyncCall.execute(retrofit2TestService.getSomething());
 
     assertEquals(response.get("message"), "success");
+  }
+
+  @Test
+  void testRetrofit2ClientWithResponse() {
+    stubFor(
+        get(urlEqualTo("/test"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"message\": \"success\", \"code\": 200}")));
+
+    ServiceEndpoint serviceEndpoint =
+        new DefaultServiceEndpoint("retrofit2service", "http://localhost:" + port);
+    Retrofit2TestService retrofit2TestService =
+        serviceClientProvider.getService(Retrofit2TestService.class, serviceEndpoint);
+    Response<Map<String, String>> response =
+        Retrofit2SyncCall.executeCall(retrofit2TestService.getSomething());
+
+    assertEquals(response.body().get("message"), "success");
   }
 
   @Test


### PR DESCRIPTION
Existing method `Retrofit2SyncCall.execute()` returns response body when an api is invoked by a retrofit2 client and hence there is no way to capture headers when needed. So added a new method that returns `retrofit2.Response` object through which headers can be accessed. 