### PR TITLE
feat(retrofit2): add ErrorHandlingExecutorCallAdapterFactory to the retrofit2 client

### DIFF
--- a/kork-retrofit2/kork-retrofit2.gradle
+++ b/kork-retrofit2/kork-retrofit2.gradle
@@ -4,12 +4,12 @@ apply from: "$rootDir/gradle/kotlin-test.gradle"
 dependencies {
   api(platform(project(":spinnaker-dependencies")))
   implementation project(":kork-web")
+  implementation project(":kork-retrofit")
   implementation "com.squareup.retrofit2:retrofit"
   implementation "com.squareup.retrofit2:converter-jackson"
   implementation "com.squareup.okhttp3:logging-interceptor"
   implementation "io.zipkin.brave:brave-instrumentation-okhttp3"
 
-  testImplementation project(":kork-retrofit")
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"

--- a/kork-retrofit2/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactory.java
+++ b/kork-retrofit2/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactory.java
@@ -57,6 +57,7 @@ public class Retrofit2ServiceFactory implements ServiceClientFactory {
         .baseUrl(Objects.requireNonNull(HttpUrl.parse(serviceEndpoint.getBaseUrl())))
         .client(okHttpClient)
         .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+        .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
         .build()
         .create(type);
   }

--- a/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
+++ b/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
@@ -24,6 +24,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -36,6 +37,9 @@ import com.netflix.spinnaker.config.okhttp3.DefaultOkHttpClientBuilderProvider;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.kork.client.ServiceClientFactory;
 import com.netflix.spinnaker.kork.client.ServiceClientProvider;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerConversionException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import java.util.List;
 import java.util.Map;
@@ -148,6 +152,54 @@ public class Retrofit2ServiceFactoryTest {
     verify(
         getRequestedFor(urlEqualTo("/test"))
             .withHeader("Authorization", equalTo("Bearer my-token")));
+  }
+
+  @Test
+  void testRetrofit2Client_withHttpException() {
+    stubFor(
+        get(urlEqualTo("/test"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withStatus(400)
+                    .withBody("{\"message\": \"error\"}")));
+
+    ServiceEndpoint serviceEndpoint =
+        new DefaultServiceEndpoint("retrofit2service", "http://localhost:" + port);
+
+    Retrofit2TestService retrofit2TestService =
+        serviceClientProvider.getService(Retrofit2TestService.class, serviceEndpoint);
+
+    SpinnakerHttpException exception =
+        assertThrows(
+            SpinnakerHttpException.class,
+            () -> Retrofit2SyncCall.executeCall(retrofit2TestService.getSomething()));
+    assertEquals(exception.getResponseCode(), 400);
+    assertEquals(
+        exception.getMessage(),
+        "Status: 400, Method: GET, URL: http://localhost:" + port + "/test, Message: error");
+  }
+
+  @Test
+  void testRetrofit2Client_withConversionException() {
+    stubFor(
+        get(urlEqualTo("/test"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"message\": \"incorrect json}")));
+
+    ServiceEndpoint serviceEndpoint =
+        new DefaultServiceEndpoint("retrofit2service", "http://localhost:" + port);
+
+    Retrofit2TestService retrofit2TestService =
+        serviceClientProvider.getService(Retrofit2TestService.class, serviceEndpoint);
+
+    SpinnakerServerException exception =
+        assertThrows(
+            SpinnakerConversionException.class,
+            () -> Retrofit2SyncCall.executeCall(retrofit2TestService.getSomething()));
+    assertEquals(exception.getMessage(), "Failed to process response body");
   }
 
   @Configuration

--- a/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
+++ b/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
@@ -112,7 +112,7 @@ public class Retrofit2ServiceFactoryTest {
             .willReturn(
                 aResponse()
                     .withHeader("Content-Type", "application/json")
-                    .withBody("{\"message\": \"success\", \"code\": 200}")));
+                    .withBody("{\"message\": \"success\"}")));
 
     ServiceEndpoint serviceEndpoint =
         new DefaultServiceEndpoint("retrofit2service", "http://localhost:" + port);
@@ -120,7 +120,8 @@ public class Retrofit2ServiceFactoryTest {
         serviceClientProvider.getService(Retrofit2TestService.class, serviceEndpoint);
     Response<Map<String, String>> response =
         Retrofit2SyncCall.executeCall(retrofit2TestService.getSomething());
-
+    assertEquals(response.code(), 200);
+    assertEquals(response.headers().get("Content-Type"), "application/json");
     assertEquals(response.body().get("message"), "success");
   }
 


### PR DESCRIPTION
- Retrofit2 client defined in Retrofit2ServiceFactory doesn't have CallAdapterFactory set. 
- This PR sets `ErrorHandlingExecutorCallAdapterFactory` to the retrofit2 client which is responsible for classifying the exceptions into `SpinnakerHttpException`, `SpinnakerNetworkException` or `SpinnakerServerException`. 