### PR TITLE
fix(retrofit2): fix retrofit2 partial encoding issue

### DIFF
--- a/kork-retrofit/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/RetrofitServiceProviderTest.kt
+++ b/kork-retrofit/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/RetrofitServiceProviderTest.kt
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.config.OkHttpClientComponents
 import com.netflix.spinnaker.kork.client.ServiceClientFactory
 import com.netflix.spinnaker.kork.client.ServiceClientProvider
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
+import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import okhttp3.OkHttpClient
@@ -97,7 +98,7 @@ private open class TestConfiguration {
 
   @Bean
   open fun okHttpClientProvider(okHttpClient: OkHttpClient): OkHttpClientProvider {
-    return OkHttpClientProvider(listOf(DefaultOkHttpClientBuilderProvider(okHttpClient, OkHttpClientConfigurationProperties())))
+    return OkHttpClientProvider(listOf(DefaultOkHttpClientBuilderProvider(okHttpClient, OkHttpClientConfigurationProperties())), Retrofit2EncodeCorrectionInterceptor())
   }
 
   @Bean

--- a/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
+++ b/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
@@ -41,6 +41,7 @@ import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerConversionExcepti
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
 import java.util.List;
 import java.util.Map;
 import okhttp3.Interceptor;
@@ -65,7 +66,8 @@ import retrofit2.http.GET;
       OkHttpClientProvider.class,
       Retrofit2ServiceFactoryAutoConfiguration.class,
       Retrofit2ServiceFactoryTest.Retrofit2TestConfig.class,
-      DefaultOkHttpClientBuilderProvider.class
+      DefaultOkHttpClientBuilderProvider.class,
+      Retrofit2EncodeCorrectionInterceptor.class
     })
 public class Retrofit2ServiceFactoryTest {
 

--- a/kork-retrofit2/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceProviderTest.kt
+++ b/kork-retrofit2/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceProviderTest.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.config.DefaultServiceClientProvider
 import com.netflix.spinnaker.kork.client.ServiceClientFactory
 import com.netflix.spinnaker.kork.client.ServiceClientProvider
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
+import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor
 import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -97,7 +98,7 @@ private open class TestConfiguration {
 
   @Bean
   open fun okHttpClientProvider(okHttpClient: OkHttpClient): OkHttpClientProvider {
-    return OkHttpClientProvider(listOf(DefaultOkHttpClientBuilderProvider(okHttpClient,  OkHttpClientConfigurationProperties())))
+    return OkHttpClientProvider(listOf(DefaultOkHttpClientBuilderProvider(okHttpClient,  OkHttpClientConfigurationProperties())), Retrofit2EncodeCorrectionInterceptor())
   }
 
   @Bean

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
@@ -61,6 +61,9 @@ class OkHttp3ClientConfiguration {
    */
   private final SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor
 
+  /**
+   * {@link okhttp3.Interceptor} for correcting partial encoding done by Retrofit2.
+   */
   private final Retrofit2EncodeCorrectionInterceptor retrofit2EncodeCorrectionInterceptor
 
   @Autowired

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.config
 
+import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor
 import com.netflix.spinnaker.okhttp.SpinnakerRequestHeaderInterceptor
 import okhttp3.Dispatcher
 import okhttp3.logging.HttpLoggingInterceptor
@@ -60,22 +61,26 @@ class OkHttp3ClientConfiguration {
    */
   private final SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor
 
+  private final Retrofit2EncodeCorrectionInterceptor retrofit2EncodeCorrectionInterceptor
+
   @Autowired
   OkHttp3ClientConfiguration(OkHttpClientConfigurationProperties okHttpClientConfigurationProperties,
                              OkHttp3MetricsInterceptor okHttp3MetricsInterceptor,
                              HttpLoggingInterceptor.Level retrofit2LogLevel,
                              SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor,
+                             Retrofit2EncodeCorrectionInterceptor retrofit2EncodeCorrectionInterceptor,
                              ObjectFactory<OkHttpClient.Builder> httpClientBuilderFactory) {
     this.okHttpClientConfigurationProperties = okHttpClientConfigurationProperties
     this.okHttp3MetricsInterceptor = okHttp3MetricsInterceptor
     this.retrofit2LogLevel = retrofit2LogLevel
     this.spinnakerRequestHeaderInterceptor = spinnakerRequestHeaderInterceptor
+    this.retrofit2EncodeCorrectionInterceptor = retrofit2EncodeCorrectionInterceptor
     this.httpClientBuilderFactory = httpClientBuilderFactory
   }
 
   public OkHttp3ClientConfiguration(OkHttpClientConfigurationProperties okHttpClientConfigurationProperties,
                                     OkHttp3MetricsInterceptor okHttp3MetricsInterceptor) {
-    this(okHttpClientConfigurationProperties, okHttp3MetricsInterceptor, null, null,
+    this(okHttpClientConfigurationProperties, okHttp3MetricsInterceptor, null, null, null,
       { new OkHttpClient.Builder() })
   }
 
@@ -96,6 +101,10 @@ class OkHttp3ClientConfiguration {
 
     if (okHttp3MetricsInterceptor != null) {
       okHttpClientBuilder.addInterceptor(okHttp3MetricsInterceptor)
+    }
+
+    if (retrofit2EncodeCorrectionInterceptor != null) {
+      okHttpClientBuilder.addInterceptor(retrofit2EncodeCorrectionInterceptor)
     }
 
     if (!okHttpClientConfigurationProperties.keyStore && !okHttpClientConfigurationProperties.trustStore) {
@@ -126,6 +135,10 @@ class OkHttp3ClientConfiguration {
 
     if (okHttp3MetricsInterceptor != null) {
       okHttpClientBuilder.addInterceptor(okHttp3MetricsInterceptor)
+    }
+
+    if (retrofit2EncodeCorrectionInterceptor != null) {
+      okHttpClientBuilder.addInterceptor(retrofit2EncodeCorrectionInterceptor)
     }
 
     /**

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
@@ -33,6 +33,7 @@ class OkHttpClientConfigurationProperties {
   int maxRequestsPerHost = 100
 
   boolean propagateSpinnakerHeaders = true
+  boolean skipRetrofit2EncodeCorrection = false
 
   File keyStore
   String keyStoreType = 'PKCS12'

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
@@ -33,6 +33,11 @@ class OkHttpClientConfigurationProperties {
   int maxRequestsPerHost = 100
 
   boolean propagateSpinnakerHeaders = true
+
+  /**
+   * Determines whether to skip the correction of partial encoding done by Retrofit2.
+   * Refer https://github.com/spinnaker/spinnaker/issues/7021 for more details
+   */
   boolean skipRetrofit2EncodeCorrection = false
 
   File keyStore

--- a/kork-web/src/main/java/com/netflix/spinnaker/config/OkHttpClientComponents.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/config/OkHttpClientComponents.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.kork.crypto.X509Identity;
 import com.netflix.spinnaker.kork.crypto.X509IdentitySource;
 import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor;
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestHeaderInterceptor;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor;
 import com.netflix.spinnaker.retrofit.Retrofit2ConfigurationProperties;
@@ -87,6 +88,12 @@ public class OkHttpClientComponents {
   @Bean
   public SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor() {
     return new SpinnakerRequestHeaderInterceptor(clientProperties.getPropagateSpinnakerHeaders());
+  }
+
+  @Bean
+  public Retrofit2EncodeCorrectionInterceptor retrofit2EncodeCorrectionInterceptor() {
+    return new Retrofit2EncodeCorrectionInterceptor(
+        clientProperties.getSkipRetrofit2EncodeCorrection());
   }
 
   @Bean

--- a/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProvider.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProvider.java
@@ -33,9 +33,11 @@ public class OkHttpClientProvider {
 
   private final Retrofit2EncodeCorrectionInterceptor retrofit2EncodeCorrectionInterceptor;
 
-  public OkHttpClientProvider(List<OkHttpClientBuilderProvider> providers) {
+  public OkHttpClientProvider(
+      List<OkHttpClientBuilderProvider> providers,
+      Retrofit2EncodeCorrectionInterceptor retrofit2EncodeCorrectionInterceptor) {
     this.providers = providers;
-    this.retrofit2EncodeCorrectionInterceptor = new Retrofit2EncodeCorrectionInterceptor();
+    this.retrofit2EncodeCorrectionInterceptor = retrofit2EncodeCorrectionInterceptor;
   }
 
   /**
@@ -54,7 +56,9 @@ public class OkHttpClientProvider {
   }
 
   public OkHttpClient getClient(ServiceEndpoint service, List<Interceptor> interceptors) {
-    return getClient(service, interceptors, false);
+    // retrofit2 does partial encoding causing issues in some cases, so the default behaviour is
+    // kept to correct it by passing false for the third argument
+    return getClient(service, interceptors, false /* skipEncodeCorrection */);
   }
 
   public OkHttpClient getClient(

--- a/kork-web/src/main/java/com/netflix/spinnaker/okhttp/Retrofit2EncodeCorrectionInterceptor.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/okhttp/Retrofit2EncodeCorrectionInterceptor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.okhttp;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class Retrofit2EncodeCorrectionInterceptor implements Interceptor {
+
+  private final boolean skipEncodingCorrection;
+
+  public Retrofit2EncodeCorrectionInterceptor() {
+    this.skipEncodingCorrection = false;
+  }
+
+  public Retrofit2EncodeCorrectionInterceptor(boolean skipEncodingCorrection) {
+    this.skipEncodingCorrection = skipEncodingCorrection;
+  }
+
+  @Override
+  public Response intercept(Interceptor.Chain chain) throws IOException {
+    if (skipEncodingCorrection) {
+      return chain.proceed(chain.request());
+    }
+
+    Request originalRequest = chain.request();
+    HttpUrl originalUrl = originalRequest.url();
+    HttpUrl.Builder newUrlBuilder = originalUrl.newBuilder();
+
+    // Decode and encode the path to correct the partial encoding done by retrofit2
+    for (int i = 0; i < originalUrl.pathSize(); i++) {
+      String retrofit2EncodedSegment = originalUrl.encodedPathSegments().get(i);
+      retrofit2EncodedSegment = processRetrofit2EncodedString(retrofit2EncodedSegment);
+      newUrlBuilder.setEncodedPathSegment(i, retrofit2EncodedSegment);
+    }
+
+    // Decode and encode the query parameters to correct the partial encoding done by retrofit2
+    for (String paramName : originalUrl.queryParameterNames()) {
+      String retrofit2EncodedParam = getEncodedQueryParam(originalUrl, paramName);
+      if (retrofit2EncodedParam != null) {
+        String encodedParam = processRetrofit2EncodedString(retrofit2EncodedParam);
+        newUrlBuilder.setEncodedQueryParameter(paramName, encodedParam);
+      }
+    }
+
+    Request newRequest = originalRequest.newBuilder().url(newUrlBuilder.build()).build();
+
+    return chain.proceed(newRequest);
+  }
+
+  /** Extracts the encoded value of a query parameter from the full encodedQuery string. */
+  private String getEncodedQueryParam(HttpUrl url, String paramName) {
+    String encodedQuery = url.encodedQuery();
+    if (encodedQuery == null) {
+      return null;
+    }
+
+    for (String pair : encodedQuery.split("&")) {
+      String[] parts = pair.split("=", 2);
+      if (parts.length == 2 && parts[0].equals(paramName)) {
+        return parts[1];
+      }
+    }
+    return null;
+  }
+
+  /** Decodes the retrofit2-encoded value and encodes it to the correct value. */
+  private String processRetrofit2EncodedString(String retrofit2EncodedString) {
+    String retrofit2EncodedVal =
+        retrofit2EncodedString
+            .replaceAll(
+                "%(?![0-9A-Fa-f]{2})",
+                "%25") // Replace % with %25, else URLDecoder.decode will fail
+            .replaceAll(
+                "\\+",
+                "%2B"); // this is needed to preserve +, else URLDecoder.decode will replace + with
+    // space
+    String decodedVal = URLDecoder.decode(retrofit2EncodedVal, StandardCharsets.UTF_8);
+    String encodedString = URLEncoder.encode(decodedVal, StandardCharsets.UTF_8);
+    return encodedString.replace("+", "%20"); // encoding replaces space with +
+  }
+}

--- a/kork-web/src/test/java/com/netflix/spinnaker/config/OkHttp3ClientConfigurationTest.java
+++ b/kork-web/src/test/java/com/netflix/spinnaker/config/OkHttp3ClientConfigurationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor;
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
+import com.netflix.spinnaker.okhttp.SpinnakerRequestHeaderInterceptor;
+import okhttp3.logging.HttpLoggingInterceptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.boot.task.TaskExecutorBuilder;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.configuration.ObjectPostProcessorConfiguration;
+
+public class OkHttp3ClientConfigurationTest {
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner()
+          .withBean(ObjectMapper.class)
+          .withBean(TaskExecutorBuilder.class)
+          .withBean(AuthenticationManagerBuilder.class)
+          .withUserConfiguration(OkHttp3ClientConfigurationTestConfig.class);
+
+  @BeforeEach
+  void init(TestInfo testInfo) {
+    System.out.println("--------------- Test " + testInfo.getDisplayName());
+  }
+
+  @Test
+  void verifyValidConfiguration() {
+    runner.run(
+        ctx -> {
+          assertThat(ctx).hasSingleBean(OkHttpClientConfigurationProperties.class);
+          assertThat(ctx).hasSingleBean(HttpLoggingInterceptor.Level.class);
+          assertThat(ctx).hasSingleBean(SpinnakerRequestHeaderInterceptor.class);
+          assertThat(ctx).hasSingleBean(Retrofit2EncodeCorrectionInterceptor.class);
+          assertThat(ctx).hasSingleBean(OkHttp3MetricsInterceptor.class);
+        });
+  }
+
+  @Configuration
+  @ComponentScan(basePackageClasses = OkHttp3ClientConfiguration.class)
+  static class OkHttp3ClientConfigurationTestConfig {
+
+    @Bean
+    public ObjectPostProcessor<Object> objectPostProcessor(AutowireCapableBeanFactory beanFactory) {
+      return new ObjectPostProcessorConfiguration().objectPostProcessor(beanFactory);
+    }
+
+    @Bean
+    public AuthenticationConfiguration authenticationConfiguration() {
+      return new AuthenticationConfiguration();
+    }
+  }
+}

--- a/kork-web/src/test/java/com/netflix/spinnaker/config/OkHttp3ClientConfigurationTest.java
+++ b/kork-web/src/test/java/com/netflix/spinnaker/config/OkHttp3ClientConfigurationTest.java
@@ -34,7 +34,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.configuration.ObjectPostProcessorConfiguration;
 
@@ -43,7 +42,6 @@ public class OkHttp3ClientConfigurationTest {
       new ApplicationContextRunner()
           .withBean(ObjectMapper.class)
           .withBean(TaskExecutorBuilder.class)
-          .withBean(AuthenticationManagerBuilder.class)
           .withUserConfiguration(OkHttp3ClientConfigurationTestConfig.class);
 
   @BeforeEach

--- a/kork-web/src/test/java/com/netflix/spinnaker/config/OkHttpClientComponentsTest.java
+++ b/kork-web/src/test/java/com/netflix/spinnaker/config/OkHttpClientComponentsTest.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor;
+import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestHeaderInterceptor;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +47,7 @@ class OkHttpClientComponentsTest {
         ctx -> {
           assertThat(ctx).hasSingleBean(SpinnakerRequestInterceptor.class);
           assertThat(ctx).hasSingleBean(SpinnakerRequestHeaderInterceptor.class);
+          assertThat(ctx).hasSingleBean(Retrofit2EncodeCorrectionInterceptor.class);
           assertThat(ctx).hasSingleBean(OkHttp3MetricsInterceptor.class);
         });
   }

--- a/kork-web/src/test/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProviderTest.java
+++ b/kork-web/src/test/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProviderTest.java
@@ -29,10 +29,12 @@ import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@ExtendWith(MockitoExtension.class)
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.NONE,
     classes = {OkHttpClient.class, OkHttpClientConfigurationProperties.class})
@@ -52,7 +54,6 @@ public class OkHttpClientProviderTest {
 
   @BeforeEach
   void setUp() {
-    MockitoAnnotations.openMocks(this);
     builder = new OkHttpClient.Builder();
     clientProvider =
         new OkHttpClientProvider(

--- a/kork-web/src/test/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProviderTest.java
+++ b/kork-web/src/test/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProviderTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.kork.exceptions.SystemException;
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
 import java.util.List;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -53,7 +54,9 @@ public class OkHttpClientProviderTest {
   void setUp() {
     MockitoAnnotations.openMocks(this);
     builder = new OkHttpClient.Builder();
-    clientProvider = new OkHttpClientProvider(List.of(defaultProvider));
+    clientProvider =
+        new OkHttpClientProvider(
+            List.of(defaultProvider), new Retrofit2EncodeCorrectionInterceptor());
   }
 
   @Test
@@ -62,7 +65,8 @@ public class OkHttpClientProviderTest {
     when(defaultProvider.get(service)).thenReturn(builder);
 
     OkHttpClient result =
-        clientProvider.getClient(service, List.of(interceptor, interceptor2), true);
+        clientProvider.getClient(
+            service, List.of(interceptor, interceptor2), true /* skipEncodeCorrection */);
 
     assertEquals(result.interceptors().size(), 2);
     assertEquals(result.interceptors().get(0), interceptor);

--- a/kork-web/src/test/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProviderTest.java
+++ b/kork-web/src/test/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProviderTest.java
@@ -61,7 +61,8 @@ public class OkHttpClientProviderTest {
     when(defaultProvider.supports(service)).thenReturn(true);
     when(defaultProvider.get(service)).thenReturn(builder);
 
-    OkHttpClient result = clientProvider.getClient(service, List.of(interceptor, interceptor2));
+    OkHttpClient result =
+        clientProvider.getClient(service, List.of(interceptor, interceptor2), true);
 
     assertEquals(result.interceptors().size(), 2);
     assertEquals(result.interceptors().get(0), interceptor);

--- a/kork-web/src/test/java/com/netflix/spinnaker/okhttp/Retrofit2EncodeCorrectionInterceptorTest.java
+++ b/kork-web/src/test/java/com/netflix/spinnaker/okhttp/Retrofit2EncodeCorrectionInterceptorTest.java
@@ -21,8 +21,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.netflix.spinnaker.config.DefaultServiceEndpoint;
 import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.DefaultOkHttpClientBuilderProvider;
@@ -31,7 +33,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import okhttp3.OkHttpClient;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,24 +50,33 @@ import retrofit2.http.Query;
       OkHttpClient.class,
       OkHttpClientConfigurationProperties.class,
       OkHttpClientProvider.class,
-      DefaultOkHttpClientBuilderProvider.class
+      DefaultOkHttpClientBuilderProvider.class,
+      Retrofit2EncodeCorrectionInterceptor.class
     })
 public class Retrofit2EncodeCorrectionInterceptorTest {
 
+  // to test if a path parameter value containing various special characters is handled correctly
+  // with Retrofit2
   private static final String PATH_VAL = "path: [] () = % $ & # @ ; , ? \" ' end path";
   private static final String ENCODED_PATH_VAL = encodedString(PATH_VAL);
+
+  // to test if a query parameter value containing various special characters is handled correctly
+  // with Retrofit2
   private static final String QUERY_PARAM1 = "qry1: [] () + = % $ & # @ ; , ? \" ' /end qry1";
   private static final String ENCODED_QUERY_PARAM1 = encodedString(QUERY_PARAM1);
+
   private static final String QUERY_PARAM2 = "qry2: [] () + = % $ & # @ ; , ? \" ' end qry2";
   private static final String ENCODED_QUERY_PARAM2 = encodedString(QUERY_PARAM2);
+  private static final String QUERY_PARAM3 = "";
   private static final String EXPECTED_URL =
       "/test/"
           + ENCODED_PATH_VAL
           + "/get?qry1="
           + ENCODED_QUERY_PARAM1
           + "&qry2="
-          + ENCODED_QUERY_PARAM2;
-  private ServiceEndpoint endpoint;
+          + ENCODED_QUERY_PARAM2
+          + "&qry3=";
+  private static ServiceEndpoint endpoint;
 
   @RegisterExtension
   static WireMockExtension wireMock =
@@ -73,26 +84,37 @@ public class Retrofit2EncodeCorrectionInterceptorTest {
 
   @Autowired OkHttpClientProvider okHttpClientProvider;
 
-  @BeforeEach
-  public void setup() {
+  @BeforeAll
+  public static void setup() {
     wireMock.stubFor(get(EXPECTED_URL).willReturn(ok()));
     endpoint = new DefaultServiceEndpoint("test", wireMock.baseUrl());
   }
 
   @Test
   public void testWithoutEncodingCorrection() throws IOException {
-    OkHttpClient okHttpClient = okHttpClientProvider.getClient(endpoint, true);
+    OkHttpClient okHttpClient =
+        okHttpClientProvider.getClient(endpoint, true /* skipEncodeCorrection */);
     Retrofit2Service service = getRetrofit2Service(endpoint.getBaseUrl(), okHttpClient);
-    service.getRequest(PATH_VAL, QUERY_PARAM1, QUERY_PARAM2).execute();
+    service.getRequest(PATH_VAL, QUERY_PARAM1, QUERY_PARAM2, QUERY_PARAM3).execute();
+    LoggedRequest requestReceived = wireMock.getAllServeEvents().get(0).getRequest();
+    // note the partial encoding done by Retrofit2
+    assertThat(getPathFromUrl(requestReceived.getUrl()))
+        .isEqualTo(
+            "/test/path:%20[]%20()%20=%20%25%20$%20&%20%23%20@%20;%20,%20%3F%20%22%20'%20end%20path/get");
     wireMock.verify(0, getRequestedFor(urlEqualTo(EXPECTED_URL)));
   }
 
   @Test
   public void testWithEncodingCorrection() throws IOException {
-    OkHttpClient okHttpClient = okHttpClientProvider.getClient(endpoint, false);
+    OkHttpClient okHttpClient =
+        okHttpClientProvider.getClient(endpoint, false /* skipEncodeCorrection */);
     Retrofit2Service service = getRetrofit2Service(endpoint.getBaseUrl(), okHttpClient);
-    service.getRequest(PATH_VAL, QUERY_PARAM1, QUERY_PARAM2).execute();
+    service.getRequest(PATH_VAL, QUERY_PARAM1, QUERY_PARAM2, QUERY_PARAM3).execute();
     wireMock.verify(getRequestedFor(urlEqualTo(EXPECTED_URL)));
+    LoggedRequest requestReceived = wireMock.getAllServeEvents().get(0).getRequest();
+    assertThat(requestReceived.queryParameter("qry1").firstValue()).isEqualTo(QUERY_PARAM1);
+    assertThat(requestReceived.queryParameter("qry2").firstValue()).isEqualTo(QUERY_PARAM2);
+    assertThat(requestReceived.queryParameter("qry3").firstValue()).isEqualTo("");
   }
 
   private Retrofit2Service getRetrofit2Service(String baseUrl, OkHttpClient okHttpClient) {
@@ -108,9 +130,16 @@ public class Retrofit2EncodeCorrectionInterceptorTest {
     return URLEncoder.encode(input, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
   }
 
+  private static String getPathFromUrl(String url) {
+    return url.substring(0, url.indexOf('?'));
+  }
+
   interface Retrofit2Service {
     @GET("test/{path}/get")
     Call<Void> getRequest(
-        @Path("path") String path, @Query("qry1") String qry1, @Query("qry2") String qry2);
+        @Path("path") String path,
+        @Query("qry1") String qry1,
+        @Query("qry2") String qry2,
+        @Query("qry3") String qry3);
   }
 }

--- a/kork-web/src/test/java/com/netflix/spinnaker/okhttp/Retrofit2EncodeCorrectionInterceptorTest.java
+++ b/kork-web/src/test/java/com/netflix/spinnaker/okhttp/Retrofit2EncodeCorrectionInterceptorTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.okhttp;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.netflix.spinnaker.config.DefaultServiceEndpoint;
+import com.netflix.spinnaker.config.ServiceEndpoint;
+import com.netflix.spinnaker.config.okhttp3.DefaultOkHttpClientBuilderProvider;
+import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = {
+      OkHttpClient.class,
+      OkHttpClientConfigurationProperties.class,
+      OkHttpClientProvider.class,
+      DefaultOkHttpClientBuilderProvider.class
+    })
+public class Retrofit2EncodeCorrectionInterceptorTest {
+
+  private static final String PATH_VAL = "path: [] () = % $ & # @ ; , ? \" ' end path";
+  private static final String ENCODED_PATH_VAL = encodedString(PATH_VAL);
+  private static final String QUERY_PARAM1 = "qry1: [] () + = % $ & # @ ; , ? \" ' /end qry1";
+  private static final String ENCODED_QUERY_PARAM1 = encodedString(QUERY_PARAM1);
+  private static final String QUERY_PARAM2 = "qry2: [] () + = % $ & # @ ; , ? \" ' end qry2";
+  private static final String ENCODED_QUERY_PARAM2 = encodedString(QUERY_PARAM2);
+  private static final String EXPECTED_URL =
+      "/test/"
+          + ENCODED_PATH_VAL
+          + "/get?qry1="
+          + ENCODED_QUERY_PARAM1
+          + "&qry2="
+          + ENCODED_QUERY_PARAM2;
+  private ServiceEndpoint endpoint;
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  @Autowired OkHttpClientProvider okHttpClientProvider;
+
+  @BeforeEach
+  public void setup() {
+    wireMock.stubFor(get(EXPECTED_URL).willReturn(ok()));
+    endpoint = new DefaultServiceEndpoint("test", wireMock.baseUrl());
+  }
+
+  @Test
+  public void testWithoutEncodingCorrection() throws IOException {
+    OkHttpClient okHttpClient = okHttpClientProvider.getClient(endpoint, true);
+    Retrofit2Service service = getRetrofit2Service(endpoint.getBaseUrl(), okHttpClient);
+    service.getRequest(PATH_VAL, QUERY_PARAM1, QUERY_PARAM2).execute();
+    wireMock.verify(0, getRequestedFor(urlEqualTo(EXPECTED_URL)));
+  }
+
+  @Test
+  public void testWithEncodingCorrection() throws IOException {
+    OkHttpClient okHttpClient = okHttpClientProvider.getClient(endpoint, false);
+    Retrofit2Service service = getRetrofit2Service(endpoint.getBaseUrl(), okHttpClient);
+    service.getRequest(PATH_VAL, QUERY_PARAM1, QUERY_PARAM2).execute();
+    wireMock.verify(getRequestedFor(urlEqualTo(EXPECTED_URL)));
+  }
+
+  private Retrofit2Service getRetrofit2Service(String baseUrl, OkHttpClient okHttpClient) {
+
+    return new Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .client(okHttpClient)
+        .build()
+        .create(Retrofit2Service.class);
+  }
+
+  private static String encodedString(String input) {
+    return URLEncoder.encode(input, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+  }
+
+  interface Retrofit2Service {
+    @GET("test/{path}/get")
+    Call<Void> getRequest(
+        @Path("path") String path, @Query("qry1") String qry1, @Query("qry2") String qry2);
+  }
+}


### PR DESCRIPTION
This PR addresses the issue - https://github.com/spinnaker/spinnaker/issues/7021

- Retrofit2 encoding is different from that of retrofit1, so if the path parameter or query parameter have special characters the APIs are rejecting the request with 400. An issue has been raised with [retrofit team](https://github.com/square/retrofit/issues/4312) but the solution from them is not in the near future.

- This PR addresses all the encoding issues caused by retrofit2 by first decoding the partially encoded path/query parameters and then encoding it properly in a newly created interceptor - `Retrofit2EncodeCorrectionInterceptor`.  

- Added a test class `Retrofit2EncodeCorrectionInterceptorTest` to demonstrate the issue and the fix.

- The default behaviour of a retrofit2 client created using any of the ways paved by kork is now to have the `Retrofit2EncodeCorrectionInterceptor`.  

- A new property `skipRetrofit2EncodeCorrection`  is added under `ok-http-client` properties which is defaulted to `false` as it is needed. For any reason, if the previous behaviour is needed, this property gives the option.

```yaml
okHttpClient:
   skipRetrofit2EncodeCorrection: false  #default
```