### PR TITLE
fix(web): remove Retrofit2EncodeCorrectionInterceptor from OkHttpClie…

### DIFF
--- a/kork-web/kork-web.gradle
+++ b/kork-web/kork-web.gradle
@@ -54,4 +54,5 @@ dependencies {
   testImplementation testFixtures(project(":kork-crypto"))
   testRuntimeOnly "cglib:cglib-nodep"
   testRuntimeOnly "org.objenesis:objenesis"
+  testImplementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
 }

--- a/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
+++ b/kork-web/src/main/groovy/com/netflix/spinnaker/config/OkHttp3ClientConfiguration.groovy
@@ -92,7 +92,7 @@ class OkHttp3ClientConfiguration {
   }
 
   /**
-   * @return OkHttpClient w/ <optional> key and trust stores
+   * @return OkHttpClient w/ <optional> key and trust stores.  For use with retrofit1.  Do not use with retrofit2.
    */
   OkHttpClient.Builder create() {
     if (okHttpClientConfigurationProperties.refreshableKeys.enabled) {
@@ -106,10 +106,6 @@ class OkHttp3ClientConfiguration {
       okHttpClientBuilder.addInterceptor(okHttp3MetricsInterceptor)
     }
 
-    if (retrofit2EncodeCorrectionInterceptor != null) {
-      okHttpClientBuilder.addInterceptor(retrofit2EncodeCorrectionInterceptor)
-    }
-
     if (!okHttpClientConfigurationProperties.keyStore && !okHttpClientConfigurationProperties.trustStore) {
       return okHttpClientBuilder
     }
@@ -118,7 +114,8 @@ class OkHttp3ClientConfiguration {
   }
 
   /**
-   * @return OkHttpClient with SpinnakerRequestHeaderInterceptor as initial interceptor w/ <optional> key and trust stores
+   * @return OkHttpClient with SpinnakerRequestHeaderInterceptor and Retrofit2EncodeCorrectionInterceptor
+   * as initial interceptors w/ <optional> key and trust stores
    */
   OkHttpClient.Builder createForRetrofit2() {
     if (okHttpClientConfigurationProperties.refreshableKeys.enabled) {

--- a/kork-web/src/test/java/com/netflix/spinnaker/okhttp/Retrofit1ImpactTest.java
+++ b/kork-web/src/test/java/com/netflix/spinnaker/okhttp/Retrofit1ImpactTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.okhttp;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.jakewharton.retrofit.Ok3Client;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
+import com.netflix.spinnaker.config.OkHttpMetricsInterceptorProperties;
+import com.netflix.spinnaker.config.okhttp3.DefaultOkHttpClientBuilderProvider;
+import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import retrofit.http.GET;
+import retrofit.http.Query;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = {
+      OkHttpClient.class,
+      OkHttpClientConfigurationProperties.class,
+      OkHttpClientProvider.class,
+      DefaultOkHttpClientBuilderProvider.class,
+      Retrofit2EncodeCorrectionInterceptor.class,
+      Retrofit1ImpactTest.TestConfiguration.class,
+      OkHttpMetricsInterceptorProperties.class,
+      OkHttp3MetricsInterceptor.class,
+      OkHttp3ClientConfiguration.class,
+      NoopRegistry.class
+    })
+public class Retrofit1ImpactTest {
+
+  private static final String QUERY_PARAM_VAL = "qry_with space";
+  private static final String ENCODED_QUERY_PARAM_VAL =
+      encodedString(QUERY_PARAM_VAL); // qry_with+space
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  @Autowired OkHttp3ClientConfiguration clientConfiguration;
+
+  @Test
+  public void test_Retrofit2Interceptors_Impact_On_Retrofit1() {
+    wireMock.stubFor(get("/test?qry=" + ENCODED_QUERY_PARAM_VAL).willReturn(ok()));
+    Retrofit1Service retrofit1Service = getRetrofit1Service(wireMock.baseUrl());
+
+    retrofit1Service.get(QUERY_PARAM_VAL);
+
+    // proves no presence of Retrofit2EncodeCorrectionInterceptor in retrofit1 client
+    wireMock.verify(1, getRequestedFor(urlEqualTo("/test?qry=" + ENCODED_QUERY_PARAM_VAL)));
+  }
+
+  private static String encodedString(String input) {
+    return URLEncoder.encode(input, StandardCharsets.UTF_8);
+  }
+
+  private Retrofit1Service getRetrofit1Service(String baseUrl) {
+    // clientConfiguration.create() is for use with retrofit1.  The point of
+    // this test is to verify that clientConfiguration.create doesn't include
+    // the Retrofit2EncodeCorrectionInterceptor since that's only for retrofit2.
+    return new retrofit.RestAdapter.Builder()
+        .setEndpoint(baseUrl)
+        .setClient(new Ok3Client(clientConfiguration.create().build()))
+        .build()
+        .create(Retrofit1Service.class);
+  }
+
+  @Configuration
+  public static class TestConfiguration {
+
+    @Bean
+    public HttpLoggingInterceptor.Level logLevel() {
+      return HttpLoggingInterceptor.Level.BASIC;
+    }
+
+    @Bean
+    public SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor() {
+      return new SpinnakerRequestHeaderInterceptor(true);
+    }
+  }
+
+  interface Retrofit1Service {
+    @GET("/test")
+    Void get(@Query(value = "qry") String qry);
+  }
+}


### PR DESCRIPTION
…nt client meant for retrofit1 client (#1229)

* test(web): add a test to demonstrate the issue of Retrofit2EncodeCorrectionInterceptor being attached to retrofit2 client

* test(web): add assertions, comments to Retrofit1ImpactTest

* fix(web): remove Retrofit2EncodeCorrectionInterceptor from OkHttpClient.Builder which is meant for retrofit1 client

* doc(web): add comments to OkHttp3ClientConfiguration

---------

Co-authored-by: David Byron <dbyron@salesforce.com>
(cherry picked from commit af2ec3933f690c873e4f2412584028a25a2d01ab)