### PR TITLE
fix(web): Update OkHttpClientProvider to maintain compatibility with existing retrofit1 clients

### DIFF
--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactoryAutoConfiguration.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactoryAutoConfiguration.java
@@ -33,6 +33,10 @@ import retrofit.RestAdapter;
 @ConditionalOnProperty(value = "retrofit.enabled", havingValue = "true", matchIfMissing = true)
 public class RetrofitServiceFactoryAutoConfiguration {
 
+  /**
+   * Creates OkHttpClientProvider bean for use with RetrofitServiceFactory i.e. for retrofit1
+   * clients
+   */
   @Bean
   public OkHttpClientProvider okHttpClientProvider(List<OkHttpClientBuilderProvider> providers) {
     return new OkHttpClientProvider(providers);

--- a/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactoryAutoConfiguration.java
+++ b/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactoryAutoConfiguration.java
@@ -17,8 +17,10 @@
 
 package com.netflix.spinnaker.kork.retrofit;
 
+import com.netflix.spinnaker.config.okhttp3.OkHttpClientBuilderProvider;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.kork.client.ServiceClientFactory;
+import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +32,11 @@ import retrofit.RestAdapter;
 @Configuration
 @ConditionalOnProperty(value = "retrofit.enabled", havingValue = "true", matchIfMissing = true)
 public class RetrofitServiceFactoryAutoConfiguration {
+
+  @Bean
+  public OkHttpClientProvider okHttpClientProvider(List<OkHttpClientBuilderProvider> providers) {
+    return new OkHttpClientProvider(providers);
+  }
 
   @Bean
   @Order(Ordered.LOWEST_PRECEDENCE)

--- a/kork-retrofit/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/RetrofitServiceProviderTest.kt
+++ b/kork-retrofit/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/RetrofitServiceProviderTest.kt
@@ -57,7 +57,6 @@ class RetrofitServiceProviderTest  : JUnit5Minutests {
             RetrofitServiceFactoryAutoConfiguration::class.java,
             TaskExecutionAutoConfiguration::class.java,
             DefaultOkHttpClientBuilderProvider::class.java,
-            OkHttpClientProvider::class.java,
             OkHttpClientComponents::class.java,
             RetrofitConfiguration::class.java,
             TestConfiguration::class.java
@@ -89,7 +88,7 @@ class RetrofitServiceProviderTest  : JUnit5Minutests {
                 .getClient(DefaultServiceEndpoint("retrofit1", "https://www.test.com"))
                 .interceptors
                 .count { it is Retrofit2EncodeCorrectionInterceptor }
-            ).isEqualTo(1)
+            ).isEqualTo(0)
           }
         }
       }

--- a/kork-retrofit/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/RetrofitServiceProviderTest.kt
+++ b/kork-retrofit/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/RetrofitServiceProviderTest.kt
@@ -56,6 +56,8 @@ class RetrofitServiceProviderTest  : JUnit5Minutests {
           .withConfiguration(AutoConfigurations.of(
             RetrofitServiceFactoryAutoConfiguration::class.java,
             TaskExecutionAutoConfiguration::class.java,
+            DefaultOkHttpClientBuilderProvider::class.java,
+            OkHttpClientProvider::class.java,
             OkHttpClientComponents::class.java,
             RetrofitConfiguration::class.java,
             TestConfiguration::class.java
@@ -79,6 +81,19 @@ class RetrofitServiceProviderTest  : JUnit5Minutests {
         }
       }
 
+      test("check if Retrofit2EncodeCorrectionInterceptor is added to OkHttpClientProvider") {
+        run { ctx: AssertableApplicationContext ->
+          expect {
+            that(
+              ctx.getBean(OkHttpClientProvider::class.java)
+                .getClient(DefaultServiceEndpoint("retrofit1", "https://www.test.com"))
+                .interceptors
+                .count { it is Retrofit2EncodeCorrectionInterceptor }
+            ).isEqualTo(1)
+          }
+        }
+      }
+
     }
   }
 
@@ -94,11 +109,6 @@ private open class TestConfiguration {
   @Bean
   open fun okHttpClient(httpTracing: HttpTracing): OkHttpClient {
     return RawOkHttpClientFactory().create(OkHttpClientConfigurationProperties(), emptyList(), httpTracing)
-  }
-
-  @Bean
-  open fun okHttpClientProvider(okHttpClient: OkHttpClient): OkHttpClientProvider {
-    return OkHttpClientProvider(listOf(DefaultOkHttpClientBuilderProvider(okHttpClient, OkHttpClientConfigurationProperties())), Retrofit2EncodeCorrectionInterceptor())
   }
 
   @Bean

--- a/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProvider.java
+++ b/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProvider.java
@@ -35,6 +35,16 @@ public class OkHttpClientProvider {
 
   private final Optional<Retrofit2EncodeCorrectionInterceptor> retrofit2EncodeCorrectionInterceptor;
 
+  /**
+   * Constructor used for retrofit2 clients through Retrofit2ServiceFactory.
+   * Retrofit2EncodeCorrectionInterceptor is required for retrofit2 clients for correcting the
+   * partial encoding done by retrofit2
+   *
+   * @param providers list of {@link OkHttpClientBuilderProvider} that can build a client for the
+   *     given service config
+   * @param retrofit2EncodeCorrectionInterceptor interceptor that corrects the partial encoding done
+   *     by retrofit2
+   */
   @Autowired
   public OkHttpClientProvider(
       List<OkHttpClientBuilderProvider> providers,
@@ -43,6 +53,13 @@ public class OkHttpClientProvider {
     this.retrofit2EncodeCorrectionInterceptor = Optional.of(retrofit2EncodeCorrectionInterceptor);
   }
 
+  /**
+   * Constructor used for retrofit1 clients through RetrofitServiceFactory.
+   * Retrofit2EncodeCorrectionInterceptor is not required for retrofit1 clients hence set to empty.
+   *
+   * @param providers list of {@link OkHttpClientBuilderProvider} that can build a client for the
+   *     given service config
+   */
   public OkHttpClientProvider(List<OkHttpClientBuilderProvider> providers) {
     this.providers = providers;
     // to maintain backward compatibility with existing Retrofit1 clients


### PR DESCRIPTION
There are existing retrofit1 clients using OkHttpClientProvider which inadvertently use Retrofit2EncodeCorrectionInterceptor  that is meant for retrofit2 clients. This PR fixes the issue. 