### PR TITLE
refactor(retrofit2): add more details to the SpinnakerConversionException's message

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/ErrorHandlingExecutorCallAdapterFactory.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/ErrorHandlingExecutorCallAdapterFactory.java
@@ -153,7 +153,7 @@ public class ErrorHandlingExecutorCallAdapterFactory extends CallAdapter.Factory
         }
       } catch (JsonProcessingException jpe) {
         throw new SpinnakerConversionException(
-            "Failed to process response body", jpe, delegate.request());
+            "Failed to process response body: " + jpe.getMessage(), jpe, delegate.request());
       } catch (IOException e) {
         throw new SpinnakerNetworkException(e, delegate.request());
       } catch (Exception e) {

--- a/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
+++ b/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
@@ -213,7 +213,10 @@ class SpinnakerRetrofit2ErrorHandleTest {
             () -> retrofit2Service.getRetrofit2().execute(), SpinnakerConversionException.class);
     assertThat(spinnakerConversionException.getRetryable()).isNotNull();
     assertThat(spinnakerConversionException.getRetryable()).isFalse();
-    assertThat(spinnakerConversionException).hasMessage("Failed to process response body");
+    assertThat(spinnakerConversionException)
+        .hasMessage(
+            "Failed to process response body: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)\n"
+                + " at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 1]");
     assertThat(spinnakerConversionException.getUrl())
         .isEqualTo(mockWebServer.url("/retrofit2").toString());
   }

--- a/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
+++ b/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
@@ -200,7 +200,10 @@ public class Retrofit2ServiceFactoryTest {
         assertThrows(
             SpinnakerConversionException.class,
             () -> Retrofit2SyncCall.executeCall(retrofit2TestService.getSomething()));
-    assertEquals("Failed to process response body", exception.getMessage());
+    assertEquals(
+        "Failed to process response body: Unexpected end-of-input: was expecting closing quote for a string value\n"
+            + " at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 29]",
+        exception.getMessage());
   }
 
   @Configuration

--- a/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
+++ b/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
@@ -102,7 +102,7 @@ public class Retrofit2ServiceFactoryTest {
         serviceClientProvider.getService(Retrofit2TestService.class, serviceEndpoint);
     Map<String, String> response = Retrofit2SyncCall.execute(retrofit2TestService.getSomething());
 
-    assertEquals(response.get("message"), "success");
+    assertEquals("success", response.get("message"));
   }
 
   @Test
@@ -120,9 +120,9 @@ public class Retrofit2ServiceFactoryTest {
         serviceClientProvider.getService(Retrofit2TestService.class, serviceEndpoint);
     Response<Map<String, String>> response =
         Retrofit2SyncCall.executeCall(retrofit2TestService.getSomething());
-    assertEquals(response.code(), 200);
-    assertEquals(response.headers().get("Content-Type"), "application/json");
-    assertEquals(response.body().get("message"), "success");
+    assertEquals(200, response.code());
+    assertEquals("application/json", response.headers().get("Content-Type"));
+    assertEquals("success", response.body().get("message"));
   }
 
   @Test
@@ -175,10 +175,10 @@ public class Retrofit2ServiceFactoryTest {
         assertThrows(
             SpinnakerHttpException.class,
             () -> Retrofit2SyncCall.executeCall(retrofit2TestService.getSomething()));
-    assertEquals(exception.getResponseCode(), 400);
+    assertEquals(400, exception.getResponseCode());
     assertEquals(
-        exception.getMessage(),
-        "Status: 400, Method: GET, URL: http://localhost:" + port + "/test, Message: error");
+        "Status: 400, Method: GET, URL: http://localhost:" + port + "/test, Message: error",
+        exception.getMessage());
   }
 
   @Test
@@ -200,7 +200,7 @@ public class Retrofit2ServiceFactoryTest {
         assertThrows(
             SpinnakerConversionException.class,
             () -> Retrofit2SyncCall.executeCall(retrofit2TestService.getSomething()));
-    assertEquals(exception.getMessage(), "Failed to process response body");
+    assertEquals("Failed to process response body", exception.getMessage());
   }
 
   @Configuration


### PR DESCRIPTION
At present the SpinnakerConversionException.getMessage() gives only the static text : `Failed to process response body`. With this PR, the message will have more details on the actual conversion error.

Ex: `Failed to process response body: Unrecognized token 'this': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')`