### PR TITLE
fix(build): fix a build error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       # Given a tag, determine what branch we are on, so we can bump dependencies in the correct branch
       - name: Get Branch
         run: |
-          BRANCHES=$(git branch -r --contains ${{ github.ref }})
+          BRANCHES=$(git branch -r --contains ${{ github.ref }} | grep -v 'HEAD')
           echo "BRANCHES is '${BRANCHES}'"
           # Check for no branches explicitly...Otherwise echo adds a newline so wc thinks there's
           # one branch.  And echo -n makes it appears that there's one less branch than there


### PR DESCRIPTION
The default HEAD reference is included in the remote branch list when `git branch -r --contains refs/tags/v7.249.0` is run. 
Refer: https://github.com/spinnaker/kork/actions/runs/12996151157/job/36284220771.

```
Run BRANCHES=$(git branch -r --contains refs/tags/v7.249.0) 
BRANCHES is '  origin/HEAD -> origin/master
  origin/master'
NUM_BRANCHES is '2'
exactly one branch required to release kork, but there are 2 (  origin/HEAD -> origin/master
  origin/master)
Error: Process completed with exit code 1.
```

